### PR TITLE
Fixed issue with space between operator and expression

### DIFF
--- a/compiler/core/src/swift/swiftRender.bs.js
+++ b/compiler/core/src/swift/swiftRender.bs.js
@@ -123,7 +123,7 @@ function render(ast) {
             case 1 : 
                 return Prettier.doc.builders.group(Curry._2(Prettier$LonaCompilerCore.Doc[/* Builders */0][/* <+> */5], Curry._2(Prettier$LonaCompilerCore.Doc[/* Builders */0][/* <+> */5], Curry._2(Prettier$LonaCompilerCore.Doc[/* Builders */0][/* <+> */5], Curry._2(Prettier$LonaCompilerCore.Doc[/* Builders */0][/* <+> */5], Curry._2(Prettier$LonaCompilerCore.Doc[/* Builders */0][/* <+> */5], Curry._1(Prettier$LonaCompilerCore.Doc[/* Builders */0][/* s */0], o$1.operator), Curry._1(Prettier$LonaCompilerCore.Doc[/* Builders */0][/* s */0], "(")), Prettier.doc.builders.softline), render(o$1.expression)), Prettier.doc.builders.softline), Curry._1(Prettier$LonaCompilerCore.Doc[/* Builders */0][/* s */0], ")")));
             case 2 : 
-                return Prettier.doc.builders.group(Curry._2(Prettier$LonaCompilerCore.Doc[/* Builders */0][/* <+> */5], Curry._2(Prettier$LonaCompilerCore.Doc[/* Builders */0][/* <+> */5], Curry._1(Prettier$LonaCompilerCore.Doc[/* Builders */0][/* s */0], o$1.operator), Curry._1(Prettier$LonaCompilerCore.Doc[/* Builders */0][/* s */0], " ")), render(o$1.expression)));
+                return Curry._2(Prettier$LonaCompilerCore.Doc[/* Builders */0][/* <+> */5], Curry._1(Prettier$LonaCompilerCore.Doc[/* Builders */0][/* s */0], o$1.operator), render(o$1.expression));
             
           }
           break;

--- a/compiler/core/src/swift/swiftRender.re
+++ b/compiler/core/src/swift/swiftRender.re
@@ -68,8 +68,7 @@ let rec render = ast : Prettier.Doc.t('a) =>
     switch o##expression {
     | LiteralExpression(_)
     | SwiftIdentifier(_)
-    | MemberExpression(_) =>
-      group(s(o##operator) <+> s(" ") <+> render(o##expression))
+    | MemberExpression(_) => s(o##operator) <+> render(o##expression)
     | _ =>
       group(
         s(o##operator)


### PR DESCRIPTION
## What

Apparently a space between a prefix operator and expression is an error in Xcode

## Testing Plan

- [X] Tested this change locally
- [X] Checked that existing features work