### PR TITLE
Update file format to be module-based

### DIFF
--- a/LonaStudio.xcodeproj/project.pbxproj
+++ b/LonaStudio.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		305A19561F463A2800EA033C /* DisclosureContentRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 305A19551F463A2800EA033C /* DisclosureContentRow.swift */; };
 		305A19581F463BD300EA033C /* NSTextFieldExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 305A19571F463BD300EA033C /* NSTextFieldExtensions.swift */; };
 		305BDA211F648F6400AD2AA3 /* CSPDFDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 305BDA201F648F6400AD2AA3 /* CSPDFDocument.swift */; };
+		305ED04620530257000D07C3 /* LonaModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 305ED04520530257000D07C3 /* LonaModule.swift */; };
 		306672C21F7D4C6400941554 /* CSGradients.swift in Sources */ = {isa = PBXBuildFile; fileRef = 306672C11F7D4C6400941554 /* CSGradients.swift */; };
 		3069E09A1F3243780005E9A8 /* parseCSSColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3069E0991F3243780005E9A8 /* parseCSSColor.swift */; };
 		3069E09C1F324C550005E9A8 /* CSWorkspacePreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3069E09B1F324C550005E9A8 /* CSWorkspacePreferences.swift */; };
@@ -168,6 +169,7 @@
 		305A19551F463A2800EA033C /* DisclosureContentRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisclosureContentRow.swift; sourceTree = "<group>"; };
 		305A19571F463BD300EA033C /* NSTextFieldExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSTextFieldExtensions.swift; sourceTree = "<group>"; };
 		305BDA201F648F6400AD2AA3 /* CSPDFDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CSPDFDocument.swift; sourceTree = "<group>"; };
+		305ED04520530257000D07C3 /* LonaModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LonaModule.swift; sourceTree = "<group>"; };
 		306672C11F7D4C6400941554 /* CSGradients.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CSGradients.swift; sourceTree = "<group>"; };
 		3069E0991F3243780005E9A8 /* parseCSSColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = parseCSSColor.swift; sourceTree = "<group>"; };
 		3069E09B1F324C550005E9A8 /* CSWorkspacePreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CSWorkspacePreferences.swift; sourceTree = "<group>"; };
@@ -339,6 +341,14 @@
 				6B0AEFB91EBF74D800F35BBF /* ViewController.swift */,
 			);
 			path = Workspace;
