### PR TITLE
Updated Readme: Xcode and MacOS requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ First, make sure you have [`bundler`](http://bundler.io/) and [Cocoapods](https:
 
 `bundle && bundle exec pod install`
 
-Open LonaStudio.xcworkspace and build in Xcode 9 on Sierra+. If there are warnings (e.g. about converting to Swift 4) you can ignore them.
+Open LonaStudio.xcworkspace and build in Xcode 9.3+ on High Sierra+. If there are warnings (e.g. about converting to Swift 4) you can ignore them.
 
 > It will build on El Capitan, but it likely won't be usable. The changes needed to make are small, if anybody wants to add support.
 


### PR DESCRIPTION
## What

Updated REAME to reflect Xcode 9.3 and High Sierra requirement.

## Why

- PR #141 changed code from `flatMap`, which works on Swift 4.0 -> to `compactMap`, which works on Swift 4.1 and newer. So, 
- Swift 4.1 runs on Xcode 9.3, which only runs on High Sierra

## Major Changes

* Updated README

## Requirements for Merging

- [X] Builds

## Testing Plan

- [X] Tested this change locally
- [X] Checked that existing features work