### PR TITLE
Compiler: If colors exist in the palette, use the id

### DIFF
--- a/compiler/core/src/javaScript/javaScriptComponent.re
+++ b/compiler/core/src/javaScript/javaScriptComponent.re
@@ -8,7 +8,7 @@ let styleNameKey = key =>
   | _ => key |> ParameterKey.toString
   };
 
-let createStyleAttributeAST = (framework: JavaScriptOptions.framework, _colors, _textStyles, layer: Types.layer, styles) =>
+let createStyleAttributeAST = (framework: JavaScriptOptions.framework, colors, _textStyles, layer: Types.layer, styles) =>
   switch framework {
   | JavaScriptOptions.ReactDOM =>
       Ast.(
@@ -26,7 +26,7 @@ let createStyleAttributeAST = (framework: JavaScriptOptions.framework, _colors, 
                   Layer.mapBindings(((key, value)) =>
                     Property({
                       "key": Identifier([key |> styleNameKey]),
-                      "value": JavaScriptLogic.logicValueToJavaScriptAST(value)
+                      "value": JavaScriptLogic.logicValueToJavaScriptAST(colors, value)
                     })
                   ) @@
                   styles
@@ -49,7 +49,7 @@ let createStyleAttributeAST = (framework: JavaScriptOptions.framework, _colors, 
                 Layer.mapBindings(((key, value)) =>
                   Property({
                     "key": Identifier([key |> styleNameKey]),
-                    "value": JavaScriptLogic.logicValueToJavaScriptAST(value)
+                    "value": JavaScriptLogic.logicValueToJavaScriptAST(colors, value)
                   })
                 ) @@
                 styles
@@ -133,7 +133,7 @@ let rec layerToJavaScriptAST =
                 "callee": Identifier(["require"]),
                 "arguments": [Literal(pathValue)]
               });
-            | _ => JavaScriptLogic.logicValueToJavaScriptAST(value)
+            | _ => JavaScriptLogic.logicValueToJavaScriptAST(colors, value)
             };
 
          JSXAttribute({"name": key, "value": attributeValue});
@@ -151,7 +151,7 @@ let rec layerToJavaScriptAST =
     switch (layer.typeName, dynamicOrStaticValue(Text)) {
     | (Types.Text, Some(textValue)) => [
         JSXExpressionContainer(
-          JavaScriptLogic.logicValueToJavaScriptAST(textValue)
+          JavaScriptLogic.logicValueToJavaScriptAST(colors, textValue)
         )
       ]
     | _ =>
@@ -340,7 +340,7 @@ let generate =
     |> layerToJavaScriptAST(options.framework, colors, textStyles, assignments, getAssetPath);
   let styleSheetAST =
     rootLayer |> toJavaScriptStyleSheetAST(options.framework, colors);
-  let logicAST = logic |> JavaScriptLogic.toJavaScriptAST |> Ast.optimize;
+  let logicAST = logic |> JavaScriptLogic.toJavaScriptAST(options.framework, colors) |> Ast.optimize;
   let {absolute, relative} =
     rootLayer |> importComponents(options.framework, getComponentFile);
   Ast.(

--- a/examples/generated/test/react-dom/interactivity/Button.js
+++ b/examples/generated/test/react-dom/interactivity/Button.js
@@ -11,10 +11,10 @@ export default class Button extends React.Component {
     Text$text = this.props.label
     View$onPress = this.props.onTap
     if (View$hovered) {
-      View$backgroundColor = "blue200"
+      View$backgroundColor = colors.blue200
     }
     if (View$pressed) {
-      View$backgroundColor = "blue50"
+      View$backgroundColor = colors.blue50
     }
     return (
       <div

--- a/examples/generated/test/react-dom/interactivity/PressableRootView.js
+++ b/examples/generated/test/react-dom/interactivity/PressableRootView.js
@@ -13,17 +13,17 @@ export default class PressableRootView extends React.Component {
     Outer$onPress = this.props.onPressOuter
     Inner$onPress = this.props.onPressInner
     if (Outer$hovered) {
-      Outer$backgroundColor = "grey100"
+      Outer$backgroundColor = colors.grey100
     }
     if (Outer$pressed) {
-      Outer$backgroundColor = "grey300"
+      Outer$backgroundColor = colors.grey300
     }
     if (Inner$hovered) {
-      Inner$backgroundColor = "blue300"
+      Inner$backgroundColor = colors.blue300
       InnerText$text = "Hovered"
     }
     if (Inner$pressed) {
-      Inner$backgroundColor = "blue800"
+      Inner$backgroundColor = colors.blue800
       InnerText$text = "Pressed"
     }
     if (Inner$hovered) {

--- a/examples/generated/test/react-dom/logic/If.js
+++ b/examples/generated/test/react-dom/logic/If.js
@@ -7,7 +7,7 @@ export default class If extends React.Component {
   render() {
     let View$backgroundColor
     if (this.props.enabled) {
-      View$backgroundColor = "red500"
+      View$backgroundColor = colors.red500
     }
     return (
       <div

--- a/examples/generated/test/react-native/interactivity/Button.js
+++ b/examples/generated/test/react-native/interactivity/Button.js
@@ -12,10 +12,10 @@ export default class Button extends React.Component {
     Text$text = this.props.label
     View$onPress = this.props.onTap
     if (View$hovered) {
-      View$backgroundColor = "blue200"
+      View$backgroundColor = colors.blue200
     }
     if (View$pressed) {
-      View$backgroundColor = "blue50"
+      View$backgroundColor = colors.blue50
     }
     return (
       <View

--- a/examples/generated/test/react-native/interactivity/PressableRootView.js
+++ b/examples/generated/test/react-native/interactivity/PressableRootView.js
@@ -14,17 +14,17 @@ export default class PressableRootView extends React.Component {
     Outer$onPress = this.props.onPressOuter
     Inner$onPress = this.props.onPressInner
     if (Outer$hovered) {
-      Outer$backgroundColor = "grey100"
+      Outer$backgroundColor = colors.grey100
     }
     if (Outer$pressed) {
-      Outer$backgroundColor = "grey300"
+      Outer$backgroundColor = colors.grey300
     }
     if (Inner$hovered) {
-      Inner$backgroundColor = "blue300"
+      Inner$backgroundColor = colors.blue300
       InnerText$text = "Hovered"
     }
     if (Inner$pressed) {
-      Inner$backgroundColor = "blue800"
+      Inner$backgroundColor = colors.blue800
       InnerText$text = "Pressed"
     }
     if (Inner$hovered) {

--- a/examples/generated/test/react-native/logic/If.js
+++ b/examples/generated/test/react-native/logic/If.js
@@ -8,7 +8,7 @@ export default class If extends React.Component {
   render() {
     let View$backgroundColor
     if (this.props.enabled) {
-      View$backgroundColor = "red500"
+      View$backgroundColor = colors.red500
     }
     return (
       <View style={[ styles.view, { backgroundColor: View$backgroundColor } ]}>

--- a/examples/generated/test/sketchJs/interactivity/Button.js
+++ b/examples/generated/test/sketchJs/interactivity/Button.js
@@ -13,10 +13,10 @@ export default class Button extends React.Component {
     Text$text = this.props.label
     View$onPress = this.props.onTap
     if (View$hovered) {
-      View$backgroundColor = "blue200"
+      View$backgroundColor = colors.blue200
     }
     if (View$pressed) {
-      View$backgroundColor = "blue50"
+      View$backgroundColor = colors.blue50
     }
     return (
       <View

--- a/examples/generated/test/sketchJs/interactivity/PressableRootView.js
+++ b/examples/generated/test/sketchJs/interactivity/PressableRootView.js
@@ -15,17 +15,17 @@ export default class PressableRootView extends React.Component {
     Outer$onPress = this.props.onPressOuter
     Inner$onPress = this.props.onPressInner
     if (Outer$hovered) {
-      Outer$backgroundColor = "grey100"
+      Outer$backgroundColor = colors.grey100
     }
     if (Outer$pressed) {
-      Outer$backgroundColor = "grey300"
+      Outer$backgroundColor = colors.grey300
     }
     if (Inner$hovered) {
-      Inner$backgroundColor = "blue300"
+      Inner$backgroundColor = colors.blue300
       InnerText$text = "Hovered"
     }
     if (Inner$pressed) {
-      Inner$backgroundColor = "blue800"
+      Inner$backgroundColor = colors.blue800
       InnerText$text = "Pressed"
     }
     if (Inner$hovered) {

--- a/examples/generated/test/sketchJs/logic/If.js
+++ b/examples/generated/test/sketchJs/logic/If.js
@@ -8,7 +8,7 @@ export default class If extends React.Component {
   render() {
     let View$backgroundColor
     if (this.props.enabled) {
-      View$backgroundColor = "red500"
+      View$backgroundColor = colors.red500
     }
     return (
       <View style={[ styles.view, { backgroundColor: View$backgroundColor } ]}>


### PR DESCRIPTION
## What

This fixes the colors that were injected for js as a string instead of a reference to the palette. 

