### PR TITLE
Store a preference for code output view visibility

### DIFF
--- a/studio/LonaStudio/Workspace/WorkspaceViewController.swift
+++ b/studio/LonaStudio/Workspace/WorkspaceViewController.swift
@@ -67,14 +67,16 @@ class WorkspaceViewController: NSSplitViewController {
 
     // MARK: Public
 
-    // TODO: Actually remove this splitViewItem when it isn't used so that the divider
-    // doesn't show up on the edge of the screen.
     public var codeViewVisible: Bool {
         get {
-            return !codeItem.isCollapsed
+            return splitViewItems.contains(codeItem)
         }
         set {
-            codeItem.isCollapsed = !newValue
+            if newValue && !codeViewVisible {
+                insertSplitViewItem(codeItem, at: 2)
+            } else if !newValue && codeViewVisible {
+                removeSplitViewItem(codeItem)
+            }
         }
     }
     public var onChangeCodeViewVisible: ((Bool) -> Void)?
@@ -376,9 +378,9 @@ class WorkspaceViewController: NSSplitViewController {
         mainItem.preferredThicknessFraction = 0.5
         addSplitViewItem(mainItem)
 
+        // The codeItem is added to the splitview dynamically, based on saved preference
         codeItem.minimumThickness = 180
         codeItem.preferredThicknessFraction = 0.5
-        addSplitViewItem(codeItem)
 
         sidebarItem.collapseBehavior = .preferResizingSiblingsWithFixedSplitView
         sidebarItem.canCollapse = false

--- a/studio/LonaStudio/Workspace/WorkspaceWindowController.swift
+++ b/studio/LonaStudio/Workspace/WorkspaceWindowController.swift
@@ -13,6 +13,8 @@ private let viewControllerId = NSStoryboard.SceneIdentifier(rawValue: "MainWorks
 private let windowControllerId = NSStoryboard.SceneIdentifier(rawValue: "Document Window Controller")
 private let storyboardName = NSStoryboard.Name(rawValue: "Main")
 
+private let codeViewVisibleKey = "LonaStudio code view visible"
+
 class WorkspaceWindowController: NSWindowController {
     @discardableResult static func create(andAttachTo document: NSDocument? = nil) -> WorkspaceWindowController {
         let storyboard = NSStoryboard(name: storyboardName, bundle: nil)
@@ -23,8 +25,11 @@ class WorkspaceWindowController: NSWindowController {
 
         let toolbar = WorkspaceToolbar()
 
+        workspaceViewController.codeViewVisible = UserDefaults.standard.bool(forKey: codeViewVisibleKey)
+
         toolbar.onChangeSplitterState = { active in
             workspaceViewController.codeViewVisible = active
+            UserDefaults.standard.set(active, forKey: codeViewVisibleKey)
         }
 
         toolbar.onChangeActivePanes = { activePanes in


### PR DESCRIPTION
## What

The code output view will remember whether it was open or closed

## Testing Plan

- [X] Tested this change locally
- [X] Checked that existing features work
