### PR TITLE
Support View borderWidth and borderColor when generating Swift code

### DIFF
--- a/compiler/core/src/core/decode.bs.js
+++ b/compiler/core/src/core/decode.bs.js
@@ -114,30 +114,42 @@ var parameterTypeMap = StringMap$LonaCompilerCore.fromList(/* :: */[
                                             ],
                                             /* :: */[
                                               /* tuple */[
-                                                "width",
+                                                "borderWidth",
                                                 Types$LonaCompilerCore.numberType
                                               ],
                                               /* :: */[
                                                 /* tuple */[
-                                                  "height",
-                                                  Types$LonaCompilerCore.numberType
+                                                  "borderColor",
+                                                  Types$LonaCompilerCore.colorType
                                                 ],
                                                 /* :: */[
                                                   /* tuple */[
-                                                    "pressed",
-                                                    Types$LonaCompilerCore.booleanType
+                                                    "width",
+                                                    Types$LonaCompilerCore.numberType
                                                   ],
                                                   /* :: */[
                                                     /* tuple */[
-                                                      "hovered",
-                                                      Types$LonaCompilerCore.booleanType
+                                                      "height",
+                                                      Types$LonaCompilerCore.numberType
                                                     ],
                                                     /* :: */[
                                                       /* tuple */[
-                                                        "onPress",
-                                                        Types$LonaCompilerCore.handlerType
+                                                        "pressed",
+                                                        Types$LonaCompilerCore.booleanType
                                                       ],
-                                                      /* [] */0
+                                                      /* :: */[
+                                                        /* tuple */[
+                                                          "hovered",
+                                                          Types$LonaCompilerCore.booleanType
+                                                        ],
+                                                        /* :: */[
+                                                          /* tuple */[
+                                                            "onPress",
+                                                            Types$LonaCompilerCore.handlerType
+                                                          ],
+                                                          /* [] */0
+                                                        ]
+                                                      ]
                                                     ]
                                                   ]
                                                 ]

--- a/compiler/core/src/core/decode.re
+++ b/compiler/core/src/core/decode.re
@@ -25,6 +25,8 @@ let parameterTypeMap =
     ("paddingBottom", Types.numberType),
     ("paddingLeft", Types.numberType),
     ("borderRadius", Types.numberType),
+    ("borderWidth", Types.numberType),
+    ("borderColor", Types.colorType),
     ("width", Types.numberType),
     ("height", Types.numberType),
     /* Interactivity */

--- a/compiler/core/src/core/lonaValue.bs.js
+++ b/compiler/core/src/core/lonaValue.bs.js
@@ -225,7 +225,7 @@ var parameterDefaultValueMap = StringMap$LonaCompilerCore.fromList(/* :: */[
                                               ],
                                               /* :: */[
                                                 /* tuple */[
-                                                  "width",
+                                                  "borderWidth",
                                                   /* record */[
                                                     /* ltype */Types$LonaCompilerCore.numberType,
                                                     /* data */0
@@ -233,37 +233,55 @@ var parameterDefaultValueMap = StringMap$LonaCompilerCore.fromList(/* :: */[
                                                 ],
                                                 /* :: */[
                                                   /* tuple */[
-                                                    "height",
+                                                    "borderColor",
                                                     /* record */[
-                                                      /* ltype */Types$LonaCompilerCore.numberType,
-                                                      /* data */0
+                                                      /* ltype */Types$LonaCompilerCore.colorType,
+                                                      /* data */"transparent"
                                                     ]
                                                   ],
                                                   /* :: */[
                                                     /* tuple */[
-                                                      "pressed",
+                                                      "width",
                                                       /* record */[
-                                                        /* ltype */Types$LonaCompilerCore.booleanType,
-                                                        /* data */Js_boolean.to_js_boolean(/* false */0)
+                                                        /* ltype */Types$LonaCompilerCore.numberType,
+                                                        /* data */0
                                                       ]
                                                     ],
                                                     /* :: */[
                                                       /* tuple */[
-                                                        "hovered",
+                                                        "height",
                                                         /* record */[
-                                                          /* ltype */Types$LonaCompilerCore.booleanType,
-                                                          /* data */Js_boolean.to_js_boolean(/* false */0)
+                                                          /* ltype */Types$LonaCompilerCore.numberType,
+                                                          /* data */0
                                                         ]
                                                       ],
                                                       /* :: */[
                                                         /* tuple */[
-                                                          "onPress",
+                                                          "pressed",
                                                           /* record */[
-                                                            /* ltype */Types$LonaCompilerCore.undefinedType,
-                                                            /* data */null
+                                                            /* ltype */Types$LonaCompilerCore.booleanType,
+                                                            /* data */Js_boolean.to_js_boolean(/* false */0)
                                                           ]
                                                         ],
-                                                        /* [] */0
+                                                        /* :: */[
+                                                          /* tuple */[
+                                                            "hovered",
+                                                            /* record */[
+                                                              /* ltype */Types$LonaCompilerCore.booleanType,
+                                                              /* data */Js_boolean.to_js_boolean(/* false */0)
+                                                            ]
+                                                          ],
+                                                          /* :: */[
+                                                            /* tuple */[
+                                                              "onPress",
+                                                              /* record */[
+                                                                /* ltype */Types$LonaCompilerCore.undefinedType,
+                                                                /* data */null
+                                                              ]
+                                                            ],
+                                                            /* [] */0
+                                                          ]
+                                                        ]
                                                       ]
                                                     ]
                                                   ]

--- a/compiler/core/src/core/lonaValue.re
+++ b/compiler/core/src/core/lonaValue.re
@@ -57,6 +57,8 @@ let parameterDefaultValueMap =
     ("paddingBottom", number(0.)),
     ("paddingLeft", number(0.)),
     ("borderRadius", number(0.)),
+    ("borderWidth", number(0.)),
+    ("borderColor", color("transparent")),
     ("width", number(0.)),
     ("height", number(0.)),
     /* Interactivity */

--- a/compiler/core/src/swift/swiftComponent.bs.js
+++ b/compiler/core/src/swift/swiftComponent.bs.js
@@ -5,6 +5,7 @@ var List                             = require("bs-platform/lib/js/list.js");
 var Block                            = require("bs-platform/lib/js/block.js");
 var Curry                            = require("bs-platform/lib/js/curry.js");
 var Caml_obj                         = require("bs-platform/lib/js/caml_obj.js");
+var ListLabels                       = require("bs-platform/lib/js/listLabels.js");
 var Pervasives                       = require("bs-platform/lib/js/pervasives.js");
 var LodashUpperfirst                 = require("lodash.upperfirst");
 var Layer$LonaCompilerCore           = require("../core/layer.bs.js");
@@ -536,6 +537,23 @@ function generate(_, swiftOptions, name, colors, textStyles, json) {
       };
       return List.concat(List.map(defineInitialLayerValues, Layer$LonaCompilerCore.flatten(rootLayer)));
     };
+    var isPropertyUsed = function (root, property) {
+      var bindings = List.map((function (param) {
+              return param[0];
+            }), List.flatten(List.map((function (v) {
+                      return Curry._1(StringMap$LonaCompilerCore.bindings, v[/* parameters */2]);
+                    }), Layer$LonaCompilerCore.flatten(root))));
+      var value = property;
+      var theList = bindings;
+      var f = function (found, elem) {
+        if (found) {
+          return /* true */1;
+        } else {
+          return +(elem === value);
+        }
+      };
+      return ListLabels.fold_left(f, /* false */0, theList);
+    };
     var resetViewStyling = function (layer) {
       var match = layer[/* typeName */0];
       if (typeof match === "number") {
@@ -543,6 +561,7 @@ function generate(_, swiftOptions, name, colors, textStyles, json) {
           if (match !== 0) {
             return /* [] */0;
           } else {
+            var match$1 = isPropertyUsed(layer, "borderWidth");
             return /* :: */[
                     /* BinaryExpression */Block.__(2, [{
                           left: memberOrSelfExpression(parentNameOrSelf(layer), /* :: */[
@@ -559,7 +578,7 @@ function generate(_, swiftOptions, name, colors, textStyles, json) {
                                   /* [] */0
                                 ]),
                             operator: "=",
-                            right: /* SwiftIdentifier */Block.__(8, [".noBorder"])
+                            right: match$1 !== 0 ? /* SwiftIdentifier */Block.__(8, [".lineBorder"]) : /* SwiftIdentifier */Block.__(8, [".noBorder"])
                           }]),
                       /* :: */[
                         /* BinaryExpression */Block.__(2, [{

--- a/compiler/core/src/swift/swiftComponent.bs.js
+++ b/compiler/core/src/swift/swiftComponent.bs.js
@@ -5,7 +5,6 @@ var List                             = require("bs-platform/lib/js/list.js");
 var Block                            = require("bs-platform/lib/js/block.js");
 var Curry                            = require("bs-platform/lib/js/curry.js");
 var Caml_obj                         = require("bs-platform/lib/js/caml_obj.js");
-var ListLabels                       = require("bs-platform/lib/js/listLabels.js");
 var Pervasives                       = require("bs-platform/lib/js/pervasives.js");
 var LodashUpperfirst                 = require("lodash.upperfirst");
 var Layer$LonaCompilerCore           = require("../core/layer.bs.js");
@@ -537,22 +536,14 @@ function generate(_, swiftOptions, name, colors, textStyles, json) {
       };
       return List.concat(List.map(defineInitialLayerValues, Layer$LonaCompilerCore.flatten(rootLayer)));
     };
-    var isPropertyUsed = function (root, property) {
-      var bindings = List.map((function (param) {
-              return param[0];
-            }), List.flatten(List.map((function (v) {
-                      return Curry._1(StringMap$LonaCompilerCore.bindings, v[/* parameters */2]);
-                    }), Layer$LonaCompilerCore.flatten(root))));
-      var value = property;
-      var theList = bindings;
-      var f = function (found, elem) {
-        if (found) {
-          return /* true */1;
-        } else {
-          return +(elem === value);
-        }
-      };
-      return ListLabels.fold_left(f, /* false */0, theList);
+    var isPropertyUsed = function (layer, property) {
+      var assignedParameters = Layer$LonaCompilerCore.LayerMap[/* find_opt */24](layer, layerParameterAssignments);
+      var parameterIsAssigned = assignedParameters ? Curry._2(StringMap$LonaCompilerCore.mem, property, assignedParameters[0]) : /* false */0;
+      if (parameterIsAssigned) {
+        return /* true */1;
+      } else {
+        return Curry._2(StringMap$LonaCompilerCore.mem, property, layer[/* parameters */2]);
+      }
     };
     var resetViewStyling = function (layer) {
       var match = layer[/* typeName */0];

--- a/compiler/core/src/swift/swiftComponent.re
+++ b/compiler/core/src/swift/swiftComponent.re
@@ -451,20 +451,16 @@ let generate =
       |> List.map(defineInitialLayerValues)
       |> List.concat;
     };
-    /* contains & isPropertyUsed should be made more general if needed in other places */
-    let contains = (~value: 'a, theList: list('a)) => {
-      let f = (found, elem) => found || elem == value;
-      ListLabels.fold_left(~f, ~init=false, theList);
-    };
-    let isPropertyUsed = (root, property) => {
-      let bindings = 
-        root
-        |> Layer.flatten
-        |> List.map((v: Types.layer) => v.parameters |> StringMap.bindings)
-        |> List.flatten
-        |> List.map(((k, _)) => k);
-
-        contains(~value=property, bindings);
+    /* isPropertyUsed should be made more general if needed in other places */
+    let isPropertyUsed = (layer: Types.layer, property) => {
+      let assignedParameters =
+        Layer.LayerMap.find_opt(layer, layerParameterAssignments);
+      let parameterIsAssigned =
+        switch assignedParameters {
+        | Some(parameters) => StringMap.mem(property, parameters)
+        | None => false
+        };
+      parameterIsAssigned || StringMap.mem(property, layer.parameters);
     };
     let resetViewStyling = (layer: Types.layer) =>
       switch layer.typeName {

--- a/compiler/core/src/swift/swiftLogic.bs.js
+++ b/compiler/core/src/swift/swiftLogic.bs.js
@@ -3,6 +3,7 @@
 
 var List                           = require("bs-platform/lib/js/list.js");
 var Block                          = require("bs-platform/lib/js/block.js");
+var Pervasives                     = require("bs-platform/lib/js/pervasives.js");
 var LodashCamelcase                = require("lodash.camelcase");
 var SwiftFormat$LonaCompilerCore   = require("./swiftFormat.bs.js");
 var SwiftDocument$LonaCompilerCore = require("./swiftDocument.bs.js");
@@ -79,6 +80,8 @@ function toSwiftAST(options, colors, textStyles, rootLayer, logicRootNode) {
         var name$2 = initialValue[0];
         if (name$2.endsWith(".borderRadius")) {
           return /* SwiftIdentifier */Block.__(8, [name$2.replace(".borderRadius", ".layer.cornerRadius")]);
+        } else if (name$2.endsWith(".borderWidth")) {
+          return /* SwiftIdentifier */Block.__(8, [name$2.replace(".borderWidth", ".layer.borderWidth")]);
         } else {
           return initialValue;
         }
@@ -215,18 +218,40 @@ function toSwiftAST(options, colors, textStyles, rootLayer, logicRootNode) {
               exit$4 = 3;
             } else if (match$2.tag === 8) {
               var name = match$2[0];
-              if (name.endsWith("visible")) {
-                return /* BinaryExpression */Block.__(2, [{
-                            left: /* SwiftIdentifier */Block.__(8, [name.replace("visible", "isHidden")]),
-                            operator: "=",
-                            right: /* PrefixExpression */Block.__(3, [{
-                                  operator: "!",
-                                  expression: match$3
-                                }])
-                          }]);
+              var exit$5 = 0;
+              if (typeof match$3 === "number") {
+                exit$5 = 4;
+              } else if (match$3.tag === 1) {
+                if (name.endsWith(".borderColor") && options[/* framework */0] === /* UIKit */0) {
+                  return /* BinaryExpression */Block.__(2, [{
+                              left: /* SwiftIdentifier */Block.__(8, [name.replace(".borderColor", ".layer.borderColor")]),
+                              operator: "=",
+                              right: /* MemberExpression */Block.__(1, [Pervasives.$at(match$3[0], /* :: */[
+                                        /* SwiftIdentifier */Block.__(8, ["cgColor"]),
+                                        /* [] */0
+                                      ])])
+                            }]);
+                } else {
+                  exit$5 = 4;
+                }
               } else {
-                exit$4 = 3;
+                exit$5 = 4;
               }
+              if (exit$5 === 4) {
+                if (name.endsWith("visible")) {
+                  return /* BinaryExpression */Block.__(2, [{
+                              left: /* SwiftIdentifier */Block.__(8, [name.replace("visible", "isHidden")]),
+                              operator: "=",
+                              right: /* PrefixExpression */Block.__(3, [{
+                                    operator: "!",
+                                    expression: match$3
+                                  }])
+                            }]);
+                } else {
+                  exit$4 = 3;
+                }
+              }
+              
             } else {
               exit$4 = 3;
             }

--- a/compiler/core/src/swift/swiftLogic.re
+++ b/compiler/core/src/swift/swiftLogic.re
@@ -78,6 +78,11 @@ let toSwiftAST =
       Ast.SwiftIdentifier(
         name |> Js.String.replace(".borderRadius", ".layer.cornerRadius")
       )
+    | (UIKit, Ast.SwiftIdentifier(name))
+        when name |> Js.String.endsWith(".borderWidth") =>
+      Ast.SwiftIdentifier(
+        name |> Js.String.replace(".borderWidth", ".layer.borderWidth")
+      )
     | (AppKit, Ast.SwiftIdentifier(name))
         when name |> Js.String.endsWith(".borderRadius") =>
       Ast.SwiftIdentifier(
@@ -115,6 +120,20 @@ let toSwiftAST =
     switch logicRootNode {
     | Logic.Assign(a, b) =>
       switch (logicValueToSwiftAST(b), logicValueToSwiftAST(a)) {
+      | (Ast.SwiftIdentifier(name), Ast.MemberExpression(right))
+          when name |> Js.String.endsWith(".borderColor")
+          && options.framework == UIKit =>
+        Ast.BinaryExpression({
+          "left":
+            Ast.SwiftIdentifier(
+              name |> Js.String.replace(".borderColor", ".layer.borderColor")
+            ),
+          "operator": "=",
+          "right":
+            Ast.MemberExpression(
+                right @ [Ast.SwiftIdentifier("cgColor")]
+            )
+        })
       | (Ast.SwiftIdentifier(name), other)
           when name |> Js.String.endsWith("visible") =>
         Ast.BinaryExpression({

--- a/examples/generated/test/appkit/style/BorderWidthColor.swift
+++ b/examples/generated/test/appkit/style/BorderWidthColor.swift
@@ -41,7 +41,7 @@ public class BorderWidthColor: NSBox {
 
   private func setUpViews() {
     boxType = .custom
-    borderType = .lineBorder
+    borderType = .noBorder
     contentViewMargins = .zero
     view1View.boxType = .custom
     view1View.borderType = .lineBorder

--- a/examples/generated/test/appkit/style/BorderWidthColor.swift
+++ b/examples/generated/test/appkit/style/BorderWidthColor.swift
@@ -1,0 +1,96 @@
+import AppKit
+import Foundation
+
+// MARK: - BorderWidthColor
+
+public class BorderWidthColor: NSBox {
+
+  // MARK: Lifecycle
+
+  public init() {
+    super.init(frame: .zero)
+
+    setUpViews()
+    setUpConstraints()
+
+    update()
+  }
+
+  public required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: Private
+
+  private var view1View = NSBox()
+
+  private var topPadding: CGFloat = 0
+  private var trailingPadding: CGFloat = 0
+  private var bottomPadding: CGFloat = 0
+  private var leadingPadding: CGFloat = 0
+  private var view1ViewTopMargin: CGFloat = 0
+  private var view1ViewTrailingMargin: CGFloat = 0
+  private var view1ViewBottomMargin: CGFloat = 0
+  private var view1ViewLeadingMargin: CGFloat = 0
+
+  private var view1ViewTopAnchorConstraint: NSLayoutConstraint?
+  private var view1ViewBottomAnchorConstraint: NSLayoutConstraint?
+  private var view1ViewLeadingAnchorConstraint: NSLayoutConstraint?
+  private var view1ViewHeightAnchorConstraint: NSLayoutConstraint?
+  private var view1ViewWidthAnchorConstraint: NSLayoutConstraint?
+
+  private func setUpViews() {
+    boxType = .custom
+    borderType = .lineBorder
+    contentViewMargins = .zero
+    view1View.boxType = .custom
+    view1View.borderType = .lineBorder
+    view1View.contentViewMargins = .zero
+
+    addSubview(view1View)
+
+    view1View.borderColor = Colors.blue300
+    view1View.cornerRadius = 10
+    view1View.borderWidth = 20
+  }
+
+  private func setUpConstraints() {
+    translatesAutoresizingMaskIntoConstraints = false
+    view1View.translatesAutoresizingMaskIntoConstraints = false
+
+    let view1ViewTopAnchorConstraint = view1View
+      .topAnchor
+      .constraint(equalTo: topAnchor, constant: topPadding + view1ViewTopMargin)
+    let view1ViewBottomAnchorConstraint = view1View
+      .bottomAnchor
+      .constraint(equalTo: bottomAnchor, constant: -(bottomPadding + view1ViewBottomMargin))
+    let view1ViewLeadingAnchorConstraint = view1View
+      .leadingAnchor
+      .constraint(equalTo: leadingAnchor, constant: leadingPadding + view1ViewLeadingMargin)
+    let view1ViewHeightAnchorConstraint = view1View.heightAnchor.constraint(equalToConstant: 100)
+    let view1ViewWidthAnchorConstraint = view1View.widthAnchor.constraint(equalToConstant: 100)
+
+    NSLayoutConstraint.activate([
+      view1ViewTopAnchorConstraint,
+      view1ViewBottomAnchorConstraint,
+      view1ViewLeadingAnchorConstraint,
+      view1ViewHeightAnchorConstraint,
+      view1ViewWidthAnchorConstraint
+    ])
+
+    self.view1ViewTopAnchorConstraint = view1ViewTopAnchorConstraint
+    self.view1ViewBottomAnchorConstraint = view1ViewBottomAnchorConstraint
+    self.view1ViewLeadingAnchorConstraint = view1ViewLeadingAnchorConstraint
+    self.view1ViewHeightAnchorConstraint = view1ViewHeightAnchorConstraint
+    self.view1ViewWidthAnchorConstraint = view1ViewWidthAnchorConstraint
+
+    // For debugging
+    view1ViewTopAnchorConstraint.identifier = "view1ViewTopAnchorConstraint"
+    view1ViewBottomAnchorConstraint.identifier = "view1ViewBottomAnchorConstraint"
+    view1ViewLeadingAnchorConstraint.identifier = "view1ViewLeadingAnchorConstraint"
+    view1ViewHeightAnchorConstraint.identifier = "view1ViewHeightAnchorConstraint"
+    view1ViewWidthAnchorConstraint.identifier = "view1ViewWidthAnchorConstraint"
+  }
+
+  private func update() {}
+}

--- a/examples/generated/test/js/style/BorderWidthColor.js
+++ b/examples/generated/test/js/style/BorderWidthColor.js
@@ -1,0 +1,21 @@
+class BorderWidthColor extends React.Component {
+  render() {
+    return (
+      <View style={[ styles.View, {} ]}>
+        <View
+          style={[ styles.View 1, {} ]}
+          borderColor={"blue300"}
+          borderRadius={10}
+          borderWidth={20}
+        >
+
+        </View>
+      </View>
+    );
+  }
+};
+
+let styles = StyleSheet.create({
+  View: { alignSelf: "stretch" },
+  View 1: { height: 100, width: 100 }
+});

--- a/examples/generated/test/swift/style/BorderWidthColor.swift
+++ b/examples/generated/test/swift/style/BorderWidthColor.swift
@@ -1,0 +1,89 @@
+import UIKit
+import Foundation
+
+// MARK: - BorderWidthColor
+
+public class BorderWidthColor: UIView {
+
+  // MARK: Lifecycle
+
+  public init() {
+    super.init(frame: .zero)
+
+    setUpViews()
+    setUpConstraints()
+
+    update()
+  }
+
+  public required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: Private
+
+  private var view1View = UIView(frame: .zero)
+
+  private var topPadding: CGFloat = 0
+  private var trailingPadding: CGFloat = 0
+  private var bottomPadding: CGFloat = 0
+  private var leadingPadding: CGFloat = 0
+  private var view1ViewTopMargin: CGFloat = 0
+  private var view1ViewTrailingMargin: CGFloat = 0
+  private var view1ViewBottomMargin: CGFloat = 0
+  private var view1ViewLeadingMargin: CGFloat = 0
+
+  private var view1ViewTopAnchorConstraint: NSLayoutConstraint?
+  private var view1ViewBottomAnchorConstraint: NSLayoutConstraint?
+  private var view1ViewLeadingAnchorConstraint: NSLayoutConstraint?
+  private var view1ViewHeightAnchorConstraint: NSLayoutConstraint?
+  private var view1ViewWidthAnchorConstraint: NSLayoutConstraint?
+
+  private func setUpViews() {
+    addSubview(view1View)
+
+    view1View.layer.borderColor = Colors.blue300.cgColor
+    view1View.layer.cornerRadius = 10
+    view1View.layer.borderWidth = 20
+  }
+
+  private func setUpConstraints() {
+    translatesAutoresizingMaskIntoConstraints = false
+    view1View.translatesAutoresizingMaskIntoConstraints = false
+
+    let view1ViewTopAnchorConstraint = view1View
+      .topAnchor
+      .constraint(equalTo: topAnchor, constant: topPadding + view1ViewTopMargin)
+    let view1ViewBottomAnchorConstraint = view1View
+      .bottomAnchor
+      .constraint(equalTo: bottomAnchor, constant: -(bottomPadding + view1ViewBottomMargin))
+    let view1ViewLeadingAnchorConstraint = view1View
+      .leadingAnchor
+      .constraint(equalTo: leadingAnchor, constant: leadingPadding + view1ViewLeadingMargin)
+    let view1ViewHeightAnchorConstraint = view1View.heightAnchor.constraint(equalToConstant: 100)
+    let view1ViewWidthAnchorConstraint = view1View.widthAnchor.constraint(equalToConstant: 100)
+
+    NSLayoutConstraint.activate([
+      view1ViewTopAnchorConstraint,
+      view1ViewBottomAnchorConstraint,
+      view1ViewLeadingAnchorConstraint,
+      view1ViewHeightAnchorConstraint,
+      view1ViewWidthAnchorConstraint
+    ])
+
+    self.view1ViewTopAnchorConstraint = view1ViewTopAnchorConstraint
+    self.view1ViewBottomAnchorConstraint = view1ViewBottomAnchorConstraint
+    self.view1ViewLeadingAnchorConstraint = view1ViewLeadingAnchorConstraint
+    self.view1ViewHeightAnchorConstraint = view1ViewHeightAnchorConstraint
+    self.view1ViewWidthAnchorConstraint = view1ViewWidthAnchorConstraint
+
+    // For debugging
+    view1ViewTopAnchorConstraint.identifier = "view1ViewTopAnchorConstraint"
+    view1ViewBottomAnchorConstraint.identifier = "view1ViewBottomAnchorConstraint"
+    view1ViewLeadingAnchorConstraint.identifier = "view1ViewLeadingAnchorConstraint"
+    view1ViewHeightAnchorConstraint.identifier = "view1ViewHeightAnchorConstraint"
+    view1ViewWidthAnchorConstraint.identifier = "view1ViewWidthAnchorConstraint"
+  }
+
+  private func update() {}
+}

--- a/examples/test/style/BorderWidthColor.component
+++ b/examples/test/style/BorderWidthColor.component
@@ -1,0 +1,56 @@
+{
+  "devices" : [
+    {
+      "height" : 100,
+      "heightMode" : "At Least",
+      "name" : "iPhone SE",
+      "width" : 320
+    },
+    {
+      "height" : 100,
+      "heightMode" : "At Least",
+      "name" : "iPhone 7",
+      "width" : 375
+    },
+    {
+      "height" : 100,
+      "heightMode" : "At Least",
+      "name" : "iPhone 7+",
+      "width" : 414
+    }
+  ],
+  "examples" : [
+    {
+      "name" : "Default",
+      "params" : {
+
+      }
+    }
+  ],
+  "logic" : [
+
+  ],
+  "params" : [
+
+  ],
+  "root" : {
+    "children" : [
+      {
+        "id" : "View 1",
+        "params" : {
+          "borderColor" : "blue300",
+          "borderRadius" : 10,
+          "borderWidth" : 20,
+          "height" : 100,
+          "width" : 100
+        },
+        "type" : "Lona:View"
+      }
+    ],
+    "id" : "View",
+    "params" : {
+      "alignSelf" : "stretch"
+    },
+    "type" : "Lona:View"
+  }
+}


### PR DESCRIPTION
cc: @dabbott 

## What

Github issue: https://github.com/airbnb/Lona/issues/83

(screenshots below)

## Major Changes

* Adds borderWidth and borderColor support for both iOS and MacOS.
* MacOS generated files will continue to use a `borderType` of `.noBorder` when `borderWidth` is not set in the Lona component file. If it is set, `borderType` will change to `.lineBorder`.**

** See _Feedback_ section for more about this.

## Requirements for Merging

* Generated Swift code should match the Lona component file. There is a test component file and the respective generated Swift code included in this PR.

## Testing Plan

- [x] Tested this change locally.
- [X] Checked that existing features work.

Note: there will be another PR with an iOS / MacOS app to view the generated Swift code including the UI code generated in this PR.

## Feedback

* I'm looking for feedback on the Reason implementation (this is my first venture into using Reason, so I am sure there could be improvements to my implementation).

* Also for MacOS, if a child view has a borderWidth, the current implementation will flag the parent view as having a `borderType` of `.lineBorder` also. If no borderWidth was specified in the parent view, there will be a visible border because the default border width is 1. Some guidance on addressing this would be great or maybe this is acceptable for this PR.

### iOS
<img width="291" alt="screen shot 2018-03-28 at 7 58 39 am" src="https://user-images.githubusercontent.com/13800855/38033660-8017f5ec-326e-11e8-9646-a8abe4707909.png">

### MacOS
<img width="670" alt="screen shot 2018-03-28 at 7 58 01 am" src="https://user-images.githubusercontent.com/13800855/38033668-8600cdb2-326e-11e8-8e55-ab1498c00f48.png">