### PR TITLE
Improve vertical alignment by using native lineheight when not user-provided

### DIFF
--- a/compiler/core/src/static/swift/TextStyle.appkit.swift
+++ b/compiler/core/src/static/swift/TextStyle.appkit.swift
@@ -6,7 +6,7 @@ public class TextStyle {
   public let name: String?
   public let weight: NSFont.Weight
   public let size: CGFloat
-  public let lineHeight: CGFloat
+  public let lineHeight: CGFloat?
   public let kerning: Double
   public let color: NSColor
   public let alignment: NSTextAlignment
@@ -24,7 +24,7 @@ public class TextStyle {
     self.name = name
     self.weight = weight
     self.size = size
-    self.lineHeight = lineHeight ?? size * 1.5
+    self.lineHeight = lineHeight
     self.kerning = kerning
     self.color = color
     self.alignment = alignment
@@ -53,8 +53,10 @@ public class TextStyle {
 
   public lazy var paragraphStyle: NSMutableParagraphStyle = {
     let paragraphStyle = NSMutableParagraphStyle()
-    paragraphStyle.minimumLineHeight = lineHeight
-    paragraphStyle.maximumLineHeight = lineHeight
+    if let lineHeight = lineHeight {
+      paragraphStyle.minimumLineHeight = lineHeight
+      paragraphStyle.maximumLineHeight = lineHeight
+    }
     paragraphStyle.alignment = alignment
     return paragraphStyle
   }()

--- a/compiler/core/src/static/swift/TextStyle.uikit.swift
+++ b/compiler/core/src/static/swift/TextStyle.uikit.swift
@@ -6,7 +6,7 @@ public class TextStyle {
   public let name: String?
   public let weight: UIFont.Weight
   public let size: CGFloat
-  public let lineHeight: CGFloat
+  public let lineHeight: CGFloat?
   public let kerning: Double
   public let color: UIColor
   public let alignment: NSTextAlignment
@@ -24,7 +24,7 @@ public class TextStyle {
     self.name = name
     self.weight = weight
     self.size = size
-    self.lineHeight = lineHeight ?? size * 1.5
+    self.lineHeight = lineHeight
     self.kerning = kerning
     self.color = color
     self.alignment = alignment
@@ -53,8 +53,10 @@ public class TextStyle {
 
   public lazy var paragraphStyle: NSMutableParagraphStyle = {
     let paragraphStyle = NSMutableParagraphStyle()
-    paragraphStyle.minimumLineHeight = lineHeight
-    paragraphStyle.maximumLineHeight = lineHeight
+    if let lineHeight = lineHeight {
+      paragraphStyle.minimumLineHeight = lineHeight
+      paragraphStyle.maximumLineHeight = lineHeight
+    }
     paragraphStyle.alignment = alignment
     return paragraphStyle
   }()

--- a/examples/generated/test/appkit/TextStyle.swift
+++ b/examples/generated/test/appkit/TextStyle.swift
@@ -6,7 +6,7 @@ public class TextStyle {
   public let name: String?
   public let weight: NSFont.Weight
   public let size: CGFloat
-  public let lineHeight: CGFloat
+  public let lineHeight: CGFloat?
   public let kerning: Double
   public let color: NSColor
   public let alignment: NSTextAlignment
@@ -24,7 +24,7 @@ public class TextStyle {
     self.name = name
     self.weight = weight
     self.size = size
-    self.lineHeight = lineHeight ?? size * 1.5
+    self.lineHeight = lineHeight
     self.kerning = kerning
     self.color = color
     self.alignment = alignment
@@ -53,8 +53,10 @@ public class TextStyle {
 
   public lazy var paragraphStyle: NSMutableParagraphStyle = {
     let paragraphStyle = NSMutableParagraphStyle()
-    paragraphStyle.minimumLineHeight = lineHeight
-    paragraphStyle.maximumLineHeight = lineHeight
+    if let lineHeight = lineHeight {
+      paragraphStyle.minimumLineHeight = lineHeight
+      paragraphStyle.maximumLineHeight = lineHeight
+    }
     paragraphStyle.alignment = alignment
     return paragraphStyle
   }()

--- a/examples/generated/test/swift/TextStyle.swift
+++ b/examples/generated/test/swift/TextStyle.swift
@@ -6,7 +6,7 @@ public class TextStyle {
   public let name: String?
   public let weight: UIFont.Weight
   public let size: CGFloat
-  public let lineHeight: CGFloat
+  public let lineHeight: CGFloat?
   public let kerning: Double
   public let color: UIColor
   public let alignment: NSTextAlignment
@@ -24,7 +24,7 @@ public class TextStyle {
     self.name = name
     self.weight = weight
     self.size = size
-    self.lineHeight = lineHeight ?? size * 1.5
+    self.lineHeight = lineHeight
     self.kerning = kerning
     self.color = color
     self.alignment = alignment
@@ -53,8 +53,10 @@ public class TextStyle {
 
   public lazy var paragraphStyle: NSMutableParagraphStyle = {
     let paragraphStyle = NSMutableParagraphStyle()
-    paragraphStyle.minimumLineHeight = lineHeight
-    paragraphStyle.maximumLineHeight = lineHeight
+    if let lineHeight = lineHeight {
+      paragraphStyle.minimumLineHeight = lineHeight
+      paragraphStyle.maximumLineHeight = lineHeight
+    }
     paragraphStyle.alignment = alignment
     return paragraphStyle
   }()

--- a/studio/LonaStudio/Generated/TextStyle.swift
+++ b/studio/LonaStudio/Generated/TextStyle.swift
@@ -6,7 +6,7 @@ public class TextStyle {
   public let name: String?
   public let weight: NSFont.Weight
   public let size: CGFloat
-  public let lineHeight: CGFloat
+  public let lineHeight: CGFloat?
   public let kerning: Double
   public let color: NSColor
   public let alignment: NSTextAlignment
@@ -24,7 +24,7 @@ public class TextStyle {
     self.name = name
     self.weight = weight
     self.size = size
-    self.lineHeight = lineHeight ?? size * 1.5
+    self.lineHeight = lineHeight
     self.kerning = kerning
     self.color = color
     self.alignment = alignment
@@ -53,8 +53,10 @@ public class TextStyle {
 
   public lazy var paragraphStyle: NSMutableParagraphStyle = {
     let paragraphStyle = NSMutableParagraphStyle()
-    paragraphStyle.minimumLineHeight = lineHeight
-    paragraphStyle.maximumLineHeight = lineHeight
+    if let lineHeight = lineHeight {
+      paragraphStyle.minimumLineHeight = lineHeight
+      paragraphStyle.maximumLineHeight = lineHeight
+    }
     paragraphStyle.alignment = alignment
     return paragraphStyle
   }()

--- a/studio/LonaStudio/Preferences/CSTypography.swift
+++ b/studio/LonaStudio/Preferences/CSTypography.swift
@@ -75,7 +75,10 @@ struct CSTextStyle {
 
     var summary: String {
         let weight = fontWeightName(fontWeight: font.weight)
-        return "\(weight) \(font.size)/\(font.lineHeight)"
+        if let lineHeight = font.lineHeight {
+            return "\(weight) \(font.size)/\(lineHeight)"
+        }
+        return "\(weight) \(font.size)"
     }
 
     private func base() -> CSTextStyle? {

--- a/studio/LonaStudio/Workspace/TextStylePreviewCollection.swift
+++ b/studio/LonaStudio/Workspace/TextStylePreviewCollection.swift
@@ -130,7 +130,7 @@ extension TextStylePreviewCollectionView: NSCollectionViewDelegateFlowLayout {
 
         return NSSize(
             width: 260,
-            height: textStyle.font.lineHeight + 81)
+            height: (textStyle.font.lineHeight ?? textStyle.font.nsFont.capHeight) + 81)
     }
 }
 


### PR DESCRIPTION
## What

We no longer compute a (very inaccurate) default line height for text styles

## Testing Plan

- [X] Tested this change locally
- [X] Checked that existing features work

@outdooricon 