### PR TITLE
Rename variant to enum and tag to case

### DIFF
--- a/LonaStudio/Models/CSType.swift
+++ b/LonaStudio/Models/CSType.swift
@@ -97,7 +97,7 @@ indirect enum CSType: Equatable, CSDataSerializable, CSDataDeserializable {
                         returnType = CSType(value)
                     }
                     self = .function(parameters, returnType)
-                case "Variant":
+                case "Enum", "Variant":
                     var parameters: [(String, CSType)] = []
                     if let values = object["cases"]?.array {
                         parameters = values.map({ (arg) in
@@ -105,7 +105,9 @@ indirect enum CSType: Equatable, CSDataSerializable, CSDataDeserializable {
                                 return (tag, CSType.unit)
                             }
 
-                            return (arg.get(key: "tag").stringValue, CSType(arg.get(key: "type")))
+                            return (
+                                arg.get(key: "case").string ?? arg.get(key: "tag").stringValue,
+                                CSType(arg.get(key: "type")))
                         })
                     }
                     self = .variant(parameters)
@@ -248,7 +250,7 @@ indirect enum CSType: Equatable, CSDataSerializable, CSDataDeserializable {
             return data
         case .variant(let cases):
             var data: CSData = .Object([
-                "name": "Variant".toData()
+                "name": "Enum".toData()
                 ])
 
             if cases.count > 0 {
@@ -260,7 +262,7 @@ indirect enum CSType: Equatable, CSDataSerializable, CSDataDeserializable {
                     }
 
                     return CSData.Object([
-                        "tag": tag.toData(),
+                        "case": tag.toData(),
                         "type": innerType.toData()
                         ])
                 }))

--- a/LonaStudio/Models/CSValue.swift
+++ b/LonaStudio/Models/CSValue.swift
@@ -28,10 +28,10 @@ struct CSValue: Equatable, CSDataSerializable, CSDataDeserializable {
             let hasData = cases.contains(where: { arg in arg.1 != CSType.unit })
 
             if !hasData, data.object != nil {
-                return data.get(key: "tag")
+                return data.get(key: "case")
             }
 
-            if type.isOptional(), data.get(key: "tag").string != nil {
+            if type.isOptional(), data.get(key: "case").string != nil {
                 return data.get(key: "data")
             }
         case CSType.dictionary(let schema):
@@ -58,14 +58,14 @@ struct CSValue: Equatable, CSDataSerializable, CSDataDeserializable {
 
             if !hasData, let tag = data.string {
                 return CSData.Object([
-                    "tag": tag.toData(),
+                    "case": tag.toData(),
                     "data": CSData.Null
                     ])
             }
 
-            if type.isOptional(), data.get(key: "tag").string == nil {
+            if type.isOptional(), data.get(key: "case").string == nil {
                 return CSData.Object([
-                    "tag": (data.isNull ? "None" : "Some").toData(),
+                    "case": (data.isNull ? "None" : "Some").toData(),
                     "data": data
                     ])
             }
@@ -232,7 +232,7 @@ struct CSValue: Equatable, CSDataSerializable, CSDataDeserializable {
 
 extension CSValue {
     func tag() -> String {
-        return self.data.get(key: "tag").stringValue
+        return self.data.get(key: "case").stringValue
     }
 
     func wrap(in variant: CSType, tagged tag: String) -> CSValue {
@@ -247,7 +247,7 @@ extension CSValue {
         }
 
         return CSValue(type: variant, data: CSData.Object([
-            "tag": tag.toData(),
+            "case": tag.toData(),
             "data": data
             ]))
     }
@@ -258,7 +258,7 @@ extension CSValue {
             return nil
         }
 
-        let tag = self.data.get(key: "tag").stringValue
+        let tag = self.data.get(key: "case").stringValue
         guard let match = cases.first(where: { item in item.0 == tag }) else {
             Swift.print("Could not find tag", tag, "in variant type of value", self)
             return nil

--- a/LonaStudio/ParameterList/ParameterListView.swift
+++ b/LonaStudio/ParameterList/ParameterListView.swift
@@ -132,14 +132,14 @@ class ParameterListView: NSOutlineView, NSOutlineViewDataSource, NSOutlineViewDe
                 components.append(.value("typedef", fieldsValue, []))
             case .variant(let cases) where !parameter.type.isOptional():
                 let variantCaseType = CSType.dictionary([
-                    "tag": (CSType.string, .write),
+                    "case": (CSType.string, .write),
                     "type": (CSType.parameterType(), .write)
                     ])
                 let variantCasesType = CSType.array(variantCaseType)
                 let casesData: [CSData] = cases.map({ arg in
                     let (key, value) = arg
                     return CSData.Object([
-                        "tag": key.toData(),
+                        "case": key.toData(),
                         "type": (value.unwrapOptional() ?? value).toString().toData(),
                         "optional": value.isOptional().toData()
                         ])
@@ -196,7 +196,7 @@ class ParameterListView: NSOutlineView, NSOutlineViewDataSource, NSOutlineViewDe
                         parameter.type = CSType.dictionary(schema)
                     case .variant:
                         let cases: [(String, CSType)] = value.data.arrayValue.map({ field in
-                            let tag = field.get(key: "tag").stringValue
+                            let tag = field.get(key: "case").stringValue
                             let type = CSType.from(string: field.get(key: "type").stringValue)
                             let optional = field.get(key: "optional").boolValue
                             return (tag, type: optional ? type.makeOptional() : type)


### PR DESCRIPTION
## What

Variant => Enum
Tag => Case

## Why

The Swift names for these seem clearer than the OCaml/Reason names when reading the .component JSON

## Testing Plan

- [X] Tested this change locally
- [ ] Checked that existing features work