### PR TITLE
Add Record type editor

### DIFF
--- a/LonaStudio/Models/CSComponent.swift
+++ b/LonaStudio/Models/CSComponent.swift
@@ -110,7 +110,11 @@ class CSComponent: DataNode, NSCopying {
             .reduce(CSData.Object([:])) { (result, parameter) -> CSData in
                 var result = result
                 parametersSchema[parameter.name] = (type: parameter.type, access: CSAccess.read)
-                result[parameter.name] = CSData.Null
+                if case CSType.dictionary(_) = parameter.type {
+                    result[parameter.name] = CSValue.defaultValue(for: parameter.type).data
+                } else {
+                    result[parameter.name] = CSData.Null
+                }
                 return result
             }
 

--- a/LonaStudio/Workspace/Inspector View/ComponentInspectorView.swift
+++ b/LonaStudio/Workspace/Inspector View/ComponentInspectorView.swift
@@ -53,8 +53,10 @@ final class ComponentInspectorView: NSStackView {
     private func setupValueFields() -> [(view: NSView, keyView: NSView)] {
         let views: [(view: NSView, keyView: NSView)] = componentLayer.component.parameters.map({ parameter in
             let data: CSData
-            if parameter.type.isOptional() {
+            if parameter.type.unwrappedNamedType().isOptional() {
                 data = componentLayer.parameters[parameter.name] ?? CSUnitValue.wrap(in: parameter.type, tagged: "None").data
+            } else if parameter.type.unwrappedNamedType().isVariant {
+                data = componentLayer.parameters[parameter.name] ?? CSValue.defaultValue(for: parameter.type).data
             } else {
                 data = componentLayer.parameters[parameter.name] ?? CSData.Null
             }
@@ -62,7 +64,7 @@ final class ComponentInspectorView: NSStackView {
             var usesYogaLayout = true
             if case .named("URL", .string) = value.type {
                 usesYogaLayout = false
-            } else if case .variant(_) = value.type {
+            } else if case .variant(_) = value.type.unwrappedNamedType() {
                 usesYogaLayout = false
             }
 


### PR DESCRIPTION
## What

You can now create custom Record types as parameters (necessary for current Airbnb components). Other complex type editing to come.

A record is a type that contains key-value pairs. This is useful for grouping parameters, or directly interoperating with complex types in the target codebase.

In JSON, record types are akin to:
`{ "title": "String", "subtitle": "String?" }`

## Testing Plan

- [X] Tested this change locally
- [X] Checked that existing features work