### PR TITLE
Uncomment swiflint rule: legacy_nsgeometry_functions and fix a warning.

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -7,7 +7,6 @@ disabled_rules:
   - type_body_length
   - force_cast
   - force_try
-  - legacy_nsgeometry_functions
   - function_parameter_count
   - multiple_closures_with_trailing_closure
   - line_length

--- a/LonaStudio/CSStatementView.swift
+++ b/LonaStudio/CSStatementView.swift
@@ -287,7 +287,7 @@ class CSStatementView: NSTableCellView {
             if activated { return }
 
             if view.tag == EDITABLE_TEXT_FIELD_TAG {
-                if NSPointInRect(point, view.frame) {
+                if view.frame.contains(point) {
                     window?.makeFirstResponder(view)
                     activated = true
                 }


### PR DESCRIPTION
## What

- I uncommented a new SwiftLint rule and fixed a warning.

## Why

- This rule is necessary because we should not use the legacy functions.

## Major Changes

- Uncomment SwiftLint rule: legacy_nsgeometry_functions
- Fixed a warning.

## Testing Plan

- [x] Tested this change locally
- [x] Checked that existing features work

cc: @dabbott, @ryngonzalez