+			sourceTree = "<group>";
+		};
+		305ED04420530238000D07C3 /* Module */ = {
+			isa = PBXGroup;
+			children = (
+				305ED04520530257000D07C3 /* LonaModule.swift */,
+			);
+			path = Module;
 			sourceTree = "<group>";
 		};
 		3069E0981F32432C0005E9A8 /* Utils */ = {
@@ -529,24 +539,25 @@
 		6B0AEFB61EBF74D800F35BBF /* LonaStudio */ = {
 			isa = PBXGroup;
 			children = (
-				BA153BC8202B2CBA002A83A5 /* Undo */,
+				6B0AEFC21EBF74D800F35BBF /* Info.plist */,
 				6B0AEFB71EBF74D800F35BBF /* AppDelegate.swift */,
-				30CE64481F008F43008D01AD /* Assets */,
+				300302731EDC7FA90085E140 /* CSStatementView.swift */,
+				6B0AEFBB1EBF74D800F35BBF /* Document.swift */,
 				6B0AEFBD1EBF74D800F35BBF /* Assets.xcassets */,
+				30CE64481F008F43008D01AD /* Assets */,
 				306DA4ED1F33E19F002772DC /* Canvas */,
 				3030311C1F34E6980078086F /* CanvasList */,
 				306DA4F21F34E265002772DC /* Controls */,
-				300302731EDC7FA90085E140 /* CSStatementView.swift */,
-				6B0AEFBB1EBF74D800F35BBF /* Document.swift */,
 				30C8BC291EDB640500B99F1B /* Extensions */,
-				6B0AEFC21EBF74D800F35BBF /* Info.plist */,
 				301433791F5C7AD100525DB1 /* ListEditors */,
 				3030311D1F34E6A70078086F /* LogicList */,
 				6B0AEFBF1EBF74D800F35BBF /* Main.storyboard */,
 				30C8BC301EDB757E00B99F1B /* Models */,
+				305ED04420530238000D07C3 /* Module */,
 				3030311E1F34E6B40078086F /* ParameterList */,
 				3097776E1F296A1F004C8975 /* Preferences */,
 				30DDEE881F47925C001D41AB /* Scripting */,
+				BA153BC8202B2CBA002A83A5 /* Undo */,
 				3069E0981F32432C0005E9A8 /* Utils */,
 				3030311F1F34E7200078086F /* Workspace */,
 			);
@@ -933,6 +944,7 @@
 				30D9B40E1F79BADC00C8A3D4 /* NSMenuExtensions.swift in Sources */,
 				30C8BC2D1EDB653400B99F1B /* CanvasListView.swift in Sources */,
 				3090D78D1F01B050009277E7 /* CSParameter.swift in Sources */,
+				305ED04620530257000D07C3 /* LonaModule.swift in Sources */,
 				6B0AEFBC1EBF74D800F35BBF /* Document.swift in Sources */,
 				306D2FEE1F84735900907B4E /* LayerThumbnail.swift in Sources */,
 				301433761F5B499900525DB1 /* DictionaryEditorButton.swift in Sources */,

--- a/LonaStudio/Canvas/CanvasView.swift
+++ b/LonaStudio/Canvas/CanvasView.swift
@@ -206,7 +206,7 @@ func renderBox(layer: CSLayer, node: YGNodeRef, options: RenderOptions) -> NSVie
         box.layer?.borderColor = borderColor
     }
 
-    if layer.type == "Animation" {
+    if layer.type == .animation {
         let animation: String? = layer.config?.get(attribute: "animation", for: layer.name).string ?? layer.animation
 
         if  let animation = animation,
@@ -232,7 +232,7 @@ func renderBox(layer: CSLayer, node: YGNodeRef, options: RenderOptions) -> NSVie
                 animationView.play()
             }
         }
-    } else if layer.type == "Image" {
+    } else if layer.type == .image {
         let image: String? = layer.config?.get(attribute: "image", for: layer.name).string ?? layer.image
 
         if let image = image, let url = URL(string: image)?.absoluteURLForWorkspaceURL() {
@@ -292,7 +292,7 @@ func renderBox(layer: CSLayer, node: YGNodeRef, options: RenderOptions) -> NSVie
 //        return false
 //    }
 
-    if layer.type == "Text" {
+    if layer.type == .text {
         if #available(OSX 10.12, *) {
             let width = YGNodeLayoutGetWidth(node)
             let height = YGNodeLayoutGetHeight(node)
@@ -373,7 +373,7 @@ func renderBoxJSON(layer: CSLayer, node: YGNodeRef, references: inout SketchFile
 
     var sketchLayers = CSData.Array([])
 
-    if layer.type == "Image" {
+    if layer.type == .image {
         let image: String? = layer.config?.get(attribute: "image", for: layer.name).string ?? layer.image
 
         if let image = image {
@@ -469,7 +469,7 @@ func setFlexExpand(for layer: CSLayer, node: YGNodeRef) {
     node.flexShrink = 1
     node.flexGrow = 1
 
-    if layer.type == "Text" {
+    if layer.type == .text {
         node.flexBasis = .value(0)
     } else {
         node.flexBasis = .auto
@@ -596,7 +596,7 @@ func layoutLayer(layer: CSLayer, parentLayoutDirection: YGFlexDirection) -> YGNo
     }
 
     // Non-text layer
-    if layer.type == "Text" {
+    if layer.type == .text {
         YGNodeSetContext(node, UnsafeMutableRawPointer(Unmanaged.passUnretained(layer).toOpaque()))
         YGNodeSetMeasureFunc(node, measureFunc(node:width:widthMode:height:heightMode:))
     } else {

--- a/LonaStudio/Controls/ComponentEditorButton.swift
+++ b/LonaStudio/Controls/ComponentEditorButton.swift
@@ -32,7 +32,8 @@ class ComponentEditorButton: Button, CSControl, NSPopoverDelegate {
     private var editor: DictionaryEditor?
 
     func layerValue(for input: CSValue, parameters: CSData? = nil) -> CSValue {
-        let layerType = input.data.get(key: "type").stringValue
+        // TODO: Need to test this after changing to enum-based layer types
+        let layerType = CSLayer.LayerType(input.data.get(key: "type"))
         let template = CSLayer(name: "Component", type: layerType).layerValue()
 
         let updatedData = parameters != nil ? input.data.merge(CSData.Object(["parameters": parameters!])) : input.data
@@ -65,7 +66,7 @@ class ComponentEditorButton: Button, CSControl, NSPopoverDelegate {
             self.editor = editor
 
             // TODO: All built-in components currently share the same CSType... need to use different types
-            func setValue(withViewType type: String) {
+            func setValue(withViewType type: CSLayer.LayerType) {
                 let template = CSLayer(name: "Component", type: type).layerValue()
                 let value = CSValue(type: template.type, data: CSData.Object([
                     "type": type.toData(),
@@ -73,7 +74,7 @@ class ComponentEditorButton: Button, CSControl, NSPopoverDelegate {
                 ]))
 
                 self.value = value
-                self.title = type
+                self.title = type.string
                 self.editor?.setParameters(value: value.get(key: "parameters"))
             }
 
@@ -87,13 +88,13 @@ class ComponentEditorButton: Button, CSControl, NSPopoverDelegate {
                 }),
                 NSMenuItem.separator(),
                 NSMenuItem(title: "View", onClick: {
-                    setValue(withViewType: "View")
+                    setValue(withViewType: .view)
                 }),
                 NSMenuItem(title: "Text", onClick: {
-                    setValue(withViewType: "Text")
+                    setValue(withViewType: .text)
                 }),
                 NSMenuItem(title: "Image", onClick: {
-                    setValue(withViewType: "Image")
+                    setValue(withViewType: .image)
                 }),
                 NSMenuItem.separator(),
                 NSMenuItem(title: "Component...", onClick: {})

--- a/LonaStudio/Models/CSComponentLayer.swift
+++ b/LonaStudio/Models/CSComponentLayer.swift
@@ -37,7 +37,7 @@ class CSComponentLayer: CSLayer {
     }
 
     private static var defaultComponent: CSComponent {
-        let rootLayer = CSLayer(name: "Failed to Load Component", type: "View")
+        let rootLayer = CSLayer(name: "Failed to Load Component", type: .view)
         return CSComponent(name: nil, canvas: [], rootLayer: rootLayer, parameters: [], cases: [], logic: [], config: CSData.Object([:]), metadata: CSData.Object([:]))
     }
 
@@ -66,7 +66,7 @@ class CSComponentLayer: CSLayer {
 
     init(name: String, url: String, parameters: [String: CSData] = [:], children: [CSLayer] = []) {
         self.url = url
-        super.init(name: name, type: "Component", parameters: parameters, children: children)
+        super.init(name: name, type: .custom(name), parameters: parameters, children: children)
 
         reload()
     }

--- a/LonaStudio/Models/CSComponentLayer.swift
+++ b/LonaStudio/Models/CSComponentLayer.swift
@@ -9,13 +9,12 @@
 import Foundation
 
 class CSComponentLayer: CSLayer {
-    var url: String
     var component: CSComponent!
     var failedToLoad: Bool = false
 
     func reload() {
-        if let component = CSComponentLayer.loadComponent(at: url) {
-            self.component = component
+        if case CSLayer.LayerType.custom(let name) = type {
+            self.component = LonaModule.current.component(named: name)
         } else {
             self.component = CSComponentLayer.defaultComponent
             failedToLoad = true
@@ -48,14 +47,8 @@ class CSComponentLayer: CSLayer {
     }
 
     required init(_ json: CSData) {
-        let rawURL = json.get(key: "url").stringValue
-
-        self.url = rawURL.hasPrefix("./")
-            ? URL(fileURLWithPath: rawURL, relativeTo: CSWorkspacePreferences.workspaceURL).absoluteString
-            : rawURL
-
-        if let component = CSComponentLayer.loadComponent(at: self.url) {
-            self.component = component
+        if case CSLayer.LayerType.custom(let name) = LayerType(json.get(key: "type")) {
+            self.component = LonaModule.current.component(named: name)
         } else {
             self.component = CSComponentLayer.defaultComponent
             failedToLoad = true
@@ -64,9 +57,8 @@ class CSComponentLayer: CSLayer {
         super.init(json)
     }
 
-    init(name: String, url: String, parameters: [String: CSData] = [:], children: [CSLayer] = []) {
-        self.url = url
-        super.init(name: name, type: .custom(name), parameters: parameters, children: children)
+    override init(name: String, type: LayerType, parameters: [String: CSData] = [:], children: [CSLayer] = []) {
+        super.init(name: name, type: type, parameters: parameters, children: children)
 
         reload()
     }
@@ -93,20 +85,4 @@ class CSComponentLayer: CSLayer {
         return parameters
     }
 
-    override func toData() -> CSData {
-        var data = super.toData()
-
-        guard let absolutePath = URL(string: url)?.path else { return data }
-        let basePath = CSWorkspacePreferences.workspaceURL.path
-
-        let relativePath = absolutePath.pathRelativeTo(basePath: basePath)
-
-//        Swift.print("absolute path", absolutePath)
-//        Swift.print("base path", basePath)
-//        Swift.print("relative path", relativePath)
-
-        data["url"] = relativePath?.toData()
-
-        return data
-    }
 }

--- a/LonaStudio/Models/CSLayer.swift
+++ b/LonaStudio/Models/CSLayer.swift
@@ -60,11 +60,11 @@ class CSLayer: CSDataDeserializable, CSDataSerializable, DataNode, NSCopying {
         case custom(String)
 
         init(from string: String) {
-            // TODO: This case is for backwards compat, before the "Lona/" prefix. Remove.
+            // TODO: This case is for backwards compat, before the "Lona:" prefix. Remove.
             if let layerType = BuiltInLayerType(rawValue: string) {
                 self = .builtIn(layerType)
-            } else if string.starts(with: "Lona/") {
-                let index = string.index(after: string.index(of: "/")!)
+            } else if string.starts(with: "Lona:") {
+                let index = string.index(after: string.index(of: ":")!)
                 let suffix = String(string[index...])
                 self = .builtIn(CSLayer.BuiltInLayerType(rawValue: suffix)!)
             } else {
@@ -79,7 +79,7 @@ class CSLayer: CSDataDeserializable, CSDataSerializable, DataNode, NSCopying {
         var string: String {
             switch self {
             case .builtIn(let builtInLayerType):
-                return "Lona/" + builtInLayerType.rawValue
+                return "Lona:" + builtInLayerType.rawValue
             case .custom(let layerType):
                 return layerType
             }
@@ -468,9 +468,9 @@ class CSLayer: CSDataDeserializable, CSDataSerializable, DataNode, NSCopying {
     }
 
     static func deserialize(_ json: CSData) -> CSLayer? {
-        let type = json.get(key: "type").stringValue
+        let type = LayerType(json.get(key: "type"))
 
-        if type == "Component" {
+        if case LayerType.custom = type {
             let layer = CSComponentLayer(json)
 
             if layer.failedToLoad {

--- a/LonaStudio/Models/CSLayer.swift
+++ b/LonaStudio/Models/CSLayer.swift
@@ -47,11 +47,71 @@ extension CSData {
 
 class CSLayer: CSDataDeserializable, CSDataSerializable, DataNode, NSCopying {
 
+    enum BuiltInLayerType: String {
+        case view = "View"
+        case text = "Text"
+        case image = "Image"
+        case animation = "Animation"
+        case children = "Children"
+    }
+
+    enum LayerType {
+        case builtIn(BuiltInLayerType)
+        case custom(String)
+
+        init(from string: String) {
+            // TODO: This case is for backwards compat, before the "Lona/" prefix. Remove.
+            if let layerType = BuiltInLayerType(rawValue: string) {
+                self = .builtIn(layerType)
+            } else if string.starts(with: "Lona/") {
+                let index = string.index(after: string.index(of: "/")!)
+                let suffix = String(string[index...])
+                self = .builtIn(CSLayer.BuiltInLayerType(rawValue: suffix)!)
+            } else {
+                self = .custom(string)
+            }
+        }
+
+        init(_ data: CSData) {
+            self.init(from: data.stringValue)
+        }
+
+        var string: String {
+            switch self {
+            case .builtIn(let builtInLayerType):
+                return "Lona/" + builtInLayerType.rawValue
+            case .custom(let layerType):
+                return layerType
+            }
+        }
+
+        func toData() -> CSData {
+            return string.toData()
+        }
+
+        static let view = LayerType.builtIn(.view)
+        static let text = LayerType.builtIn(.text)
+        static let image = LayerType.builtIn(.image)
+        static let animation = LayerType.builtIn(.animation)
+        static let children = LayerType.builtIn(.children)
+
+        static func == (lhs: LayerType, rhs: LayerType) -> Bool {
+            switch (lhs, rhs) {
+            case (.builtIn(let l), .builtIn(let r)):
+                return l == r
+            case (.custom(let l), .custom(let r)):
+                return l == r
+            default:
+                return false
+            }
+        }
+    }
+
     // Hack: attach this for use in layout
     var config: ComponentConfiguration?
 
     var name: String = "Layer"
-    var type: String = "View"
+    var type: LayerType = .view
     var children: [CSLayer] = []
     var parent: CSLayer?
     var parameters: [String: CSData] = [:]
@@ -427,13 +487,13 @@ class CSLayer: CSDataDeserializable, CSDataSerializable, DataNode, NSCopying {
 
     required init(_ json: CSData) {
         name = json.get(key: "id").string ?? json.get(key: "name").stringValue
-        type = json.get(key: "type").stringValue
+        type = LayerType(json.get(key: "type"))
         parameters = decode(parameters: json.get(key: "parameters").objectValue)
         children = json.get(key: "children").arrayValue.map({ CSLayer.deserialize($0) }).flatMap({ $0 })
         children.forEach({ $0.parent = self })
     }
 
-    init(name: String, type: String, parameters: [String: CSData] = [:], children: [CSLayer] = []) {
+    init(name: String, type: LayerType, parameters: [String: CSData] = [:], children: [CSLayer] = []) {
         self.name = name
         self.type = type
         self.parameters = parameters
@@ -628,7 +688,7 @@ class CSLayer: CSDataDeserializable, CSDataSerializable, DataNode, NSCopying {
                 }
             }
 
-            if layer.type == "Children" {
+            if layer.type == .children {
                 // TODO Maybe can consolidate and just store the link to the parent
 //                if let parent = config.parentComponentLayer {
 //                    parent.children.forEach({ result.append($0) })
@@ -682,7 +742,7 @@ class CSLayer: CSDataDeserializable, CSDataSerializable, DataNode, NSCopying {
             "children": CSData.Array([])
         ])
 
-        if type == "View" {
+        if type == .view {
             data["pressed"] = CSData.Bool(false)
             data["hovered"] = CSData.Bool(false)
             data["onPress"] = CSData.Null
@@ -695,12 +755,12 @@ class CSLayer: CSDataDeserializable, CSDataSerializable, DataNode, NSCopying {
         }
 
         // Image
-        if type == "Image" {
+        if type == .image {
             data["image"] = CSData.String(image ?? "")
         }
 
         // Animation
-        if type == "Animation",
+        if type == .animation,
             let animation = animation,
             let url = URL(string: animation),
             let animationData = AnimationUtils.decode(contentsOf: url) {

--- a/LonaStudio/Models/CSValue.swift
+++ b/LonaStudio/Models/CSValue.swift
@@ -148,8 +148,13 @@ struct CSValue: Equatable, CSDataSerializable, CSDataDeserializable {
                 return (key: arg.key, value: exampleValue(for: arg.value.type).data)
             })
             return CSValue(type: type, data: .Object(fields))
+        case .variant(let cases):
+            guard let (tag, caseType) = cases.first else {
+                return CSValue(type: type, data: CSData.Null)
+            }
+            return exampleValue(for: caseType).wrap(in: type, tagged: tag)
         default:
-            return CSValue(type: CSAnyType, data: CSData.Null)
+            return CSValue(type: type, data: CSData.Null)
         }
     }
 
@@ -165,6 +170,11 @@ struct CSValue: Equatable, CSDataSerializable, CSDataDeserializable {
                 return (key: arg.key, value: defaultValue(for: arg.value.type).data)
             })
             return CSValue(type: type, data: .Object(fields))
+        case .variant(let cases):
+            guard let (tag, caseType) = cases.first else {
+                return CSValue(type: type, data: CSData.Null)
+            }
+            return defaultValue(for: caseType).wrap(in: type, tagged: tag)
         default:
             return CSUndefinedValue.cast(to: type)
         }

--- a/LonaStudio/Module/LonaModule.swift
+++ b/LonaStudio/Module/LonaModule.swift
@@ -1,0 +1,66 @@
+//
+//  LonaModule.swift
+//  LonaStudio
+//
+//  Created by devin_abbott on 3/9/18.
+//  Copyright © 2018 Devin Abbott. All rights reserved.
+//
+
+import Foundation
+
+class LonaModule {
+    struct ComponentFile {
+        let url: URL
+        var name: String {
+            return url.deletingPathExtension().lastPathComponent
+        }
+    }
+
+    let url: URL
+
+    init(url: URL) {
+        self.url = url
+    }
+
+    func componentFiles() -> [ComponentFile] {
+        return LonaModule.componentFiles(in: url)
+    }
+
+    func component(url: URL) -> CSComponent? {
+        guard let componentFile = componentFiles().first(where: { arg in arg.url == url }) else { return nil }
+        return CSComponent(url: componentFile.url)
+    }
+
+    func component(named name: String) -> CSComponent? {
+        guard let componentFile = componentFiles().first(where: { arg in arg.name == name }) else { return nil }
+        return CSComponent(url: componentFile.url)
+    }
+
+    // MARK: - STATIC
+
+    static var current: LonaModule {
+        return LonaModule(url: CSWorkspacePreferences.workspaceURL)
+    }
+
+    static func componentFiles(in workspace: URL) -> [ComponentFile] {
+        var files: [ComponentFile] = []
+
+        let fileManager = FileManager.default
+        let keys = [URLResourceKey.isDirectoryKey, URLResourceKey.localizedNameKey]
+        let options: FileManager.DirectoryEnumerationOptions = [.skipsPackageDescendants, .skipsHiddenFiles]
+
+        guard let enumerator = fileManager.enumerator(
+            at: workspace,
+            includingPropertiesForKeys: keys,
+            options: options,
+            errorHandler: {(_, _) -> Bool in true }) else { return files }
+
+        while let file = enumerator.nextObject() as? URL {
+            if file.pathExtension == "component" {
+                files.append(ComponentFile(url: file))
+            }
+        }
+
+        return files
+    }
+}

--- a/LonaStudio/Module/LonaModule.swift
+++ b/LonaStudio/Module/LonaModule.swift
@@ -26,6 +26,10 @@ class LonaModule {
         return LonaModule.componentFiles(in: url)
     }
 
+    func componentFile(named name: String) -> ComponentFile? {
+        return componentFiles().first(where: { arg in arg.name == name })
+    }
+
     func component(url: URL) -> CSComponent? {
         guard let componentFile = componentFiles().first(where: { arg in arg.url == url }) else { return nil }
         return CSComponent(url: componentFile.url)

--- a/LonaStudio/Workspace/Inspector View/InspectorView.swift
+++ b/LonaStudio/Workspace/Inspector View/InspectorView.swift
@@ -687,7 +687,7 @@ class InspectorView: NSStackView {
         paddingBottomView.nextKeyView = paddingLeftView
     }
 
-    init(frame frameRect: NSRect, layerType: String, properties: Properties) {
+    init(frame frameRect: NSRect, layerType: CSLayer.LayerType, properties: Properties) {
         super.init(frame: frameRect)
         translatesAutoresizingMaskIntoConstraints = false
         orientation = .vertical
@@ -697,13 +697,13 @@ class InspectorView: NSStackView {
         setup(properties: properties)
 
         switch layerType {
-        case "Text":
+        case .builtIn(.text):
             textSection.isHidden = false
             layoutSection.isHidden = true
             shadowSection.isHidden = false
-        case "Image":
+        case .builtIn(.image):
             imageSection.isHidden = false
-        case "Animation":
+        case .builtIn(.animation):
             animationSection.isHidden = false
         default:
             break

--- a/LonaStudio/Workspace/LayerList.swift
+++ b/LonaStudio/Workspace/LayerList.swift
@@ -370,7 +370,7 @@ extension LayerList: NSOutlineViewDelegate, NSOutlineViewDataSource {
                 textField.drawsBackground = false
                 textField.stringValue = layer.name
 
-                if layer.type == "Component" {
+                if case CSLayer.LayerType.custom = layer.type {
                     textField.textColor = NSColor.parse(css: "rgb(101,53,160)")!
                 }
 

--- a/LonaStudio/Workspace/LayerThumbnail.swift
+++ b/LonaStudio/Workspace/LayerThumbnail.swift
@@ -34,7 +34,7 @@ class LayerThumbnail {
         let size = 16 * scale
 
         switch layer.type {
-        case "View":
+        case .builtIn(.view):
             let cacheKey = cacheKeyForView(at: scale, direction: layer.flexDirection ?? "column", backgroundColor: layer.backgroundColor)
 
             if let cached = cache.object(forKey: cacheKey) {
@@ -88,7 +88,7 @@ class LayerThumbnail {
             cache.setObject(image, forKey: cacheKey)
 
             return image
-        case "Text":
+        case .builtIn(.text):
             let template: NSImage = #imageLiteral(resourceName: "icon-layer-list-text")
 
             if let font = layer.font {
@@ -106,7 +106,7 @@ class LayerThumbnail {
             }
 
             return template
-        case "Image":
+        case .builtIn(.image):
             if let urlString = layer.image, let url = URL(string: urlString) {
                 let cacheKey = NSString(string: urlString)
 

--- a/LonaStudio/Workspace/ViewController.swift
+++ b/LonaStudio/Workspace/ViewController.swift
@@ -136,7 +136,7 @@ class ViewController: NSViewController, NSOutlineViewDataSource, NSOutlineViewDe
     }
 
     @IBAction func addChildren(_ sender: AnyObject) {
-        let newLayer = CSLayer(name: "Children", type: "Children", parameters: [
+        let newLayer = CSLayer(name: "Children", type: .children, parameters: [
             "width": 100.toData(),
             "height": 100.toData(),
             "backgroundColor": "#D8D8D8".toData()
@@ -148,7 +148,7 @@ class ViewController: NSViewController, NSOutlineViewDataSource, NSOutlineViewDe
     @IBAction func addImage(_ sender: AnyObject) {
         let name = component.getNewLayerName(startingWith: "Image")
 
-        let newLayer = CSLayer(name: name, type: "Image", parameters: [
+        let newLayer = CSLayer(name: name, type: .image, parameters: [
             "width": 100.toData(),
             "height": 100.toData(),
             "backgroundColor": "#D8D8D8".toData()
@@ -160,7 +160,7 @@ class ViewController: NSViewController, NSOutlineViewDataSource, NSOutlineViewDe
     @IBAction func addAnimation(_ sender: AnyObject) {
         let name = component.getNewLayerName(startingWith: "Animation")
 
-        let newLayer = CSLayer(name: name, type: "Animation", parameters: [
+        let newLayer = CSLayer(name: name, type: .animation, parameters: [
             "width": 100.toData(),
             "height": 100.toData(),
             "backgroundColor": "#D8D8D8".toData()
@@ -172,7 +172,7 @@ class ViewController: NSViewController, NSOutlineViewDataSource, NSOutlineViewDe
     @IBAction func addView(_ sender: AnyObject) {
         let name = component.getNewLayerName(startingWith: "View")
 
-        let newLayer = CSLayer(name: name, type: "View", parameters: [
+        let newLayer = CSLayer(name: name, type: .view, parameters: [
             "width": 100.toData(),
             "height": 100.toData(),
             "backgroundColor": "#D8D8D8".toData()
@@ -184,7 +184,7 @@ class ViewController: NSViewController, NSOutlineViewDataSource, NSOutlineViewDe
     @IBAction func addText(_ sender: AnyObject) {
         let name = component.getNewLayerName(startingWith: "Text")
 
-        let newLayer = CSLayer(name: name, type: "Text", parameters: [
+        let newLayer = CSLayer(name: name, type: .text, parameters: [
             "text": "Text goes here".toData(),
             "widthSizingRule": "Shrink".toData(),
             "heightSizingRule": "Shrink".toData()
@@ -330,7 +330,7 @@ class ViewController: NSViewController, NSOutlineViewDataSource, NSOutlineViewDe
             Canvas(visible: true, name: "iPhone 7", width: 375, height: 100, heightMode: "At Least", exportScale: 1, backgroundColor: "white"),
             Canvas(visible: true, name: "iPhone 7+", width: 414, height: 100, heightMode: "At Least", exportScale: 1, backgroundColor: "white")
         ],
-        rootLayer: CSLayer(name: "View", type: "View", parameters: [
+        rootLayer: CSLayer(name: "View", type: .view, parameters: [
             "alignSelf": "stretch".toData()
         ]),
         parameters: [],
@@ -585,7 +585,7 @@ class ViewController: NSViewController, NSOutlineViewDataSource, NSOutlineViewDe
         guard let layer = item as? CSLayer else { return }
 
         let inspectorView: NSView
-        if layer.type == "Component", let layer = layer as? CSComponentLayer {
+        if case CSLayer.LayerType.custom = layer.type, let layer = layer as? CSComponentLayer {
             let componentInspectorView = ComponentInspectorView(componentLayer: layer)
             componentInspectorView.onChangeData = {[unowned self] (data, parameter) in
                 layer.parameters[parameter.name] = data

--- a/compiler/core/src/core/decode.bs.js
+++ b/compiler/core/src/core/decode.bs.js
@@ -255,22 +255,20 @@ function parameter(json) {
 var Parameters = /* module */[/* parameter */parameter];
 
 function layerType(json) {
-  var match = Json_decode.string(json);
-  switch (match) {
-    case "Animation" : 
+  var value = Json_decode.string(json);
+  switch (value) {
+    case "Lona:Animation" : 
         return /* Animation */3;
-    case "Children" : 
+    case "Lona:Children" : 
         return /* Children */4;
-    case "Component" : 
-        return /* Component */5;
-    case "Image" : 
+    case "Lona:Image" : 
         return /* Image */2;
-    case "Text" : 
+    case "Lona:Text" : 
         return /* Text */1;
-    case "View" : 
+    case "Lona:View" : 
         return /* View */0;
     default:
-      return /* Unknown */6;
+      return /* Component */[value];
   }
 }
 

--- a/compiler/core/src/core/decode.re
+++ b/compiler/core/src/core/decode.re
@@ -97,13 +97,12 @@ module Parameters = {
 module Layer = {
   let layerType = json =>
     switch (string(json)) {
-    | "View" => View
-    | "Text" => Text
-    | "Image" => Image
-    | "Animation" => Animation
-    | "Children" => Children
-    | "Component" => Component
-    | _ => Unknown
+    | "Lona:View" => View
+    | "Lona:Text" => Text
+    | "Lona:Image" => Image
+    | "Lona:Animation" => Animation
+    | "Lona:Children" => Children
+    | value => Component(value)
     };
   let rec layer = json => {
     let parameterDictionary = json =>

--- a/compiler/core/src/core/layer.bs.js
+++ b/compiler/core/src/core/layer.bs.js
@@ -554,22 +554,24 @@ function parameterMapToLogicValueMap(params) {
 }
 
 function layerTypeToString(x) {
-  switch (x) {
-    case 0 : 
-        return "View";
-    case 1 : 
-        return "Text";
-    case 2 : 
-        return "Image";
-    case 3 : 
-        return "Animation";
-    case 4 : 
-        return "Children";
-    case 5 : 
-        return "Component";
-    case 6 : 
-        return "Unknown";
-    
+  if (typeof x === "number") {
+    switch (x) {
+      case 0 : 
+          return "View";
+      case 1 : 
+          return "Text";
+      case 2 : 
+          return "Image";
+      case 3 : 
+          return "Animation";
+      case 4 : 
+          return "Children";
+      case 5 : 
+          return "Unknown";
+      
+    }
+  } else {
+    return x[0];
   }
 }
 

--- a/compiler/core/src/core/layer.re
+++ b/compiler/core/src/core/layer.re
@@ -232,7 +232,7 @@ let layerTypeToString = x =>
   | Image => "Image"
   | Animation => "Animation"
   | Children => "Children"
-  | Component => "Component"
+  | Component(value) => value
   | Unknown => "Unknown"
   };
 

--- a/compiler/core/src/core/types.re
+++ b/compiler/core/src/core/types.re
@@ -67,7 +67,7 @@ type layerType =
   | Image
   | Animation
   | Children
-  | Component
+  | Component(string)
   | Unknown;
 
 type layer = {

--- a/compiler/core/src/swift/swiftComponent.bs.js
+++ b/compiler/core/src/swift/swiftComponent.bs.js
@@ -71,21 +71,24 @@ function generate(_, swiftOptions, name, colors, textStyles, json) {
   var getLayerTypeName = function (layerType) {
     var match = swiftOptions[/* framework */0];
     if (match !== 0) {
-      switch (layerType) {
-        case 0 : 
-            return "NSBox";
-        case 1 : 
-            return "NSTextField";
-        case 2 : 
-            return "NSImageView";
-        case 3 : 
-        case 4 : 
-        case 5 : 
-        case 6 : 
-            return "TypeUnknown";
-        
+      if (typeof layerType === "number") {
+        switch (layerType) {
+          case 0 : 
+              return "NSBox";
+          case 1 : 
+              return "NSTextField";
+          case 2 : 
+              return "NSImageView";
+          case 3 : 
+          case 4 : 
+          case 5 : 
+              return "TypeUnknown";
+          
+        }
+      } else {
+        return "TypeUnknown";
       }
-    } else {
+    } else if (typeof layerType === "number") {
       switch (layerType) {
         case 0 : 
             return "UIView";
@@ -96,49 +99,64 @@ function generate(_, swiftOptions, name, colors, textStyles, json) {
         case 3 : 
         case 4 : 
         case 5 : 
-        case 6 : 
             return "TypeUnknown";
         
       }
+    } else {
+      return "TypeUnknown";
     }
   };
   var getLayerInitCall = function (layerType) {
     var typeName = /* SwiftIdentifier */Block.__(8, [getLayerTypeName(layerType)]);
     var match = swiftOptions[/* framework */0];
     if (match !== 0) {
-      if (layerType !== 1) {
-        return /* FunctionCallExpression */Block.__(19, [{
-                    name: typeName,
-                    arguments: /* [] */0
-                  }]);
+      if (typeof layerType === "number") {
+        if (layerType !== 1) {
+          return /* FunctionCallExpression */Block.__(19, [{
+                      name: typeName,
+                      arguments: /* [] */0
+                    }]);
+        } else {
+          return /* FunctionCallExpression */Block.__(19, [{
+                      name: typeName,
+                      arguments: /* :: */[
+                        /* FunctionCallArgument */Block.__(18, [{
+                              name: /* Some */[/* SwiftIdentifier */Block.__(8, ["labelWithString"])],
+                              value: /* LiteralExpression */Block.__(0, [/* String */Block.__(3, [""])])
+                            }]),
+                        /* [] */0
+                      ]
+                    }]);
+        }
       } else {
         return /* FunctionCallExpression */Block.__(19, [{
                     name: typeName,
-                    arguments: /* :: */[
-                      /* FunctionCallArgument */Block.__(18, [{
-                            name: /* Some */[/* SwiftIdentifier */Block.__(8, ["labelWithString"])],
-                            value: /* LiteralExpression */Block.__(0, [/* String */Block.__(3, [""])])
-                          }]),
-                      /* [] */0
-                    ]
+                    arguments: /* [] */0
                   }]);
       }
-    } else if (layerType !== 1) {
-      if (layerType >= 3) {
-        return /* FunctionCallExpression */Block.__(19, [{
-                    name: typeName,
-                    arguments: /* [] */0
-                  }]);
+    } else if (typeof layerType === "number") {
+      if (layerType !== 1) {
+        if (layerType >= 3) {
+          return /* FunctionCallExpression */Block.__(19, [{
+                      name: typeName,
+                      arguments: /* [] */0
+                    }]);
+        } else {
+          return /* FunctionCallExpression */Block.__(19, [{
+                      name: typeName,
+                      arguments: /* :: */[
+                        /* FunctionCallArgument */Block.__(18, [{
+                              name: /* Some */[/* SwiftIdentifier */Block.__(8, ["frame"])],
+                              value: /* SwiftIdentifier */Block.__(8, [".zero"])
+                            }]),
+                        /* [] */0
+                      ]
+                    }]);
+        }
       } else {
         return /* FunctionCallExpression */Block.__(19, [{
                     name: typeName,
-                    arguments: /* :: */[
-                      /* FunctionCallArgument */Block.__(18, [{
-                            name: /* Some */[/* SwiftIdentifier */Block.__(8, ["frame"])],
-                            value: /* SwiftIdentifier */Block.__(8, [".zero"])
-                          }]),
-                      /* [] */0
-                    ]
+                    arguments: /* [] */0
                   }]);
       }
     } else {
@@ -520,54 +538,58 @@ function generate(_, swiftOptions, name, colors, textStyles, json) {
     };
     var resetViewStyling = function (layer) {
       var match = layer[/* typeName */0];
-      if (match !== 1) {
-        if (match !== 0) {
-          return /* [] */0;
-        } else {
-          return /* :: */[
-                  /* BinaryExpression */Block.__(2, [{
-                        left: memberOrSelfExpression(parentNameOrSelf(layer), /* :: */[
-                              /* SwiftIdentifier */Block.__(8, ["boxType"]),
-                              /* [] */0
-                            ]),
-                        operator: "=",
-                        right: /* SwiftIdentifier */Block.__(8, [".custom"])
-                      }]),
-                  /* :: */[
+      if (typeof match === "number") {
+        if (match !== 1) {
+          if (match !== 0) {
+            return /* [] */0;
+          } else {
+            return /* :: */[
                     /* BinaryExpression */Block.__(2, [{
                           left: memberOrSelfExpression(parentNameOrSelf(layer), /* :: */[
-                                /* SwiftIdentifier */Block.__(8, ["borderType"]),
+                                /* SwiftIdentifier */Block.__(8, ["boxType"]),
                                 /* [] */0
                               ]),
                           operator: "=",
-                          right: /* SwiftIdentifier */Block.__(8, [".noBorder"])
+                          right: /* SwiftIdentifier */Block.__(8, [".custom"])
                         }]),
                     /* :: */[
                       /* BinaryExpression */Block.__(2, [{
                             left: memberOrSelfExpression(parentNameOrSelf(layer), /* :: */[
-                                  /* SwiftIdentifier */Block.__(8, ["contentViewMargins"]),
+                                  /* SwiftIdentifier */Block.__(8, ["borderType"]),
                                   /* [] */0
                                 ]),
                             operator: "=",
-                            right: /* SwiftIdentifier */Block.__(8, [".zero"])
+                            right: /* SwiftIdentifier */Block.__(8, [".noBorder"])
                           }]),
-                      /* [] */0
+                      /* :: */[
+                        /* BinaryExpression */Block.__(2, [{
+                              left: memberOrSelfExpression(parentNameOrSelf(layer), /* :: */[
+                                    /* SwiftIdentifier */Block.__(8, ["contentViewMargins"]),
+                                    /* [] */0
+                                  ]),
+                              operator: "=",
+                              right: /* SwiftIdentifier */Block.__(8, [".zero"])
+                            }]),
+                        /* [] */0
+                      ]
                     ]
-                  ]
+                  ];
+          }
+        } else {
+          return /* :: */[
+                  /* BinaryExpression */Block.__(2, [{
+                        left: memberOrSelfExpression(parentNameOrSelf(layer), /* :: */[
+                              /* SwiftIdentifier */Block.__(8, ["lineBreakMode"]),
+                              /* [] */0
+                            ]),
+                        operator: "=",
+                        right: /* SwiftIdentifier */Block.__(8, [".byWordWrapping"])
+                      }]),
+                  /* [] */0
                 ];
         }
       } else {
-        return /* :: */[
-                /* BinaryExpression */Block.__(2, [{
-                      left: memberOrSelfExpression(parentNameOrSelf(layer), /* :: */[
-                            /* SwiftIdentifier */Block.__(8, ["lineBreakMode"]),
-                            /* [] */0
-                          ]),
-                      operator: "=",
-                      right: /* SwiftIdentifier */Block.__(8, [".byWordWrapping"])
-                    }]),
-                /* [] */0
-              ];
+        return /* [] */0;
       }
     };
     var addSubviews = function (parent, layer) {

--- a/examples/material-design/components/Card.component
+++ b/examples/material-design/components/Card.component
@@ -217,7 +217,7 @@
           "backgroundColor" : "#D8D8D8",
           "image" : ""
         },
-        "type" : "Image"
+        "type" : "Lona:Image"
       },
       {
         "children" : [
@@ -227,7 +227,7 @@
               "font" : "headline",
               "text" : "Headline"
             },
-            "type" : "Text"
+            "type" : "Lona:Text"
           },
           {
             "id" : "Body",
@@ -237,7 +237,7 @@
               "text" : "Body",
               "visible" : false
             },
-            "type" : "Text"
+            "type" : "Lona:Text"
           }
         ],
         "id" : "Description",
@@ -248,13 +248,13 @@
           "paddingRight" : 16,
           "paddingTop" : 20
         },
-        "type" : "View"
+        "type" : "Lona:View"
       }
     ],
     "id" : "View",
     "parameters" : {
       "alignSelf" : "stretch"
     },
-    "type" : "View"
+    "type" : "Lona:View"
   }
 }

--- a/examples/material-design/components/ListItem.component
+++ b/examples/material-design/components/ListItem.component
@@ -140,7 +140,7 @@
           "marginTop" : 4,
           "width" : 44
         },
-        "type" : "Image"
+        "type" : "Lona:Image"
       },
       {
         "children" : [
@@ -150,7 +150,7 @@
               "font" : "subheading1",
               "text" : "Two-line item"
             },
-            "type" : "Text"
+            "type" : "Lona:Text"
           },
           {
             "id" : "Secondary Text",
@@ -158,7 +158,7 @@
               "font" : "body1",
               "text" : "Secondary text"
             },
-            "type" : "Text"
+            "type" : "Lona:Text"
           }
         ],
         "id" : "View 1",
@@ -166,7 +166,7 @@
           "flex" : 1,
           "marginLeft" : 16
         },
-        "type" : "View"
+        "type" : "Lona:View"
       }
     ],
     "id" : "View",
@@ -178,6 +178,6 @@
       "paddingRight" : 16,
       "paddingTop" : 16
     },
-    "type" : "View"
+    "type" : "Lona:View"
   }
 }

--- a/examples/material-design/screens/Team.component
+++ b/examples/material-design/screens/Team.component
@@ -44,8 +44,7 @@
           "headline" : "The Lona Team",
           "image" : "https:\/\/picsum.photos\/600\/600?image=202"
         },
-        "type" : "Component",
-        "url" : ".\/components\/Card.component"
+        "type" : "Card"
       },
       {
         "id" : "ListItem1",
@@ -54,8 +53,7 @@
           "primaryText" : "Devin Abbott",
           "secondaryText" : "Software Engineer @ Airbnb"
         },
-        "type" : "Component",
-        "url" : ".\/components\/ListItem.component"
+        "type" : "ListItem"
       },
       {
         "id" : "ListItem2",
@@ -64,8 +62,7 @@
           "primaryText" : "Ryan Gonzalez",
           "secondaryText" : "Design Technologist @ DoorDash"
         },
-        "type" : "Component",
-        "url" : ".\/components\/ListItem.component"
+        "type" : "ListItem"
       },
       {
         "id" : "ListItem3",
@@ -74,14 +71,13 @@
           "primaryText" : "Pablo Caro",
           "secondaryText" : "Design Systems Lead Designer @ Airbnb"
         },
-        "type" : "Component",
-        "url" : ".\/components\/ListItem.component"
+        "type" : "ListItem"
       }
     ],
     "id" : "View",
     "parameters" : {
       "alignSelf" : "stretch"
     },
-    "type" : "View"
+    "type" : "Lona:View"
   }
 }

--- a/examples/test/images/LocalAsset.component
+++ b/examples/test/images/LocalAsset.component
@@ -45,13 +45,13 @@
           "image" : "file:\/\/.\/assets\/icon_128x128.png",
           "width" : 100
         },
-        "type" : "Image"
+        "type" : "Lona:Image"
       }
     ],
     "id" : "View",
     "parameters" : {
       "alignSelf" : "stretch"
     },
-    "type" : "View"
+    "type" : "Lona:View"
   }
 }

--- a/examples/test/interactivity/PressableRootView.component
+++ b/examples/test/interactivity/PressableRootView.component
@@ -498,7 +498,7 @@
               "font" : "headline",
               "text" : ""
             },
-            "type" : "Text"
+            "type" : "Lona:Text"
           }
         ],
         "id" : "Inner",
@@ -507,7 +507,7 @@
           "height" : 100,
           "width" : 100
         },
-        "type" : "View"
+        "type" : "Lona:View"
       }
     ],
     "id" : "Outer",
@@ -519,6 +519,6 @@
       "paddingRight" : 24,
       "paddingTop" : 24
     },
-    "type" : "View"
+    "type" : "Lona:View"
   }
 }

--- a/examples/test/layouts/FitContentParentSecondaryChildren.component
+++ b/examples/test/layouts/FitContentParentSecondaryChildren.component
@@ -44,7 +44,7 @@
           "height" : 60,
           "width" : 60
         },
-        "type" : "View"
+        "type" : "Lona:View"
       },
       {
         "id" : "View 3",
@@ -53,7 +53,7 @@
           "height" : 120,
           "width" : 100
         },
-        "type" : "View"
+        "type" : "Lona:View"
       },
       {
         "id" : "View 2",
@@ -62,7 +62,7 @@
           "height" : 180,
           "width" : 100
         },
-        "type" : "View"
+        "type" : "Lona:View"
       }
     ],
     "id" : "Container",
@@ -75,6 +75,6 @@
       "paddingRight" : 24,
       "paddingTop" : 24
     },
-    "type" : "View"
+    "type" : "Lona:View"
   }
 }

--- a/examples/test/layouts/FixedParentFillAndFitChildren.component
+++ b/examples/test/layouts/FixedParentFillAndFitChildren.component
@@ -46,7 +46,7 @@
               "height" : 100,
               "width" : 60
             },
-            "type" : "View"
+            "type" : "Lona:View"
           },
           {
             "id" : "View 5",
@@ -56,7 +56,7 @@
               "marginLeft" : 12,
               "width" : 60
             },
-            "type" : "View"
+            "type" : "Lona:View"
           }
         ],
         "id" : "View 1",
@@ -69,7 +69,7 @@
           "paddingRight" : 24,
           "paddingTop" : 24
         },
-        "type" : "View"
+        "type" : "Lona:View"
       },
       {
         "id" : "View 2",
@@ -78,7 +78,7 @@
           "backgroundColor" : "indigo100",
           "flex" : 1
         },
-        "type" : "View"
+        "type" : "Lona:View"
       },
       {
         "id" : "View 3",
@@ -87,7 +87,7 @@
           "backgroundColor" : "teal100",
           "flex" : 1
         },
-        "type" : "View"
+        "type" : "Lona:View"
       }
     ],
     "id" : "View",
@@ -99,6 +99,6 @@
       "paddingRight" : 24,
       "paddingTop" : 24
     },
-    "type" : "View"
+    "type" : "Lona:View"
   }
 }

--- a/examples/test/layouts/FixedParentFitChild.component
+++ b/examples/test/layouts/FixedParentFitChild.component
@@ -46,7 +46,7 @@
               "height" : 100,
               "width" : 60
             },
-            "type" : "View"
+            "type" : "Lona:View"
           },
           {
             "id" : "View 5",
@@ -56,7 +56,7 @@
               "marginLeft" : 12,
               "width" : 60
             },
-            "type" : "View"
+            "type" : "Lona:View"
           }
         ],
         "id" : "View 1",
@@ -69,7 +69,7 @@
           "paddingRight" : 24,
           "paddingTop" : 24
         },
-        "type" : "View"
+        "type" : "Lona:View"
       }
     ],
     "id" : "View",
@@ -82,6 +82,6 @@
       "paddingRight" : 24,
       "paddingTop" : 24
     },
-    "type" : "View"
+    "type" : "Lona:View"
   }
 }

--- a/examples/test/layouts/PrimaryAxis.component
+++ b/examples/test/layouts/PrimaryAxis.component
@@ -45,7 +45,7 @@
           "marginBottom" : 24,
           "width" : 100
         },
-        "type" : "View"
+        "type" : "Lona:View"
       },
       {
         "children" : [
@@ -54,7 +54,7 @@
             "parameters" : {
               "text" : "Text goes here"
             },
-            "type" : "Text"
+            "type" : "Lona:Text"
           }
         ],
         "id" : "Fit",
@@ -63,7 +63,7 @@
           "marginBottom" : 24,
           "width" : 100
         },
-        "type" : "View"
+        "type" : "Lona:View"
       },
       {
         "id" : "Fill1",
@@ -72,7 +72,7 @@
           "flex" : 1,
           "width" : 100
         },
-        "type" : "View"
+        "type" : "Lona:View"
       },
       {
         "id" : "Fill2",
@@ -81,7 +81,7 @@
           "flex" : 1,
           "width" : 100
         },
-        "type" : "View"
+        "type" : "Lona:View"
       }
     ],
     "id" : "View",
@@ -93,6 +93,6 @@
       "paddingRight" : 24,
       "paddingTop" : 24
     },
-    "type" : "View"
+    "type" : "Lona:View"
   }
 }

--- a/examples/test/layouts/SecondaryAxis.component
+++ b/examples/test/layouts/SecondaryAxis.component
@@ -45,7 +45,7 @@
           "marginBottom" : 24,
           "width" : 100
         },
-        "type" : "View"
+        "type" : "Lona:View"
       },
       {
         "children" : [
@@ -54,7 +54,7 @@
             "parameters" : {
               "text" : "Text goes here"
             },
-            "type" : "Text"
+            "type" : "Lona:Text"
           }
         ],
         "id" : "Fit",
@@ -67,7 +67,7 @@
           "paddingRight" : 12,
           "paddingTop" : 12
         },
-        "type" : "View"
+        "type" : "Lona:View"
       },
       {
         "id" : "Fill",
@@ -76,7 +76,7 @@
           "backgroundColor" : "#D8D8D8",
           "height" : 100
         },
-        "type" : "View"
+        "type" : "Lona:View"
       }
     ],
     "id" : "Container",
@@ -87,6 +87,6 @@
       "paddingRight" : 24,
       "paddingTop" : 24
     },
-    "type" : "View"
+    "type" : "Lona:View"
   }
 }

--- a/examples/test/logic/Assign.component
+++ b/examples/test/logic/Assign.component
@@ -72,13 +72,13 @@
         "parameters" : {
           "text" : "Text goes here"
         },
-        "type" : "Text"
+        "type" : "Lona:Text"
       }
     ],
     "id" : "View",
     "parameters" : {
       "alignSelf" : "stretch"
     },
-    "type" : "View"
+    "type" : "Lona:View"
   }
 }

--- a/examples/test/logic/If.component
+++ b/examples/test/logic/If.component
@@ -108,6 +108,6 @@
     "parameters" : {
       "alignSelf" : "stretch"
     },
-    "type" : "View"
+    "type" : "Lona:View"
   }
 }

