### PR TITLE
Don't print comments that are empty strings

### DIFF
--- a/compiler/core/src/javaScript/javaScriptColor.re
+++ b/compiler/core/src/javaScript/javaScriptColor.re
@@ -8,8 +8,9 @@ let render = colors => {
         "value": Literal(LonaValue.string(color.value))
       });
     switch color.comment {
+    | None
+    | Some("") => property
     | Some(comment) => LineEndComment({"comment": comment, "line": property})
-    | None => property
     };
   };
   let doc =


### PR DESCRIPTION
## What

Small one, for an edge case. Normally comments should but null if they don't exist, but this handles empty strings better. This doesn't affect our current test cases, but that's fine.

## Testing Plan

- [X] Tested this change locally
- [X] Checked that existing features work

cc: @outdooricon 