### PR TITLE
Text styles can extend other text styles

### DIFF
--- a/compiler/core/src/core/layer.bs.js
+++ b/compiler/core/src/core/layer.bs.js
@@ -427,7 +427,7 @@ function getInsets(prefix, layer) {
     throw [
           Caml_builtin_exceptions.match_failure,
           [
-            "/Users/devinabbott/Projects/Lona/compiler/core/src/core/layer.re",
+            "/Users/devin_abbott/Projects/ComponentStudio/ComponentStudio/compiler/core/src/core/layer.re",
             157,
             6
           ]

--- a/compiler/core/src/core/textStyle.bs.js
+++ b/compiler/core/src/core/textStyle.bs.js
@@ -2,6 +2,7 @@
 'use strict';
 
 var List                    = require("bs-platform/lib/js/list.js");
+var Curry                   = require("bs-platform/lib/js/curry.js");
 var Json_decode             = require("bs-json/src/Json_decode.js");
 var Caml_builtin_exceptions = require("bs-platform/lib/js/caml_builtin_exceptions.js");
 
@@ -14,7 +15,8 @@ var emptyStyle = /* record */[
   /* fontSize : None */0,
   /* lineHeight : None */0,
   /* letterSpacing : None */0,
-  /* color : None */0
+  /* color : None */0,
+  /* extends : None */0
 ];
 
 function normalizeFontWeight(value) {
@@ -59,6 +61,28 @@ function find(textStyles, id) {
   
 }
 
+function lookup(textStyles, _style, f) {
+  while(true) {
+    var style = _style;
+    var match = Curry._1(f, style);
+    var match$1 = style[/* extends */9];
+    if (match) {
+      return /* Some */[match[0]];
+    } else if (match$1) {
+      var match$2 = find(textStyles, match$1[0]);
+      if (match$2) {
+        _style = match$2[0];
+        continue ;
+        
+      } else {
+        return /* None */0;
+      }
+    } else {
+      return /* None */0;
+    }
+  };
+}
+
 function parseFile(content) {
   var parsed = JSON.parse(content);
   var parseTextStyle = function (json) {
@@ -88,6 +112,9 @@ function parseFile(content) {
                   }), json),
             /* color */Json_decode.optional((function (param) {
                     return Json_decode.field("color", Json_decode.string, param);
+                  }), json),
+            /* extends */Json_decode.optional((function (param) {
+                    return Json_decode.field("extends", Json_decode.string, param);
                   }), json)
           ];
   };
@@ -114,5 +141,6 @@ exports.emptyStyle          = emptyStyle;
 exports.normalizeFontWeight = normalizeFontWeight;
 exports.normalizeId         = normalizeId;
 exports.find                = find;
+exports.lookup              = lookup;
 exports.parseFile           = parseFile;
 /* No side effect */

--- a/compiler/core/src/javaScript/javaScriptLogic.bs.js
+++ b/compiler/core/src/javaScript/javaScriptLogic.bs.js
@@ -85,7 +85,7 @@ function toJavaScriptAST(node) {
           throw [
                 Caml_builtin_exceptions.match_failure,
                 [
-                  "/Users/devinabbott/Projects/Lona/compiler/core/src/javaScript/javaScriptLogic.re",
+                  "/Users/devin_abbott/Projects/ComponentStudio/ComponentStudio/compiler/core/src/javaScript/javaScriptLogic.re",
                   20,
                   2
                 ]

--- a/compiler/core/src/main.bs.js
+++ b/compiler/core/src/main.bs.js
@@ -166,17 +166,10 @@ function convertColors(target, contents) {
   return renderColors(target, Color$LonaCompilerCore.parseFile(contents));
 }
 
-function convertTextStyles(target, filename) {
-  var match = findWorkspaceDirectory(filename);
-  if (match) {
-    var colorsFile = Fs.readFileSync(Path.join(match[0], "colors.json"), "utf8");
-    var colors = Color$LonaCompilerCore.parseFile(colorsFile);
-    var textStylesFile = Fs.readFileSync(filename, "utf8");
-    return renderTextStyles(target, colors, TextStyle$LonaCompilerCore.parseFile(textStylesFile));
-  } else {
-    console.log("Couldn't find workspace directory. Try specifying it as a parameter (TODO)");
-    return (process.exit(1));
-  }
+function convertTextStyles(target, workspacePath, content) {
+  var colorsFile = Fs.readFileSync(Path.join(workspacePath, "colors.json"), "utf8");
+  var colors = Color$LonaCompilerCore.parseFile(colorsFile);
+  return renderTextStyles(target, colors, TextStyle$LonaCompilerCore.parseFile(content));
 }
 
 function convertComponent(filename) {
@@ -349,6 +342,24 @@ switch (command) {
         ((process.exit(1)));
       }
       console.log(convertComponent(List.nth(positionalArguments, 4)));
+      break;
+  case "textStyles" : 
+      if (List.length(positionalArguments) < 5) {
+        var render$1 = function (content) {
+          return Promise.resolve((console.log(renderColors(target, Color$LonaCompilerCore.parseFile(content))), /* () */0));
+        };
+        GetStdin().then(render$1);
+      } else {
+        var filename = List.nth(positionalArguments, 4);
+        var match$3 = findWorkspaceDirectory(filename);
+        if (match$3) {
+          var content = Fs.readFileSync(filename, "utf8");
+          console.log(convertTextStyles(target, match$3[0], content));
+        } else {
+          console.log("Couldn't find workspace directory. Try specifying it as a parameter (TODO)");
+          ((process.exit(1)));
+        }
+      }
       break;
   case "workspace" : 
       if (List.length(positionalArguments) < 5) {

--- a/compiler/core/src/swift/swiftTextStyle.bs.js
+++ b/compiler/core/src/swift/swiftTextStyle.bs.js
@@ -46,20 +46,27 @@ function render(options, colors, textStyles) {
     }
   };
   var argumentsDoc = function (textStyle) {
+    var lookup = function (f) {
+      return TextStyle$LonaCompilerCore.lookup(textStyles[/* styles */0], textStyle, f);
+    };
     return List.concat(/* :: */[
                 unwrapOptional((function (value) {
                         return /* FunctionCallArgument */Block.__(15, [{
                                     name: /* Some */[/* SwiftIdentifier */Block.__(6, ["family"])],
                                     value: /* LiteralExpression */Block.__(0, [/* String */Block.__(3, [value])])
                                   }]);
-                      }), textStyle[/* fontFamily */3]),
+                      }), lookup((function (style) {
+                            return style[/* fontFamily */3];
+                          }))),
                 /* :: */[
                   unwrapOptional((function (value) {
                           return /* FunctionCallArgument */Block.__(15, [{
                                       name: /* Some */[/* SwiftIdentifier */Block.__(6, ["name"])],
                                       value: /* LiteralExpression */Block.__(0, [/* String */Block.__(3, [value])])
                                     }]);
-                        }), textStyle[/* fontName */2]),
+                        }), lookup((function (style) {
+                              return style[/* fontName */2];
+                            }))),
                   /* :: */[
                     unwrapOptional((function (value) {
                             return /* FunctionCallArgument */Block.__(15, [{
@@ -75,28 +82,36 @@ function render(options, colors, textStyles) {
                                               ]
                                             ]])
                                       }]);
-                          }), textStyle[/* fontWeight */4]),
+                          }), lookup((function (style) {
+                                return style[/* fontWeight */4];
+                              }))),
                     /* :: */[
                       unwrapOptional((function (value) {
                               return /* FunctionCallArgument */Block.__(15, [{
                                           name: /* Some */[/* SwiftIdentifier */Block.__(6, ["size"])],
                                           value: /* LiteralExpression */Block.__(0, [/* FloatingPoint */Block.__(2, [value])])
                                         }]);
-                            }), textStyle[/* fontSize */5]),
+                            }), lookup((function (style) {
+                                  return style[/* fontSize */5];
+                                }))),
                       /* :: */[
                         unwrapOptional((function (value) {
                                 return /* FunctionCallArgument */Block.__(15, [{
                                             name: /* Some */[/* SwiftIdentifier */Block.__(6, ["lineHeight"])],
                                             value: /* LiteralExpression */Block.__(0, [/* FloatingPoint */Block.__(2, [value])])
                                           }]);
-                              }), textStyle[/* lineHeight */6]),
+                              }), lookup((function (style) {
+                                    return style[/* lineHeight */6];
+                                  }))),
                         /* :: */[
                           unwrapOptional((function (value) {
                                   return /* FunctionCallArgument */Block.__(15, [{
                                               name: /* Some */[/* SwiftIdentifier */Block.__(6, ["kerning"])],
                                               value: /* LiteralExpression */Block.__(0, [/* FloatingPoint */Block.__(2, [value])])
                                             }]);
-                                }), textStyle[/* letterSpacing */7]),
+                                }), lookup((function (style) {
+                                      return style[/* letterSpacing */7];
+                                    }))),
                           /* :: */[
                             unwrapOptional((function (value) {
                                     var match = Color$LonaCompilerCore.find(colors, value);
@@ -111,7 +126,9 @@ function render(options, colors, textStyles) {
                                                 name: /* Some */[/* SwiftIdentifier */Block.__(6, ["color"])],
                                                 value: value$1
                                               }]);
-                                  }), textStyle[/* color */8]),
+                                  }), lookup((function (style) {
+                                        return style[/* color */8];
+                                      }))),
                             /* [] */0
                           ]
                         ]

