### PR TITLE
fix #58 (out of range error on picker view)

### DIFF
--- a/LonaStudio/Controls/Picker/PickerView.swift
+++ b/LonaStudio/Controls/Picker/PickerView.swift
@@ -147,6 +147,7 @@ extension PickerView {
                     let index = self.currentHover - 1
                     updateHover(index: index)
                 case .enter:
+                    guard self.currentHover != -1 else { return }
                     guard self.currentHover < self.filterData.count else { return }
                     let item = self.filterData[self.currentHover]
                     self.parameter.didSelectItem(self, item)


### PR DESCRIPTION
## What

Fixed Bug #58 where the color picker crashes.

## Why

If there is nothing to select in the picker view then you hitting enter
shouldn’t really do anything.

## Major Changes

None that I'm aware of.

## Requirements for Merging

- [x] It should not crash when reproduced like #58 specifies
- [x] It should not do anything when enter is hit on empty picker view

## Testing Plan

- [x] Tested this change locally
- [x] Checked that existing features work

## Feedback

I'm looking for feedback on:

* Maybe it should give a "No results" or something. Didn't want to add anything just wanted to fix the bug. This project is very cool and I've been toying with it so I thought I'd show my appreciation with fix a bug or two.

<!-- Tag relevant people for example -->
cc: @dabbott 