--- a/examples/test/style/TextStyleConditional.component
+++ b/examples/test/style/TextStyleConditional.component
@@ -115,13 +115,13 @@
           "font" : "headline",
           "text" : "Text goes here"
         },
-        "type" : "Text"
+        "type" : "Lona:Text"
       }
     ],
     "id" : "View",
     "parameters" : {
       "alignSelf" : "stretch"
     },
-    "type" : "View"
+    "type" : "Lona:View"
   }
 }

--- a/examples/test/style/TextStylesTest.component
+++ b/examples/test/style/TextStylesTest.component
@@ -43,7 +43,7 @@
           "font" : "display4",
           "text" : "Text goes here"
         },
-        "type" : "Text"
+        "type" : "Lona:Text"
       },
       {
         "id" : "Text 1",
@@ -51,7 +51,7 @@
           "font" : "display3",
           "text" : "Text goes here"
         },
-        "type" : "Text"
+        "type" : "Lona:Text"
       },
       {
         "id" : "Text 2",
@@ -59,7 +59,7 @@
           "font" : "display2",
           "text" : "Text goes here"
         },
-        "type" : "Text"
+        "type" : "Lona:Text"
       },
       {
         "id" : "Text 3",
@@ -67,7 +67,7 @@
           "font" : "display1",
           "text" : "Text goes here"
         },
