### PR TITLE
Simplify secondary axis constraints in fill/fit case

### DIFF
--- a/compiler/core/src/component.bs.js
+++ b/compiler/core/src/component.bs.js
@@ -765,20 +765,17 @@ function generate$1(name, json, colors) {
         var secondaryAfterConstant = match$6 !== 0 ? constraintConstantExpression(layer, "trailingPadding", child, "trailingMargin") : constraintConstantExpression(layer, "bottomPadding", child, "bottomMargin");
         var secondaryBeforeConstraint = setUpContraint(child, secondaryBeforeAnchor, layer, secondaryBeforeAnchor, "equalTo", secondaryBeforeConstant, "Constraint");
         var secondaryAfterConstraint;
+        var exit = 0;
         if (typeof childSecondarySizingRule === "number") {
           if (childSecondarySizingRule !== 0) {
-            var shrinkConstraint = setUpDimensionContraint(child, secondaryDimensionAnchor, 0.0);
-            secondaryAfterConstraint = /* :: */[
-              setUpContraint(child, secondaryAfterAnchor, layer, secondaryAfterAnchor, "lessThanOrEqualTo", negateNumber(secondaryAfterConstant), "Constraint"),
-              /* :: */[
-                /* record */[
-                  /* variableName */shrinkConstraint[/* variableName */0],
-                  /* initialValue */shrinkConstraint[/* initialValue */1],
-                  /* priority : Low */1
-                ],
+            if (typeof secondarySizingRule === "number" && secondarySizingRule === 0) {
+              secondaryAfterConstraint = /* :: */[
+                setUpContraint(child, secondaryAfterAnchor, layer, secondaryAfterAnchor, "lessThanOrEqualTo", negateNumber(secondaryAfterConstant), "Constraint"),
                 /* [] */0
-              ]
-            ];
+              ];
+            } else {
+              exit = 1;
+            }
           } else {
             secondaryAfterConstraint = /* :: */[
               setUpContraint(child, secondaryAfterAnchor, layer, secondaryAfterAnchor, "equalTo", negateNumber(secondaryAfterConstant), "Constraint"),
@@ -787,6 +784,12 @@ function generate$1(name, json, colors) {
           }
         } else {
           secondaryAfterConstraint = /* [] */0;
+        }
+        if (exit === 1) {
+          secondaryAfterConstraint = /* :: */[
+            setUpContraint(child, secondaryAfterAnchor, layer, secondaryAfterAnchor, "equalTo", negateNumber(secondaryAfterConstant), "Constraint"),
+            /* [] */0
+          ];
         }
         var fitContentSecondaryConstraint = typeof secondarySizingRule === "number" && secondarySizingRule !== 0 ? /* :: */[
             setUpLessThanOrEqualToContraint(child, secondaryDimensionAnchor, layer, secondaryDimensionAnchor, negateNumber(/* BinaryExpression */Block.__(2, [{

--- a/compiler/core/src/component.re
+++ b/compiler/core/src/component.re
@@ -585,8 +585,7 @@ module Swift = {
                   "Constraint"
                 )
               ]
-            | (_, FitContent) =>
-              let shrinkConstraint = setUpDimensionContraint(child, secondaryDimensionAnchor, 0.0);
+            | (Fill, FitContent) =>
               [
                 setUpContraint(
                   child,
@@ -596,12 +595,19 @@ module Swift = {
                   "lessThanOrEqualTo",
                   negateNumber(secondaryAfterConstant),
                   "Constraint"
-                ),
-                {
-                  variableName: shrinkConstraint.variableName,
-                  initialValue: shrinkConstraint.initialValue,
-                  priority: Low
-                }
+                )
+              ]
+            | (_, FitContent) =>
+              [
+                setUpContraint(
+                  child,
+                  secondaryAfterAnchor,
+                  layer,
+                  secondaryAfterAnchor,
+                  "equalTo",
+                  negateNumber(secondaryAfterConstant),
+                  "Constraint"
+                )
               ]
             };
           /* If the parent's secondary axis is set to "fit content", this ensures

--- a/examples/generated/test/swift/layouts/PrimaryAxis.swift
+++ b/examples/generated/test/swift/layouts/PrimaryAxis.swift
@@ -78,7 +78,6 @@ public class PrimaryAxis: UIView {
   private var textViewBottomAnchorConstraint: NSLayoutConstraint?
   private var textViewLeadingAnchorConstraint: NSLayoutConstraint?
   private var textViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var textViewWidthAnchorConstraint: NSLayoutConstraint?
   private var fill1ViewWidthAnchorConstraint: NSLayoutConstraint?
   private var fill2ViewWidthAnchorConstraint: NSLayoutConstraint?
 
@@ -150,13 +149,9 @@ public class PrimaryAxis: UIView {
       .constraint(equalTo: fitView.leadingAnchor, constant: fitViewLeadingPadding + textViewLeadingMargin)
     let textViewTrailingAnchorConstraint = textView
       .trailingAnchor
-      .constraint(
-        lessThanOrEqualTo: fitView.trailingAnchor,
-        constant: -(fitViewTrailingPadding + textViewTrailingMargin))
-    let textViewWidthAnchorConstraint = textView.widthAnchor.constraint(equalToConstant: 0)
+      .constraint(equalTo: fitView.trailingAnchor, constant: -(fitViewTrailingPadding + textViewTrailingMargin))
     let fill1ViewWidthAnchorConstraint = fill1View.widthAnchor.constraint(equalToConstant: 100)
     let fill2ViewWidthAnchorConstraint = fill2View.widthAnchor.constraint(equalToConstant: 100)
-    textViewWidthAnchorConstraint.priority = UILayoutPriority.defaultLow
 
     NSLayoutConstraint.activate([
       heightAnchorConstraint,
@@ -177,7 +172,6 @@ public class PrimaryAxis: UIView {
       textViewBottomAnchorConstraint,
       textViewLeadingAnchorConstraint,
       textViewTrailingAnchorConstraint,
-      textViewWidthAnchorConstraint,
       fill1ViewWidthAnchorConstraint,
       fill2ViewWidthAnchorConstraint
     ])
@@ -200,7 +194,6 @@ public class PrimaryAxis: UIView {
     self.textViewBottomAnchorConstraint = textViewBottomAnchorConstraint
     self.textViewLeadingAnchorConstraint = textViewLeadingAnchorConstraint
     self.textViewTrailingAnchorConstraint = textViewTrailingAnchorConstraint
-    self.textViewWidthAnchorConstraint = textViewWidthAnchorConstraint
     self.fill1ViewWidthAnchorConstraint = fill1ViewWidthAnchorConstraint
     self.fill2ViewWidthAnchorConstraint = fill2ViewWidthAnchorConstraint
 
@@ -223,7 +216,6 @@ public class PrimaryAxis: UIView {
     textViewBottomAnchorConstraint.identifier = "textViewBottomAnchorConstraint"
     textViewLeadingAnchorConstraint.identifier = "textViewLeadingAnchorConstraint"
     textViewTrailingAnchorConstraint.identifier = "textViewTrailingAnchorConstraint"
-    textViewWidthAnchorConstraint.identifier = "textViewWidthAnchorConstraint"
     fill1ViewWidthAnchorConstraint.identifier = "fill1ViewWidthAnchorConstraint"
     fill2ViewWidthAnchorConstraint.identifier = "fill2ViewWidthAnchorConstraint"
   }

--- a/examples/generated/test/swift/layouts/SecondaryAxis.swift
+++ b/examples/generated/test/swift/layouts/SecondaryAxis.swift
@@ -60,7 +60,6 @@ public class SecondaryAxis: UIView {
   private var fitViewTopAnchorConstraint: NSLayoutConstraint?
   private var fitViewLeadingAnchorConstraint: NSLayoutConstraint?
   private var fitViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var fitViewWidthAnchorConstraint: NSLayoutConstraint?
   private var fillViewBottomAnchorConstraint: NSLayoutConstraint?
   private var fillViewTopAnchorConstraint: NSLayoutConstraint?
   private var fillViewLeadingAnchorConstraint: NSLayoutConstraint?
@@ -71,7 +70,6 @@ public class SecondaryAxis: UIView {
   private var textViewTopAnchorConstraint: NSLayoutConstraint?
   private var textViewLeadingAnchorConstraint: NSLayoutConstraint?
   private var textViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var textViewWidthAnchorConstraint: NSLayoutConstraint?
   private var textViewWidthAnchorParentConstraint: NSLayoutConstraint?
   private var fillViewHeightAnchorConstraint: NSLayoutConstraint?
 
@@ -110,7 +108,6 @@ public class SecondaryAxis: UIView {
     let fitViewTrailingAnchorConstraint = fitView
       .trailingAnchor
       .constraint(lessThanOrEqualTo: trailingAnchor, constant: -(trailingPadding + fitViewTrailingMargin))
-    let fitViewWidthAnchorConstraint = fitView.widthAnchor.constraint(equalToConstant: 0)
     let fillViewBottomAnchorConstraint = fillView
       .bottomAnchor
       .constraint(equalTo: bottomAnchor, constant: -(bottomPadding + fillViewBottomMargin))
@@ -134,18 +131,13 @@ public class SecondaryAxis: UIView {
       .constraint(equalTo: fitView.leadingAnchor, constant: fitViewLeadingPadding + textViewLeadingMargin)
     let textViewTrailingAnchorConstraint = textView
       .trailingAnchor
-      .constraint(
-        lessThanOrEqualTo: fitView.trailingAnchor,
-        constant: -(fitViewTrailingPadding + textViewTrailingMargin))
-    let textViewWidthAnchorConstraint = textView.widthAnchor.constraint(equalToConstant: 0)
+      .constraint(equalTo: fitView.trailingAnchor, constant: -(fitViewTrailingPadding + textViewTrailingMargin))
     let textViewWidthAnchorParentConstraint = textView
       .widthAnchor
       .constraint(
         lessThanOrEqualTo: fitView.widthAnchor,
         constant: -(fitViewLeadingPadding + textViewLeadingMargin + fitViewTrailingPadding + textViewTrailingMargin))
     let fillViewHeightAnchorConstraint = fillView.heightAnchor.constraint(equalToConstant: 100)
-    fitViewWidthAnchorConstraint.priority = UILayoutPriority.defaultLow
-    textViewWidthAnchorConstraint.priority = UILayoutPriority.defaultLow
     textViewWidthAnchorParentConstraint.priority = UILayoutPriority.defaultLow
 
     NSLayoutConstraint.activate([
@@ -154,7 +146,6 @@ public class SecondaryAxis: UIView {
       fitViewTopAnchorConstraint,
       fitViewLeadingAnchorConstraint,
       fitViewTrailingAnchorConstraint,
-      fitViewWidthAnchorConstraint,
       fillViewBottomAnchorConstraint,
       fillViewTopAnchorConstraint,
       fillViewLeadingAnchorConstraint,
@@ -165,7 +156,6 @@ public class SecondaryAxis: UIView {
       textViewTopAnchorConstraint,
       textViewLeadingAnchorConstraint,
       textViewTrailingAnchorConstraint,
-      textViewWidthAnchorConstraint,
       textViewWidthAnchorParentConstraint,
       fillViewHeightAnchorConstraint
     ])
@@ -175,7 +165,6 @@ public class SecondaryAxis: UIView {
     self.fitViewTopAnchorConstraint = fitViewTopAnchorConstraint
     self.fitViewLeadingAnchorConstraint = fitViewLeadingAnchorConstraint
     self.fitViewTrailingAnchorConstraint = fitViewTrailingAnchorConstraint
-    self.fitViewWidthAnchorConstraint = fitViewWidthAnchorConstraint
     self.fillViewBottomAnchorConstraint = fillViewBottomAnchorConstraint
     self.fillViewTopAnchorConstraint = fillViewTopAnchorConstraint
     self.fillViewLeadingAnchorConstraint = fillViewLeadingAnchorConstraint
@@ -186,7 +175,6 @@ public class SecondaryAxis: UIView {
     self.textViewTopAnchorConstraint = textViewTopAnchorConstraint
     self.textViewLeadingAnchorConstraint = textViewLeadingAnchorConstraint
     self.textViewTrailingAnchorConstraint = textViewTrailingAnchorConstraint
-    self.textViewWidthAnchorConstraint = textViewWidthAnchorConstraint
     self.textViewWidthAnchorParentConstraint = textViewWidthAnchorParentConstraint
     self.fillViewHeightAnchorConstraint = fillViewHeightAnchorConstraint
 
@@ -196,7 +184,6 @@ public class SecondaryAxis: UIView {
     fitViewTopAnchorConstraint.identifier = "fitViewTopAnchorConstraint"
     fitViewLeadingAnchorConstraint.identifier = "fitViewLeadingAnchorConstraint"
     fitViewTrailingAnchorConstraint.identifier = "fitViewTrailingAnchorConstraint"
-    fitViewWidthAnchorConstraint.identifier = "fitViewWidthAnchorConstraint"
     fillViewBottomAnchorConstraint.identifier = "fillViewBottomAnchorConstraint"
     fillViewTopAnchorConstraint.identifier = "fillViewTopAnchorConstraint"
     fillViewLeadingAnchorConstraint.identifier = "fillViewLeadingAnchorConstraint"
@@ -207,7 +194,6 @@ public class SecondaryAxis: UIView {
     textViewTopAnchorConstraint.identifier = "textViewTopAnchorConstraint"
     textViewLeadingAnchorConstraint.identifier = "textViewLeadingAnchorConstraint"
     textViewTrailingAnchorConstraint.identifier = "textViewTrailingAnchorConstraint"
-    textViewWidthAnchorConstraint.identifier = "textViewWidthAnchorConstraint"
     textViewWidthAnchorParentConstraint.identifier = "textViewWidthAnchorParentConstraint"
     fillViewHeightAnchorConstraint.identifier = "fillViewHeightAnchorConstraint"
   }

--- a/examples/generated/test/swift/logic/Assign.swift
+++ b/examples/generated/test/swift/logic/Assign.swift
@@ -43,7 +43,6 @@ public class Assign: UIView {
   private var textViewBottomAnchorConstraint: NSLayoutConstraint?
   private var textViewLeadingAnchorConstraint: NSLayoutConstraint?
   private var textViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var textViewWidthAnchorConstraint: NSLayoutConstraint?
 
   private func setUpViews() {
     addSubview(textView)
@@ -65,29 +64,24 @@ public class Assign: UIView {
     let textViewTrailingAnchorConstraint = textView
       .trailingAnchor
       .constraint(lessThanOrEqualTo: trailingAnchor, constant: -(trailingPadding + textViewTrailingMargin))
-    let textViewWidthAnchorConstraint = textView.widthAnchor.constraint(equalToConstant: 0)
-    textViewWidthAnchorConstraint.priority = UILayoutPriority.defaultLow
 
     NSLayoutConstraint.activate([
       textViewTopAnchorConstraint,
       textViewBottomAnchorConstraint,
       textViewLeadingAnchorConstraint,
-      textViewTrailingAnchorConstraint,
-      textViewWidthAnchorConstraint
+      textViewTrailingAnchorConstraint
     ])
 
     self.textViewTopAnchorConstraint = textViewTopAnchorConstraint
     self.textViewBottomAnchorConstraint = textViewBottomAnchorConstraint
     self.textViewLeadingAnchorConstraint = textViewLeadingAnchorConstraint
     self.textViewTrailingAnchorConstraint = textViewTrailingAnchorConstraint
-    self.textViewWidthAnchorConstraint = textViewWidthAnchorConstraint
 
     // For debugging
     textViewTopAnchorConstraint.identifier = "textViewTopAnchorConstraint"
     textViewBottomAnchorConstraint.identifier = "textViewBottomAnchorConstraint"
     textViewLeadingAnchorConstraint.identifier = "textViewLeadingAnchorConstraint"
     textViewTrailingAnchorConstraint.identifier = "textViewTrailingAnchorConstraint"
-    textViewWidthAnchorConstraint.identifier = "textViewWidthAnchorConstraint"
   }
 
   private func update() {


### PR DESCRIPTION
## What

I removed the low priority constraint that made FitContent layers shrink. Instead, I special-cased the Fill parent/FitContent child case.

## Why

Simpler, clearer constraints

## Testing Plan

- [X] Tested this change locally
- [X] Checked that existing features work