### PR TITLE
disable dark mode for now

### DIFF
--- a/studio/LonaStudio/AppDelegate.swift
+++ b/studio/LonaStudio/AppDelegate.swift
@@ -14,10 +14,13 @@ import MASPreferences
 class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationWillFinishLaunching(_ notification: Notification) {
-#if DEBUG
-#else
-    PFMoveToApplicationsFolderIfNecessary()
-#endif
+        if #available(OSX 10.14, *) {
+            NSApp.appearance = NSAppearance(named: .aqua)
+        }
+        #if DEBUG
+        #else
+            PFMoveToApplicationsFolderIfNecessary()
+        #endif
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {


### PR DESCRIPTION
## What

Disable dark mode on macOS 10.14 for now otherwise half of the controls are white while the others are black
