### PR TITLE
Store custom variant types in compact format

### DIFF
--- a/LonaStudio/Models/CSType.swift
+++ b/LonaStudio/Models/CSType.swift
@@ -101,6 +101,10 @@ indirect enum CSType: Equatable, CSDataSerializable, CSDataDeserializable {
                     var parameters: [(String, CSType)] = []
                     if let values = object["cases"]?.array {
                         parameters = values.map({ (arg) in
+                            if let tag = arg.string {
+                                return (tag, CSType.unit)
+                            }
+
                             return (arg.get(key: "tag").stringValue, CSType(arg.get(key: "type")))
                         })
                     }
@@ -250,6 +254,10 @@ indirect enum CSType: Equatable, CSDataSerializable, CSDataDeserializable {
             if cases.count > 0 {
                 data["cases"] = CSData.Array(cases.map({ (arg) -> CSData in
                     let (tag, innerType) = arg
+
+                    if innerType == CSType.unit {
+                        return tag.toData()
+                    }
 
                     return CSData.Object([
                         "tag": tag.toData(),


### PR DESCRIPTION
## What

Custom variant cases with `type` of `Unit` are now stored as plain strings

## Why

Save space

## Testing Plan

- [X] Tested this change locally
- [X] Checked that existing features work