--- a/compiler/core/src/swift/swiftTextStyle.re
+++ b/compiler/core/src/swift/swiftTextStyle.re
@@ -29,73 +29,76 @@ let render =
     | "900" => "black"
     | _ => "regular";
   let argumentsDoc = (textStyle: TextStyle.t) =>
-    [
-      textStyle.fontFamily
-      |> unwrapOptional(value =>
-           FunctionCallArgument({
-             "name": Some(SwiftIdentifier("family")),
-             "value": LiteralExpression(String(value))
+    {
+      let lookup = f => TextStyle.lookup(textStyles.styles, textStyle, f);
+      [
+        lookup(style => style.fontFamily)
+        |> unwrapOptional(value =>
+             FunctionCallArgument({
+               "name": Some(SwiftIdentifier("family")),
+               "value": LiteralExpression(String(value))
+             })
+           ),
+        lookup(style => style.fontName)
+        |> unwrapOptional(value =>
+             FunctionCallArgument({
+               "name": Some(SwiftIdentifier("name")),
+               "value": LiteralExpression(String(value))
+             })
+           ),
+        lookup(style => style.fontWeight)
+        |> unwrapOptional(value =>
+             FunctionCallArgument({
+               "name": Some(SwiftIdentifier("weight")),
+               "value":
+                 MemberExpression([
+                   SwiftIdentifier(
+                     SwiftDocument.fontTypeName(options.framework)
+                   ),
+                   SwiftIdentifier("Weight"),
+                   SwiftIdentifier(convertFontWeight(value))
+                 ])
+             })
+           ),
+        lookup(style => style.fontSize)
+        |> unwrapOptional(value =>
+             FunctionCallArgument({
+               "name": Some(SwiftIdentifier("size")),
+               "value": LiteralExpression(FloatingPoint(value))
+             })
+           ),
+        lookup(style => style.lineHeight)
+        |> unwrapOptional(value =>
+             FunctionCallArgument({
+               "name": Some(SwiftIdentifier("lineHeight")),
+               "value": LiteralExpression(FloatingPoint(value))
+             })
+           ),
+        lookup(style => style.letterSpacing)
+        |> unwrapOptional(value =>
+             FunctionCallArgument({
+               "name": Some(SwiftIdentifier("kerning")),
+               "value": LiteralExpression(FloatingPoint(value))
+             })
+           ),
+        lookup(style => style.color)
+        |> unwrapOptional(value => {
+             let value =
+               switch (Color.find(colors, value)) {
+               | Some(color) =>
+                 MemberExpression([
+                   SwiftIdentifier("Colors"),
+                   SwiftIdentifier(color.id)
+                 ])
+               | None => LiteralExpression(Color(value))
+               };
+             FunctionCallArgument({
+               "name": Some(SwiftIdentifier("color")),
+               "value": value
+             });
            })
-         ),
-      textStyle.fontName
-      |> unwrapOptional(value =>
-           FunctionCallArgument({
-             "name": Some(SwiftIdentifier("name")),
-             "value": LiteralExpression(String(value))
-           })
-         ),
-      textStyle.fontWeight
-      |> unwrapOptional(value =>
-           FunctionCallArgument({
-             "name": Some(SwiftIdentifier("weight")),
-             "value":
-               MemberExpression([
-                 SwiftIdentifier(
-                   SwiftDocument.fontTypeName(options.framework)
-                 ),
-                 SwiftIdentifier("Weight"),
-                 SwiftIdentifier(convertFontWeight(value))
-               ])
-           })
-         ),
-      textStyle.fontSize
-      |> unwrapOptional(value =>
-           FunctionCallArgument({
-             "name": Some(SwiftIdentifier("size")),
-             "value": LiteralExpression(FloatingPoint(value))
-           })
-         ),
-      textStyle.lineHeight
-      |> unwrapOptional(value =>
-           FunctionCallArgument({
-             "name": Some(SwiftIdentifier("lineHeight")),
-             "value": LiteralExpression(FloatingPoint(value))
-           })
-         ),
-      textStyle.letterSpacing
-      |> unwrapOptional(value =>
-           FunctionCallArgument({
-             "name": Some(SwiftIdentifier("kerning")),
-             "value": LiteralExpression(FloatingPoint(value))
-           })
-         ),
-      textStyle.color
-      |> unwrapOptional(value => {
-           let value =
-             switch (Color.find(colors, value)) {
-             | Some(color) =>
-               MemberExpression([
-                 SwiftIdentifier("Colors"),
-                 SwiftIdentifier(color.id)
-               ])
-             | None => LiteralExpression(Color(value))
-             };
-           FunctionCallArgument({
-             "name": Some(SwiftIdentifier("color")),
-             "value": value
-           });
-         })
-    ]
+      ];
+    }
     |> List.concat;
   let textStyleConstantDoc = (textStyle: TextStyle.t) =>
     ConstantDeclaration({


### PR DESCRIPTION
## What

Text styles can extend other text styles. This is useful for cases where many styles share the same font family, metrics, etc.

## Testing Plan

- [X] Tested this change locally
- [X] Checked that existing features work