### PR TITLE
Update Gemfile.lock with missing gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,10 @@ GEM
       no_proxy_fix
       octokit (~> 4.7)
       terminal-table (~> 1)
+    danger-swiftlint (0.12.1)
+      danger
+      rake (> 10)
+      thor (~> 0.19)
     escape (0.0.4)
     faraday (0.14.0)
       multipart-post (>= 1.2, < 3)
@@ -86,6 +90,7 @@ GEM
       sawyer (~> 0.8.0, >= 0.5.3)
     open4 (1.3.4)
     public_suffix (3.0.1)
+    rake (12.3.0)
     rouge (2.0.7)
     ruby-macho (1.1.0)
     sawyer (0.8.1)
@@ -93,6 +98,7 @@ GEM
       faraday (~> 0.8, < 1.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
+    thor (0.20.0)
     thread_safe (0.3.6)
     tzinfo (1.2.4)
       thread_safe (~> 0.1)
@@ -111,6 +117,7 @@ PLATFORMS
 DEPENDENCIES
   cocoapods (= 1.2.1)
   danger
+  danger-swiftlint
   xcpretty
 
 BUNDLED WITH


### PR DESCRIPTION
## What

I must've forgotten to update the Gemfile.lock when I cherry-picked the danger-swiftlint commit, or maybe they weren't updated in that commit.

## Testing Plan

- [X] Tested this change locally

cc @NghiaTranUIT 