### PR TITLE
Rename "cases" to "examples"

### DIFF
--- a/LonaStudio/Models/CSComponent.swift
+++ b/LonaStudio/Models/CSComponent.swift
@@ -175,12 +175,14 @@ class CSComponent: DataNode, NSCopying {
     }
 
     func toData() -> CSData? {
+        let parametersType = CSParameter.csType(from: parameters)
+
         var data = CSData.Object([
             "parameters": CSData.Array(parameters.map({ $0.toData() })),
             "rootLayer": rootLayer.toData(),
             "logic": logic.toData(),
             "canvases": canvas.toData(),
-            "cases": cases.toData()
+            "examples": CSData.Array(cases.map({ $0.toData(parametersType: parametersType) }))
         ])
 
         var config = self.config
@@ -206,7 +208,9 @@ class CSComponent: DataNode, NSCopying {
         canvas = json.get(key: "canvases").arrayValue.map({ Canvas($0) })
         config = json["config"] ?? CSData.Object([:])
         metadata = json["metadata"] ?? CSData.Object([:])
-        cases = json.get(key: "cases").arrayValue.map({ CSCase($0) })
+
+        let parametersType = CSParameter.csType(from: parameters)
+        cases = (json["examples"] ?? json.get(key: "cases")).arrayValue.map({ CSCase($0, parametersType: parametersType) })
     }
 
     convenience init?(url: URL) {

--- a/LonaStudio/Models/CSComponentLayer.swift
+++ b/LonaStudio/Models/CSComponentLayer.swift
@@ -25,15 +25,11 @@ class CSComponentLayer: CSLayer {
     override func value() -> CSValue {
         if failedToLoad { return CSUndefinedValue }
 
-        let parametersSchema: CSType.Schema = component.parameters.key {(parameter) -> (key: String, value: (CSType, CSAccess)) in
-            return (key: parameter.name, value: (parameter.type, .write))
-        }
-
         let parametersMap: [String: CSData] = component.parameters.key {(parameter) -> (key: String, value: CSData) in
             return (key: parameter.name, value: parameters[parameter.name] ?? CSData.Null)
         }
 
-        return CSValue(type: CSType.dictionary(parametersSchema), data: CSData.Object(parametersMap))
+        return CSValue(type: CSParameter.csType(from: component.parameters), data: CSData.Object(parametersMap))
     }
 
     private static var defaultComponent: CSComponent {

--- a/LonaStudio/Models/CSParameter.swift
+++ b/LonaStudio/Models/CSParameter.swift
@@ -53,3 +53,13 @@ final class CSParameter: CSDataDeserializable, CSDataSerializable, DataNode {
     func childCount() -> Int { return 0 }
     func child(at index: Int) -> Any { return 0 }
 }
+
+extension CSParameter {
+    static func csType(from parameters: [CSParameter]) -> CSType {
+        let parametersSchema: CSType.Schema = parameters.key {(parameter) -> (key: String, value: (CSType, CSAccess)) in
+            return (key: parameter.name, value: (parameter.type, .write))
+        }
+
+        return CSType.dictionary(parametersSchema)
+    }
+}

--- a/LonaStudio/Models/CSValue.swift
+++ b/LonaStudio/Models/CSValue.swift
@@ -38,7 +38,10 @@ struct CSValue: Equatable, CSDataSerializable, CSDataDeserializable {
             var copy = data
             schema.forEach({ arg in
                 let (key, value) = arg
-                copy[key] = CSValue.compact(type: value.type, data: data.get(key: key))
+
+                if data[key] != nil {
+                    copy[key] = CSValue.compact(type: value.type, data: data.get(key: key))
+                }
             })
             return copy
         default:
@@ -70,7 +73,10 @@ struct CSValue: Equatable, CSDataSerializable, CSDataDeserializable {
             var copy = data
             schema.forEach({ arg in
                 let (key, value) = arg
-                copy[key] = CSValue.expand(type: value.type, data: data.get(key: key))
+
+                if data[key] != nil {
+                    copy[key] = CSValue.expand(type: value.type, data: data.get(key: key))
+                }
             })
             return copy
         default:

--- a/LonaStudio/Workspace/ViewController.swift
+++ b/LonaStudio/Workspace/ViewController.swift
@@ -415,7 +415,7 @@ class ViewController: NSViewController, NSOutlineViewDataSource, NSOutlineViewDe
 
         // Splitter setup
 
-        let tabs = SegmentedControlField(frame: NSRect(x: 0, y: 0, width: 500, height: 24), values: ["Details", "Canvases", "Parameters", "Logic", "Cases"])
+        let tabs = SegmentedControlField(frame: NSRect(x: 0, y: 0, width: 500, height: 24), values: ["Details", "Canvases", "Parameters", "Logic", "Examples"])
         tabs.segmentWidth = 97
         tabs.useYogaLayout = true
         tabs.segmentStyle = .roundRect
@@ -489,7 +489,7 @@ class ViewController: NSViewController, NSOutlineViewDataSource, NSOutlineViewDe
             "Details": metadataEditorView,
             "Canvases": canvasListView,
             "Parameters": parameterListEditorView,
-            "Cases": caseList.editor,
+            "Examples": caseList.editor,
             "Logic": logicListView.editor
         ]
 

--- a/docs/file-formats/component.md
+++ b/docs/file-formats/component.md
@@ -14,7 +14,7 @@ The file is an object containing top-level fields:
 
 - [**`metadata`**](#metadata)
 - [**`canvases`**](#canvases)
-- [**`cases`**](#cases)
+- [**`examples`**](#examples)
 - [**`parameters`**](#parameters)
 - [**`rootLayer`**](#rootLayer)
 - [**`logic`**](#logic)
@@ -78,31 +78,29 @@ The various canvases sizes to render a component within Lona Studio. These do no
 // ...
 ```
 
-## Cases
+## Examples
 
-These are the _use cases_ or _test cases_ for a component. These do not currently generate any code, although conceptually they could be useful for generating automated tests. This is an array of objects, where each object has the following fields:
+These are the _examples_ or _test cases_ for a component. These do not currently generate any code, although conceptually they could be useful for generating automated tests. This is an array of objects, where each object has the following fields:
 
 |Attribute|Type|Required|Description|
 |---|---|---|---|
-|`name`|`string`|Yes|The human-readable name of the test case.|
-|`type`|`'entry' or 'importedList'`|Yes|Is this an individual case defined explicitly, or a list of cases imported from JSON?|
-|`visible`|`boolean`|Yes|This determines whether or not to draw this particular test case on the screen.|
-|`parameters`|`JSON`|No|This contains optional parameter values for use within [`Logic`](#logic). This will only be defined for cases with a `type` of `entry`.|
-|`url`|`URL`|No|The URL of a list of cases defined in JSON. This will only be defined for cases with a `type` of `importedList`.|
+|`name`|`string`|Yes|The human-readable name of the example.|
+|`type`|`'entry' or 'importedList'`|No|Is this an individual case defined explicitly, or a list of examples imported from JSON? Defaults to `entry`.|
+|`visible`|`boolean`|No|This determines whether or not to draw this particular test case on the screen. Defaults to `true`.|
+|`params`|`JSON`|No|This contains optional parameter values for use within [`Logic`](#logic). This will only be defined for examples with a `type` of `entry`.|
+|`url`|`URL`|No|The URL of a list of examples defined in JSON. This will only be defined for examples with a `type` of `importedList`.|
 
 ### Sample
 
 ```json
 // ...
 
-"cases": [
+"examples": [
   {
     "name" : "Default case",
-    "value" : {
+    "params" : {
       "title" : "Header sample text"
-    },
-    "type" : "entry",
-    "visible" : true
+    }
   }
 ]
 

--- a/examples/material-design/components/Card.component
+++ b/examples/material-design/components/Card.component
@@ -19,28 +19,21 @@
       "width" : 414
     }
   ],
-  "cases" : [
+  "examples" : [
     {
       "name" : "Headline only",
-      "type" : "entry",
-      "value" : {
+      "params" : {
         "headline" : "Headline Only",
         "image" : "https:\/\/picsum.photos\/600\/600?image=20"
-      },
-      "visible" : true
+      }
     },
     {
       "name" : "All content",
-      "type" : "entry",
-      "value" : {
-        "body" : {
-          "data" : "Located two hours south of Sydney in the Souther Highlands of New South Wales, this destination is truly one you won't want to miss.",
-          "tag" : "Some"
-        },
+      "params" : {
+        "body" : "Located two hours south of Sydney in the Souther Highlands of New South Wales, this destination is truly one you won't want to miss.",
         "headline" : "Kangaroo Valley Safari",
         "image" : "https:\/\/picsum.photos\/600\/600?image=10"
-      },
-      "visible" : true
+      }
     }
   ],
   "logic" : [

--- a/examples/material-design/components/ListItem.component
+++ b/examples/material-design/components/ListItem.component
@@ -19,14 +19,12 @@
       "width" : 414
     }
   ],
-  "cases" : [
+  "examples" : [
     {
       "name" : "Default",
-      "type" : "entry",
-      "value" : {
+      "params" : {
 
-      },
-      "visible" : true
+      }
     }
   ],
   "logic" : [

--- a/examples/material-design/screens/Team.component
+++ b/examples/material-design/screens/Team.component
@@ -19,14 +19,12 @@
       "width" : 414
     }
   ],
-  "cases" : [
+  "examples" : [
     {
       "name" : "Default",
-      "type" : "entry",
-      "value" : {
+      "params" : {
 
-      },
-      "visible" : true
+      }
     }
   ],
   "logic" : [

--- a/examples/test/images/LocalAsset.component
+++ b/examples/test/images/LocalAsset.component
@@ -19,14 +19,12 @@
       "width" : 414
     }
   ],
-  "cases" : [
+  "examples" : [
     {
       "name" : "Default",
-      "type" : "entry",
-      "value" : {
+      "params" : {
 
-      },
-      "visible" : true
+      }
     }
   ],
   "logic" : [

--- a/examples/test/interactivity/PressableRootView.component
+++ b/examples/test/interactivity/PressableRootView.component
@@ -19,14 +19,12 @@
       "width" : 414
     }
   ],
-  "cases" : [
+  "examples" : [
     {
       "name" : "Default",
-      "type" : "entry",
-      "value" : {
+      "params" : {
 
-      },
-      "visible" : true
+      }
     }
   ],
   "logic" : [

--- a/examples/test/layouts/FitContentParentSecondaryChildren.component
+++ b/examples/test/layouts/FitContentParentSecondaryChildren.component
@@ -19,14 +19,12 @@
       "width" : 414
     }
   ],
-  "cases" : [
+  "examples" : [
     {
       "name" : "Default",
-      "type" : "entry",
-      "value" : {
+      "params" : {
 
-      },
-      "visible" : true
+      }
     }
   ],
   "logic" : [

--- a/examples/test/layouts/FixedParentFillAndFitChildren.component
+++ b/examples/test/layouts/FixedParentFillAndFitChildren.component
@@ -19,14 +19,12 @@
       "width" : 414
     }
   ],
-  "cases" : [
+  "examples" : [
     {
       "name" : "Default",
-      "type" : "entry",
-      "value" : {
+      "params" : {
 
-      },
-      "visible" : true
+      }
     }
   ],
   "logic" : [

--- a/examples/test/layouts/FixedParentFitChild.component
+++ b/examples/test/layouts/FixedParentFitChild.component
@@ -19,14 +19,12 @@
       "width" : 414
     }
   ],
-  "cases" : [
+  "examples" : [
     {
       "name" : "Default",
-      "type" : "entry",
-      "value" : {
+      "params" : {
 
-      },
-      "visible" : true
+      }
     }
   ],
   "logic" : [

--- a/examples/test/layouts/PrimaryAxis.component
+++ b/examples/test/layouts/PrimaryAxis.component
@@ -19,14 +19,12 @@
       "width" : 414
     }
   ],
-  "cases" : [
+  "examples" : [
     {
       "name" : "Default",
-      "type" : "entry",
-      "value" : {
+      "params" : {
 
-      },
-      "visible" : true
+      }
     }
   ],
   "logic" : [

--- a/examples/test/layouts/SecondaryAxis.component
+++ b/examples/test/layouts/SecondaryAxis.component
@@ -19,14 +19,12 @@
       "width" : 414
     }
   ],
-  "cases" : [
+  "examples" : [
     {
       "name" : "Default",
-      "type" : "entry",
-      "value" : {
+      "params" : {
 
-      },
-      "visible" : true
+      }
     }
   ],
   "logic" : [

--- a/examples/test/logic/Assign.component
+++ b/examples/test/logic/Assign.component
@@ -19,14 +19,12 @@
       "width" : 414
     }
   ],
-  "cases" : [
+  "examples" : [
     {
       "name" : "Default",
-      "type" : "entry",
-      "value" : {
+      "params" : {
 
-      },
-      "visible" : true
+      }
     }
   ],
   "logic" : [

--- a/examples/test/logic/If.component
+++ b/examples/test/logic/If.component
@@ -19,22 +19,18 @@
       "width" : 414
     }
   ],
-  "cases" : [
+  "examples" : [
     {
       "name" : "Default",
-      "type" : "entry",
-      "value" : {
+      "params" : {
 
-      },
-      "visible" : true
+      }
     },
     {
       "name" : "name",
-      "type" : "entry",
-      "value" : {
+      "params" : {
         "enabled" : true
-      },
-      "visible" : true
+      }
     }
   ],
   "logic" : [

--- a/examples/test/style/TextStyleConditional.component
+++ b/examples/test/style/TextStyleConditional.component
@@ -19,22 +19,18 @@
       "width" : 414
     }
   ],
-  "cases" : [
+  "examples" : [
     {
       "name" : "Default",
-      "type" : "entry",
-      "value" : {
+      "params" : {
 
-      },
-      "visible" : true
+      }
     },
     {
       "name" : "name",
-      "type" : "entry",
-      "value" : {
+      "params" : {
         "large" : true
-      },
-      "visible" : true
+      }
     }
   ],
   "logic" : [

--- a/examples/test/style/TextStylesTest.component
+++ b/examples/test/style/TextStylesTest.component
@@ -19,14 +19,12 @@
       "width" : 414
     }
   ],
-  "cases" : [
+  "examples" : [
     {
       "name" : "Default",
-      "type" : "entry",
-      "value" : {
+      "params" : {
 
-      },
-      "visible" : true
+      }
     }
   ],
   "logic" : [


### PR DESCRIPTION
## What

Rename "cases" to "examples". Also store example "params" in a compact format

## Why

The word "cases" always confused people. I think "examples" is much more clear.

## Testing Plan

- [X] Tested this change locally
- [X] Checked that existing features work