-        "type" : "Text"
+        "type" : "Lona:Text"
       },
       {
         "id" : "Text 4",
@@ -75,7 +75,7 @@
           "font" : "headline",
           "text" : "Text goes here"
         },
-        "type" : "Text"
+        "type" : "Lona:Text"
       },
       {
         "id" : "Text 5",
@@ -83,7 +83,7 @@
           "font" : "subheading2",
           "text" : "Text goes here"
         },
-        "type" : "Text"
+        "type" : "Lona:Text"
       },
       {
         "id" : "Text 6",
@@ -91,7 +91,7 @@
           "font" : "subheading1",
           "text" : "Text goes here"
         },
-        "type" : "Text"
+        "type" : "Lona:Text"
       },
       {
         "id" : "Text 7",
@@ -99,7 +99,7 @@
           "font" : "body2",
           "text" : "Text goes here"
         },
-        "type" : "Text"
+        "type" : "Lona:Text"
       },
       {
         "id" : "Text 8",
@@ -107,7 +107,7 @@
           "font" : "body1",
           "text" : "Text goes here"
         },
-        "type" : "Text"
+        "type" : "Lona:Text"
       },
       {
         "id" : "Text 9",
@@ -115,13 +115,13 @@
           "font" : "caption",
           "text" : "Text goes here"
         },
-        "type" : "Text"
+        "type" : "Lona:Text"
       }
     ],
     "id" : "View",
     "parameters" : {
       "alignSelf" : "stretch"
     },
-    "type" : "View"
+    "type" : "Lona:View"
   }
 }


### PR DESCRIPTION
## What

Custom components are found in the workspace directory by name. We don't allow two components with the same name in the same "module" (although there's no way to create another module at the moment).

Previously, custom components were included via URL. There was a separate `type` and `url` field in the save file. These have been combined into `type`. Built-in types are namespaced with `Lona:`, e.g. `Lona:View`.

## Why

Simpler, smaller format that doesn't break when files are moved around.

## Testing Plan

- [X] Tested this change locally
- [X] Checked that existing features work