### PR TITLE
Components no longer need force-unwrapping

### DIFF
--- a/LonaStudio/Models/CSComponentLayer.swift
+++ b/LonaStudio/Models/CSComponentLayer.swift
@@ -9,12 +9,13 @@
 import Foundation
 
 class CSComponentLayer: CSLayer {
-    var component: CSComponent!
+    var component: CSComponent
     var failedToLoad: Bool = false
 
     func reload() {
-        if case CSLayer.LayerType.custom(let name) = type {
-            self.component = LonaModule.current.component(named: name)
+        if case CSLayer.LayerType.custom(let name) = type,
+            let component = LonaModule.current.component(named: name) {
+            self.component = component
         } else {
             self.component = CSComponentLayer.defaultComponent
             failedToLoad = true
@@ -47,8 +48,9 @@ class CSComponentLayer: CSLayer {
     }
 
     required init(_ json: CSData) {
-        if case CSLayer.LayerType.custom(let name) = LayerType(json.get(key: "type")) {
-            self.component = LonaModule.current.component(named: name)
+        if case CSLayer.LayerType.custom(let name) = LayerType(json.get(key: "type")),
+            let component = LonaModule.current.component(named: name) {
+            self.component = component
         } else {
             self.component = CSComponentLayer.defaultComponent
             failedToLoad = true
@@ -58,9 +60,15 @@ class CSComponentLayer: CSLayer {
     }
 
     override init(name: String, type: LayerType, parameters: [String: CSData] = [:], children: [CSLayer] = []) {
-        super.init(name: name, type: type, parameters: parameters, children: children)
+        if case CSLayer.LayerType.custom(let name) = type,
+            let component = LonaModule.current.component(named: name) {
+            self.component = component
+        } else {
+            self.component = CSComponentLayer.defaultComponent
+            failedToLoad = true
+        }
 
-        reload()
+        super.init(name: name, type: type, parameters: parameters, children: children)
     }
 
     override func encode(parameters: [String: CSData]) -> [String: CSData] {

--- a/LonaStudio/Models/CSLayer.swift
+++ b/LonaStudio/Models/CSLayer.swift
@@ -599,8 +599,7 @@ class CSLayer: CSDataDeserializable, CSDataSerializable, DataNode, NSCopying {
 
     func attributesNames(for type: CSType) -> [String] {
         if let _self = self as? CSComponentLayer {
-            let component = _self.component!
-            return component.parameters.filter({ $0.type == type }).map({ $0.name })
+            return _self.component.parameters.filter({ $0.type == type }).map({ $0.name })
         }
 
         switch type {
@@ -660,7 +659,7 @@ class CSLayer: CSDataDeserializable, CSDataSerializable, DataNode, NSCopying {
             if let componentLayer = layer as? CSComponentLayer {
                 let originalLayer = layer
                 let originalName = layer.name
-                let component = componentLayer.component!
+                let component = componentLayer.component
                 layer = component.rootLayer
 
                 if shouldAssignConfig {

--- a/LonaStudio/Workspace/LayerList.swift
+++ b/LonaStudio/Workspace/LayerList.swift
@@ -317,7 +317,7 @@ extension LayerList {
 
         NSDocumentController.shared.openDocument(
             withContentsOf: url, display: true, completionHandler: { (document, _, _) in
-            layer.component = (document as! Document).file
+            layer.component = (document as! Document).file!
             layer.name = self.componentName(for: url)
             layer.type = CSLayer.LayerType.custom(url.deletingPathExtension().lastPathComponent)
             self.onChange()


### PR DESCRIPTION
## What

Components were force-unwrapped, since I wrote this back when I didn't know Swift

## Why

Reduce crashes

## Testing Plan

- [X] Tested this change locally
- [X] Checked that existing features work