### PR TITLE
Fixed an issue where text wasn't wrapping when rendered

### DIFF
--- a/LonaStudio/Utils/AttributedFont.swift
+++ b/LonaStudio/Utils/AttributedFont.swift
@@ -26,7 +26,7 @@ public class AttributedFont {
         weight: AttributedFontWeight,
         color: NSColor = NSColor.black,
         textAlignment: NSTextAlignment = .left,
-        lineBreakMode: NSParagraphStyle.LineBreakMode = .byTruncatingTail) {
+        lineBreakMode: NSParagraphStyle.LineBreakMode = .byWordWrapping) {
         self.fontFamily = fontFamily
         self.fontSize = fontSize
         self.lineHeight = lineHeight


### PR DESCRIPTION
## What

Text on the canvas wasn't wrapping... but now it is again!

@NghiaTranUIT do you remember why we changed this? https://github.com/airbnb/Lona/pull/31/files#diff-9b2c28461b90b88c93fed4d2505438f6R30

Maybe in whatever case we need this, we can just change `lineBreakMode` for that instance.

## Testing Plan

- [X] Tested this change locally
- [X] Checked that existing features work