### PR TITLE
docs(github): Add PR and Issue templates for better communication.

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,48 +1,4 @@
-Hi there :wave:!
-
-## Submitting a Bug Report
-
-If you're adding an issue, please search in the issues for this repo first. If
-there is not an existing issue already submitted, use the template below to
-submit a new bug report:
-
-```markdown
-## Expected Behavior
-
-<!--- Tell us what should happen -->
-
-## Current Behavior
-
-<!--- Tell us what happens instead of the expected behavior -->
-
-## Possible Solution
-
-<!--- Not obligatory, but suggest a fix/reason for the bug, -->
-
-## Steps to Reproduce
-
-<!--- Provide a link to a live example, or an unambiguous set of steps to -->
-
-<!--- reproduce this bug. Include code to reproduce, if relevant -->
-
-1. 2. 3. 4.
-
-## Context (Environment)
-
-<!--- How has this issue affected you? What are you trying to accomplish? -->
-
-<!--- Providing context helps us come up with a solution that is most useful in the real world -->
-
-<!--- Provide a general summary of the issue in the Title above -->
-
-## Detailed Description
-
-<!--- Provide a detailed description of the change or addition you are proposing -->
-
-## Possible Implementation
-
-<!--- Not obligatory, but suggest an idea for implementing addition or change -->
-```
+Hi there :wave:! We've provided some issue templates for your convenience, but if they don't match what you need, feel free to start from scratch.
 
 ## Suggesting a New Feature
 
@@ -67,4 +23,18 @@ template below to kickoff a discussion about the feature:
 ## References
 
 <!--- Link to any existing ideas, references that might be useful for describing your idea.  -->
+```
+
+## Submitting a Bug Report
+
+We're only providing support to developers/collaborators at the moment. In other words: if you've built Lona Studio in Xcode or attempted to generate code, feel free to report issues or ask for help. Otherwise, please wait for our official release -- we'll provide more designer-facing instructions and documentation as we get closer.
+
+```markdown
+## Expected Behavior
+
+<!--- Tell us what should happen -->
+
+## Current Behavior
+
+<!--- Tell us what happens instead of the expected behavior -->
 ```

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,70 @@
+Hi there :wave:!
+
+## Submitting a Bug Report
+
+If you're adding an issue, please search in the issues for this repo first. If
+there is not an existing issue already submitted, use the template below to
+submit a new bug report:
+
+```markdown
+## Expected Behavior
+
+<!--- Tell us what should happen -->
+
+## Current Behavior
+
+<!--- Tell us what happens instead of the expected behavior -->
+
+## Possible Solution
+
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+
+## Steps to Reproduce
+
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+
+1. 2. 3. 4.
+
+## Context (Environment)
+
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Detailed Description
+
+<!--- Provide a detailed description of the change or addition you are proposing -->
+
+## Possible Implementation
+
+<!--- Not obligatory, but suggest an idea for implementing addition or change -->
+```
+
+## Suggesting a New Feature
+
+If you're interested in suggesting a new feature, please search for any existing
+issues or pull requests first. If there isn't any available, use the issue
+template below to kickoff a discussion about the feature:
+
+```markdown
+## Summary of Idea
+
+<!--- Give a summary of what the idea is, in a paragraph or two. -->
+
+## Initial Design
+
+<!--- Images/wireframes/designs are super helpful for this! -->
+<!--- Explain the change visually, give more context. -->
+
+## Proposed Implementation
+
+<!--- If you have an idea of the implementation needed, describe it here. -->
+
+## References
+
+<!--- Link to any existing ideas, references that might be useful for describing your idea.  -->
+```

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -32,4 +32,4 @@ I'm looking for feedback on:
 * <this code style>
 
 <!-- Tag relevant people for example -->
-cc: @dabott, @ryngonzalez
+cc: @dabbott, @ryngonzalez

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+## What
+
+I added a new button / fixed this bug / added this endpoint. It looks like this
+<screenshot / endpoint url / whatever>
+
+## Why
+
+I did this change in order to...
+
+## Major Changes
+
+* I added the modules for this change…
+* And this other thing too!
+
+## Requirements for Merging
+
+- [ ] It should do this
+- [ ] It should edit this file
+- [ ] It should look like this
+
+## Testing Plan
+
+- [ ] Tested this change locally
+- [ ] Checked that existing features work
+
+## Feedback
+
+I'm looking for feedback on:
+
+* <this important decision>
+* <this design>
+* <this code style>
+
+<!-- Tag relevant people for example -->
+cc: @dabott, @ryngonzalez


### PR DESCRIPTION
## What

Closes #13.

Added docs that will be used by-default for helping folks make better PRs and Issues. https://help.github.com/articles/creating-an-issue-template-for-your-repository/

## Why

Will make it easier to understand issues, triage them, and kickoff discussions for PRs and new features.

## Major Changes

* Added a `.github` folder
* Added docs.

## Feedback
We can potentially edit these if they don't have the sections we need!