### PR TITLE
Improve the handling of default values for unknown types

### DIFF
--- a/compiler/core/src/swift/swiftDocument.bs.js
+++ b/compiler/core/src/swift/swiftDocument.bs.js
@@ -305,7 +305,7 @@ function defaultValueForLonaType(framework, _, textStyles, _ltype) {
                 _ltype = /* Reference */Block.__(0, [typeName.replace("?", "")]);
                 continue ;
               } else {
-                return /* SwiftIdentifier */Block.__(8, [typeName]);
+                return /* LiteralExpression */Block.__(0, [/* Nil */0]);
               }
           }
           if (exit === 1) {

--- a/compiler/core/src/swift/swiftDocument.re
+++ b/compiler/core/src/swift/swiftDocument.re
@@ -226,7 +226,7 @@ let rec defaultValueForLonaType =
         textStyles,
         Reference(Js.String.replace("?", "", value))
       )
-    | _ => SwiftIdentifier(typeName)
+    | _ => LiteralExpression(Nil)
     }
   | Function(_) => SwiftIdentifier("PLACEHOLDER")
   | Named(alias, _) =>


### PR DESCRIPTION
## What

When generating Swift and encountering an unknown type, the default value for this type will be `nil` now. Previously we generated invalid code, but printing `nil` allows using foreign types.

## Why

It's a hack until we officially support custom types in generated code.

## Testing Plan

- [X] Tested this change locally
- [X] Checked that existing features work
