### PR TITLE
Make TextStyles also add units for ReactDom

### DIFF
--- a/compiler/core/src/javaScript/javaScriptComponent.re
+++ b/compiler/core/src/javaScript/javaScriptComponent.re
@@ -206,7 +206,7 @@ let toJavaScriptStyleSheetAST =
                | (_, JavaScriptOptions.ReactDOM, true) =>
                 Property({
                   "key": Identifier([key |> ParameterKey.toString]),
-                  "value": Literal(LonaValue.string(string_of_int(value.data |> Json.Decode.int) ++ "px"))
+                  "value": Literal(LonaValue.string(value.data |> ReactDomTranslators.convertUnitlessStyle))
                 })
                | (ParameterKey.TextStyle, _, false) =>
                  switch (value.data |> Js.Json.decodeString) {

--- a/compiler/core/src/javaScript/javaScriptTextStyle.re
+++ b/compiler/core/src/javaScript/javaScriptTextStyle.re
@@ -1,6 +1,14 @@
 open JavaScriptAst;
 
-let render = (colors, textStyles: TextStyle.file) => {
+let render = (options: JavaScriptOptions.options, colors, textStyles: TextStyle.file) => {
+  let buildStyleNodeForFramework = 
+    options.framework
+    |> (framework, value: Types.lonaValue) =>
+      switch framework {
+      | JavaScriptOptions.ReactDOM => Literal(LonaValue.string(value.data |> ReactDomTranslators.convertUnitlessStyle))
+      | _ => Literal(value)
+      };
+
   let unwrapOptional = (f, a) =>
     switch a {
     | Some(value) => [f(value)]
@@ -40,7 +48,7 @@ let render = (colors, textStyles: TextStyle.file) => {
              };
              Property({
                "key": Identifier(["fontSize"]),
-               "value": Literal(lonaValue)
+               "value": lonaValue |> buildStyleNodeForFramework
              });
            }),
         lookup(style => style.lineHeight)
@@ -51,7 +59,7 @@ let render = (colors, textStyles: TextStyle.file) => {
              };
              Property({
                "key": Identifier(["lineHeight"]),
-               "value": Literal(lonaValue)
+               "value": lonaValue |> buildStyleNodeForFramework
              });
            }),
         lookup(style => style.letterSpacing)
@@ -62,7 +70,7 @@ let render = (colors, textStyles: TextStyle.file) => {
              };
              Property({
                "key": Identifier(["letterSpacing"]),
-               "value": Literal(lonaValue)
+               "value": lonaValue |> buildStyleNodeForFramework
              });
            }),
         lookup(style => style.color)

--- a/compiler/core/src/javaScript/utils/reactDomTranslators.re
+++ b/compiler/core/src/javaScript/utils/reactDomTranslators.re
@@ -1,5 +1,9 @@
 open ParameterKey;
 
+let styleUnit = "px";
+
+let convertUnitlessStyle = (value) => string_of_int(value |> Json.Decode.int) ++ styleUnit;
+
 let isUnitNumberParameter = key =>
   switch key {
   | MarginTop => true

--- a/compiler/core/src/main.re
+++ b/compiler/core/src/main.re
@@ -110,7 +110,7 @@ let renderColors = (target, colors) =>
 let renderTextStyles = (target, colors, textStyles) =>
   switch target {
   | Types.Swift => Swift.TextStyle.render(swiftOptions, colors, textStyles)
-  | JavaScript => JavaScriptTextStyle.render(colors, textStyles)
+  | JavaScript => JavaScriptTextStyle.render(javaScriptOptions, colors, textStyles)
   | _ => ""
   };
 

--- a/examples/generated/test/react-dom/textStyles.js
+++ b/examples/generated/test/react-dom/textStyles.js
@@ -4,78 +4,78 @@ export default {
   display4: {
     family: "Arial",
     fontWeight: "300",
-    fontSize: 112,
-    lineHeight: 120,
+    fontSize: "112px",
+    lineHeight: "120px",
     color: colors.grey900
   },
   display3: {
     family: "Arial",
     fontWeight: "400",
-    fontSize: 56,
-    lineHeight: 60,
+    fontSize: "56px",
+    lineHeight: "60px",
     color: colors.grey900
   },
   display2: {
     family: "Arial",
     fontWeight: "400",
-    fontSize: 45,
-    lineHeight: 48,
+    fontSize: "45px",
+    lineHeight: "48px",
     color: colors.grey900
   },
   display1: {
     family: "Arial",
     fontWeight: "400",
-    fontSize: 34,
-    lineHeight: 40,
+    fontSize: "34px",
+    lineHeight: "40px",
     color: colors.grey900
   },
   headline: {
     family: "Arial",
     fontWeight: "400",
-    fontSize: 24,
-    lineHeight: 32,
+    fontSize: "24px",
+    lineHeight: "32px",
     color: colors.grey900
   },
   subheading2: {
     family: "Arial",
     fontWeight: "400",
-    fontSize: 16,
-    lineHeight: 28,
+    fontSize: "16px",
+    lineHeight: "28px",
     color: colors.grey900
   },
   subheading1: {
     family: "Arial",
     fontWeight: "400",
-    fontSize: 16,
-    lineHeight: 24,
+    fontSize: "16px",
+    lineHeight: "24px",
     color: colors.grey900
   },
   body2: {
     family: "Arial",
     fontWeight: "500",
-    fontSize: 14,
-    lineHeight: 24,
+    fontSize: "14px",
+    lineHeight: "24px",
     color: colors.grey900
   },
   body1: {
     family: "Arial",
     fontWeight: "400",
-    fontSize: 14,
-    lineHeight: 20,
+    fontSize: "14px",
+    lineHeight: "20px",
     color: colors.grey900
   },
   caption: {
     family: "Arial",
     fontWeight: "400",
-    fontSize: 12,
-    lineHeight: 15,
+    fontSize: "12px",
+    lineHeight: "15px",
     color: colors.grey900
   },
   button: {
     family: "Arial",
     fontWeight: "500",
-    fontSize: 14,
-    lineHeight: 18,
+    fontSize: "14px",
+    lineHeight: "18px",
     color: colors.grey900
   }
 };


### PR DESCRIPTION
## What

This fixes the compiler not adding units in TextStyles.js for react-dom

## Why

I did this change in order to fix TextStyles!

