### PR TITLE
Less verbose Swift generation

### DIFF
--- a/compiler/core/src/core/lonaValue.re
+++ b/compiler/core/src/core/lonaValue.re
@@ -69,3 +69,6 @@ let parameterDefaultValue = key =>
   };
 
 let defaultValueForParameter = name => parameterDefaultValue(name);
+
+let decodeNumber = (value: Types.lonaValue): float =>
+  value.data |> Json.Decode.float;

--- a/compiler/core/src/main.re
+++ b/compiler/core/src/main.re
@@ -36,6 +36,11 @@ let swiftOptions: Swift.Options.options = {
     | Some("appkit") => Swift.Options.AppKit
     | _ => Swift.Options.UIKit
     },
+  debugConstraints:
+    switch (getArgument("debugConstraints")) {
+    | Some(_) => true
+    | _ => false
+    },
   typePrefix:
     switch (getArgument("typePrefix")) {
     | Some(value) => value

--- a/compiler/core/src/swift/swiftComponent.re
+++ b/compiler/core/src/swift/swiftComponent.re
@@ -775,7 +775,6 @@ let generate =
                         colors,
                         textStyles,
                         getComponent,
-                        assignmentsFromLayerParameters,
                         assignmentsFromLogic,
                         layerMemberExpression,
                         rootLayer,

--- a/compiler/core/src/swift/swiftComponent.re
+++ b/compiler/core/src/swift/swiftComponent.re
@@ -533,7 +533,7 @@ let generate =
   let parameters = json |> Decode.Component.parameters;
   open SwiftAst;
 
-  let viewVariableNode = (layer: Types.layer): node =>
+  let viewVariableDoc = (layer: Types.layer): node =>
     Build.privateVariableDeclaration(
       layer.name |> SwiftFormat.layerName,
       None,
@@ -738,7 +738,7 @@ let generate =
                     |> List.map(Doc.parameterVariable(swiftOptions)),
                     [LineComment("MARK: Private")],
                     needsTracking ? [AppkitPressable.trackingAreaVar] : [],
-                    nonRootLayers |> List.map(viewVariableNode),
+                    nonRootLayers |> List.map(viewVariableDoc),
                     nonRootLayers
                     |> List.filter(Layer.isTextLayer)
                     |> List.map(textStyleVariableDoc),

--- a/compiler/core/src/swift/swiftComponent.re
+++ b/compiler/core/src/swift/swiftComponent.re
@@ -751,6 +751,9 @@ let generate =
                     |> List.map(Doc.pressableVariables(rootLayer))
                     |> List.concat,
                     constraints
+                    |> List.filter(
+                         SwiftConstraint.isDynamic(assignmentsFromLogic),
+                       )
                     |> List.map(def =>
                          constraintVariableDoc(
                            SwiftConstraint.formatConstraintVariableName(
@@ -778,6 +781,7 @@ let generate =
                         textStyles,
                         getComponent,
                         assignmentsFromLayerParameters,
+                        assignmentsFromLogic,
                         layerMemberExpression,
                         rootLayer,
                       ),

--- a/compiler/core/src/swift/swiftComponent.re
+++ b/compiler/core/src/swift/swiftComponent.re
@@ -302,10 +302,6 @@ let generate =
     Layer.parameterAssignmentsFromLogic(rootLayer, logic);
   let parameters = json |> Decode.Component.parameters;
   open SwiftAst;
-  let priorityName =
-    fun
-    | Constraint.Required => "required"
-    | Low => "defaultLow";
 
   let viewVariableNode = (layer: Types.layer): node =>
     Build.privateVariableDeclaration(
@@ -688,350 +684,7 @@ let generate =
         ),
     });
   };
-  let negateNumber = expression =>
-    PrefixExpression({"operator": "-", "expression": expression});
-  let constraintConstantExpression =
-      (layer: Types.layer, variable1, parent: Types.layer, variable2) => {
-    let variableName = (layer: Types.layer, variable) =>
-      layer === rootLayer ?
-        variable :
-        SwiftFormat.layerName(layer.name) ++ Format.upperFirst(variable);
-    BinaryExpression({
-      "left": SwiftIdentifier(variableName(layer, variable1)),
-      "operator": "+",
-      "right": SwiftIdentifier(variableName(parent, variable2)),
-    });
-  };
-  let generateConstraintWithInitialValue = (constr: Constraint.t, node) =>
-    switch (constr) {
-    | Constraint.Dimension((layer: Types.layer), dimension, _, _) =>
-      layerMemberExpression(
-        layer,
-        [
-          SwiftIdentifier(Constraint.anchorToString(dimension)),
-          FunctionCallExpression({
-            "name": SwiftIdentifier("constraint"),
-            "arguments": [
-              FunctionCallArgument({
-                "name": Some(SwiftIdentifier("equalToConstant")),
-                "value": node,
-              }),
-            ],
-          }),
-        ],
-      )
-    | Constraint.Relation(
-        (layer1: Types.layer),
-        edge1,
-        relation,
-        (layer2: Types.layer),
-        edge2,
-        _,
-        _,
-      ) =>
-      layerMemberExpression(
-        layer1,
-        [
-          SwiftIdentifier(Constraint.anchorToString(edge1)),
-          FunctionCallExpression({
-            "name": SwiftIdentifier("constraint"),
-            "arguments": [
-              FunctionCallArgument({
-                "name":
-                  Some(SwiftIdentifier(Constraint.cmpToString(relation))),
-                "value":
-                  layerMemberExpression(
-                    layer2,
-                    [SwiftIdentifier(Constraint.anchorToString(edge2))],
-                  ),
-              }),
-              FunctionCallArgument({
-                "name": Some(SwiftIdentifier("constant")),
-                "value": node,
-              }),
-            ],
-          }),
-        ],
-      )
-    };
-  let generateConstantFromConstraint = (constr: Constraint.t) =>
-    Constraint.(
-      switch (constr) {
-      /* Currently centering doesn't require any constants, since a centered view also
-         has a pair of before/after constraints that include the constants */
-      | Relation(_, CenterX, _, _, CenterX, _, _)
-      | Relation(_, CenterY, _, _, CenterY, _, _) =>
-        LiteralExpression(FloatingPoint(0.0))
-      | Relation(child, Top, _, layer, Top, _, PrimaryBefore)
-      | Relation(child, Top, _, layer, Top, _, SecondaryBefore) =>
-        constraintConstantExpression(layer, "topPadding", child, "topMargin")
-      | Relation(child, Leading, _, layer, Leading, _, PrimaryBefore)
-      | Relation(child, Leading, _, layer, Leading, _, SecondaryBefore) =>
-        constraintConstantExpression(
-          layer,
-          "leadingPadding",
-          child,
-          "leadingMargin",
-        )
-      | Relation(child, Bottom, _, layer, Bottom, _, PrimaryAfter)
-      | Relation(child, Bottom, _, layer, Bottom, _, SecondaryAfter) =>
-        negateNumber(
-          constraintConstantExpression(
-            layer,
-            "bottomPadding",
-            child,
-            "bottomMargin",
-          ),
-        )
-      | Relation(child, Trailing, _, layer, Trailing, _, SecondaryAfter)
-      | Relation(child, Trailing, _, layer, Trailing, _, PrimaryAfter) =>
-        negateNumber(
-          constraintConstantExpression(
-            layer,
-            "trailingPadding",
-            child,
-            "trailingMargin",
-          ),
-        )
-      | Relation(child, Top, _, previousLayer, Bottom, _, PrimaryBetween) =>
-        constraintConstantExpression(
-          previousLayer,
-          "bottomMargin",
-          child,
-          "topMargin",
-        )
-      | Relation(
-          child,
-          Leading,
-          _,
-          previousLayer,
-          Trailing,
-          _,
-          PrimaryBetween,
-        ) =>
-        constraintConstantExpression(
-          previousLayer,
-          "trailingMargin",
-          child,
-          "leadingMargin",
-        )
-      | Relation(child, Width, Leq, layer, Width, _, FitContentSecondary) =>
-        negateNumber(
-          BinaryExpression({
-            "left":
-              constraintConstantExpression(
-                layer,
-                "leadingPadding",
-                child,
-                "leadingMargin",
-              ),
-            "operator": "+",
-            "right":
-              constraintConstantExpression(
-                layer,
-                "trailingPadding",
-                child,
-                "trailingMargin",
-              ),
-          }),
-        )
-      | Relation(child, Height, Leq, layer, Height, _, FitContentSecondary) =>
-        negateNumber(
-          BinaryExpression({
-            "left":
-              constraintConstantExpression(
-                layer,
-                "topPadding",
-                child,
-                "topMargin",
-              ),
-            "operator": "+",
-            "right":
-              constraintConstantExpression(
-                layer,
-                "bottomPadding",
-                child,
-                "bottomMargin",
-              ),
-          }),
-        )
-      | Relation(_, _, _, _, _, _, FlexSibling) =>
-        LiteralExpression(FloatingPoint(0.0))
-      | Dimension((layer: Types.layer), Height, _, _) =>
-        let constant = Layer.getNumberParameter(Height, layer);
-        LiteralExpression(FloatingPoint(constant));
-      | Dimension((layer: Types.layer), Width, _, _) =>
-        let constant = Layer.getNumberParameter(Width, layer);
-        LiteralExpression(FloatingPoint(constant));
-      | _ =>
-        Js.log("Unknown constraint types");
-        raise(Not_found);
-      }
-    );
-  let formatConstraintVariableName = (constr: Constraint.t) => {
-    open Constraint;
-    let formatAnchorVariableName = (layer: Types.layer, anchor, suffix) => {
-      let anchorString = Constraint.anchorToString(anchor);
-      (
-        layer === rootLayer ?
-          anchorString :
-          SwiftFormat.layerName(layer.name)
-          ++ Format.upperFirst(anchorString)
-      )
-      ++ suffix;
-    };
-    switch (constr) {
-    | Relation(
-        (layer1: Types.layer),
-        edge1,
-        _,
-        (layer2: Types.layer),
-        _,
-        _,
-        FlexSibling,
-      ) =>
-      SwiftFormat.layerName(layer1.name)
-      ++ Format.upperFirst(SwiftFormat.layerName(layer2.name))
-      ++ Format.upperFirst(Constraint.anchorToString(edge1))
-      ++ "SiblingConstraint"
-    | Relation((layer1: Types.layer), edge1, _, _, _, _, FitContentSecondary) =>
-      formatAnchorVariableName(layer1, edge1, "ParentConstraint")
-    | Relation((layer1: Types.layer), edge1, _, _, _, _, _) =>
-      formatAnchorVariableName(layer1, edge1, "Constraint")
-    | Dimension((layer: Types.layer), dimension, _, _) =>
-      formatAnchorVariableName(layer, dimension, "Constraint")
-    };
-  };
-  let constraints =
-    Constraint.getConstraints(
-      /* For the purposes of layouts, we want to swap the custom component layer
-         with the root layer from the custom component's definition. We should
-         use the parameters of the custom component's root layer, since these
-         determine layout. We should still use the type, name, and children of
-         the custom component layer. */
-      (layer: Types.layer, name) => {
-        let component = getComponent(name);
-        let rootLayer = component |> Decode.Component.rootLayer(getComponent);
-        {
-          typeName: layer.typeName,
-          styles: layer.styles,
-          name: layer.name,
-          parameters: rootLayer.parameters,
-          children: layer.children,
-        };
-      },
-      rootLayer,
-    );
-  let setUpConstraintsDoc = (root: Types.layer) => {
-    let translatesAutoresizingMask = (layer: Types.layer) =>
-      BinaryExpression({
-        "left":
-          layerMemberExpression(
-            layer,
-            [SwiftIdentifier("translatesAutoresizingMaskIntoConstraints")],
-          ),
-        "operator": "=",
-        "right": LiteralExpression(Boolean(false)),
-      });
-    let getInitialValue = constr =>
-      generateConstraintWithInitialValue(
-        constr,
-        generateConstantFromConstraint(constr),
-      );
-    let defineConstraint = def =>
-      ConstantDeclaration({
-        "modifiers": [],
-        "init": Some(getInitialValue(def)),
-        "pattern":
-          IdentifierPattern({
-            "identifier": SwiftIdentifier(formatConstraintVariableName(def)),
-            "annotation": None,
-          }),
-      });
-    let setConstraintPriority = def =>
-      BinaryExpression({
-        "left":
-          MemberExpression([
-            SwiftIdentifier(formatConstraintVariableName(def)),
-            SwiftIdentifier("priority"),
-          ]),
-        "operator": "=",
-        "right":
-          MemberExpression([
-            SwiftDocument.layoutPriorityTypeDoc(swiftOptions.framework),
-            SwiftIdentifier(priorityName(Constraint.getPriority(def))),
-          ]),
-      });
-    let activateConstraints = () =>
-      FunctionCallExpression({
-        "name":
-          MemberExpression([
-            SwiftIdentifier("NSLayoutConstraint"),
-            SwiftIdentifier("activate"),
-          ]),
-        "arguments": [
-          FunctionCallArgument({
-            "name": None,
-            "value":
-              LiteralExpression(
-                Array(
-                  constraints
-                  |> List.map(def =>
-                       SwiftIdentifier(formatConstraintVariableName(def))
-                     ),
-                ),
-              ),
-          }),
-        ],
-      });
-    let assignConstraint = def =>
-      BinaryExpression({
-        "left":
-          MemberExpression([
-            SwiftIdentifier("self"),
-            SwiftIdentifier(formatConstraintVariableName(def)),
-          ]),
-        "operator": "=",
-        "right": SwiftIdentifier(formatConstraintVariableName(def)),
-      });
-    let assignConstraintIdentifier = def =>
-      BinaryExpression({
-        "left":
-          MemberExpression([
-            SwiftIdentifier(formatConstraintVariableName(def)),
-            SwiftIdentifier("identifier"),
-          ]),
-        "operator": "=",
-        "right":
-          LiteralExpression(String(formatConstraintVariableName(def))),
-      });
-    FunctionDeclaration({
-      "name": "setUpConstraints",
-      "modifiers": [AccessLevelModifier(PrivateModifier)],
-      "parameters": [],
-      "result": None,
-      "throws": false,
-      "body":
-        SwiftDocument.joinGroups(
-          Empty,
-          [
-            root |> Layer.flatmap(translatesAutoresizingMask),
-            constraints |> List.map(defineConstraint),
-            constraints
-            |> List.filter(def => Constraint.getPriority(def) == Low)
-            |> List.map(setConstraintPriority),
-            List.length(constraints) > 0 ? [activateConstraints()] : [],
-            constraints |> List.map(assignConstraint),
-            List.length(constraints) > 0 ?
-              [
-                LineComment("For debugging"),
-                ...constraints |> List.map(assignConstraintIdentifier),
-              ] :
-              [],
-          ],
-        ),
-    });
-  };
+
   let updateDoc = () => {
     /* let printStringBinding = ((key, value)) => Js.log2(key, value);
        let printLayerBinding = ((key: Types.layer, value)) => {
@@ -1084,6 +737,8 @@ let generate =
           ),
     });
   };
+  let constraints =
+    SwiftConstraint.calculateConstraints(getComponent, rootLayer);
   TopLevelDeclaration({
     "statements":
       SwiftDocument.joinGroups(
@@ -1142,11 +797,21 @@ let generate =
                     constraints
                     |> List.map(def =>
                          constraintVariableDoc(
-                           formatConstraintVariableName(def),
+                           SwiftConstraint.formatConstraintVariableName(
+                             rootLayer,
+                             def,
+                           ),
                          )
                        ),
                     [setUpViewsDoc(rootLayer)],
-                    [setUpConstraintsDoc(rootLayer)],
+                    [
+                      SwiftConstraint.setUpFunction(
+                        swiftOptions,
+                        getComponent,
+                        layerMemberExpression,
+                        rootLayer,
+                      ),
+                    ],
                     [updateDoc()],
                     needsTracking ?
                       AppkitPressable.mouseTrackingFunctions(

--- a/compiler/core/src/swift/swiftComponent.re
+++ b/compiler/core/src/swift/swiftComponent.re
@@ -1,12 +1,6 @@
-module Ast = SwiftAst;
-
-module Document = SwiftDocument;
-
-module Render = SwiftRender;
-
 type constraintDefinition = {
   variableName: string,
-  initialValue: Ast.node,
+  initialValue: SwiftAst.node,
   priority: Constraint.layoutPriority,
 };
 
@@ -15,12 +9,6 @@ type directionParameter = {
   swiftName: string,
 };
 
-/* type parameterAssignmentMode =
-   | Initialized
-   | AlwaysAssigned
-   | ConditionallyAssigned
-   | InitializedAndAlwaysAssigned
-   | InitializedAndConditionallyAssigned; */
 let isFunctionParameter = (param: Types.parameter) =>
   param.ltype == Types.handlerType;
 
@@ -104,7 +92,7 @@ let generate =
     Layer.logicAssignmentsFromLayerParameters(rootLayer);
   let assignments = Layer.parameterAssignmentsFromLogic(rootLayer, logic);
   let parameters = json |> Decode.Component.parameters;
-  open Ast;
+  open SwiftAst;
   let priorityName =
     fun
     | Constraint.Required => "required"
@@ -407,7 +395,7 @@ let generate =
       "failable": None,
       "throws": false,
       "body":
-        Document.joinGroups(
+        SwiftDocument.joinGroups(
           Empty,
           [
             parameters
@@ -457,7 +445,7 @@ let generate =
       "failable": None,
       "throws": false,
       "body":
-        Document.joinGroups(
+        SwiftDocument.joinGroups(
           Empty,
           [
             [
@@ -477,7 +465,7 @@ let generate =
                                ),
                              ),
                            "value":
-                             Document.defaultValueForLonaType(
+                             SwiftDocument.defaultValueForLonaType(
                                swiftOptions.framework,
                                colors,
                                textStyles,
@@ -696,7 +684,7 @@ let generate =
       "result": None,
       "throws": false,
       "body":
-        Document.joinGroups(
+        SwiftDocument.joinGroups(
           Empty,
           [
             Layer.flatmap(resetViewStyling, root) |> List.concat,
@@ -1030,7 +1018,7 @@ let generate =
       "result": None,
       "throws": false,
       "body":
-        Document.joinGroups(
+        SwiftDocument.joinGroups(
           Empty,
           [
             root |> Layer.flatmap(translatesAutoresizingMask),
@@ -1104,7 +1092,7 @@ let generate =
   };
   TopLevelDeclaration({
     "statements":
-      Document.joinGroups(
+      SwiftDocument.joinGroups(
         Empty,
         [
           [
@@ -1120,7 +1108,7 @@ let generate =
               "modifier": Some(PublicModifier),
               "isFinal": false,
               "body":
-                Document.joinGroups(
+                SwiftDocument.joinGroups(
                   Empty,
                   [
                     [Empty, LineComment("MARK: Lifecycle")],

--- a/compiler/core/src/swift/swiftComponent.re
+++ b/compiler/core/src/swift/swiftComponent.re
@@ -447,26 +447,21 @@ module Doc = {
         rootLayer: Types.layer,
         logic,
       ) => {
-    let filterParameters = ((name, _)) =>
-      name != ParameterKey.PaddingTop
-      && name != PaddingRight
-      && name != PaddingBottom
-      && name != PaddingLeft
-      && name != MarginTop
-      && name != MarginRight
-      && name != MarginBottom
-      && name != MarginLeft;
     let conditionallyAssigned = Logic.conditionallyAssignedIdentifiers(logic);
-    let filterConditionallyAssigned = (layer: Types.layer, (name, _)) => {
-      let isAssigned = ((_, value)) =>
-        value == ["layers", layer.name, name |> ParameterKey.toString];
-      conditionallyAssigned |> Logic.IdentifierSet.exists(isAssigned);
-    };
+
+    let isConditionallyAssigned = (layer: Types.layer, (key, _)) =>
+      conditionallyAssigned
+      |> Logic.IdentifierSet.exists(((_, value)) =>
+           value == ["layers", layer.name, key |> ParameterKey.toString]
+         );
+
     let defineInitialLayerValues = ((layer, propertyMap)) =>
       propertyMap
       |> ParameterMap.bindings
-      |> List.filter(filterParameters)
-      |> List.filter(filterConditionallyAssigned(layer))
+      |> List.filter(((key, _)) =>
+           !SwiftComponentParameter.isPaddingOrMargin(key)
+         )
+      |> List.filter(isConditionallyAssigned(layer))
       |> List.map(
            defineInitialLayerValue(
              swiftOptions,

--- a/compiler/core/src/swift/swiftComponentParameter.re
+++ b/compiler/core/src/swift/swiftComponentParameter.re
@@ -1,8 +1,3 @@
-/* type directionParameter = {
-     lonaName: ParameterKey.t,
-     swiftName: string,
-   }; */
-
 let isFunction = (param: Types.parameter) => param.ltype == Types.handlerType;
 
 let isSetInitially = (layer: Types.layer, parameter) =>
@@ -23,14 +18,27 @@ let isUsed = (assignments, layer: Types.layer, parameter) =>
   isAssigned(assignments, layer, parameter)
   || isSetInitially(layer, parameter);
 
-/* let paddingParameters = [
+let paddingAndMarginKeys = [
+  ParameterKey.PaddingTop,
+  PaddingRight,
+  PaddingBottom,
+  PaddingLeft,
+  MarginTop,
+  MarginRight,
+  MarginBottom,
+  MarginLeft,
+];
+
+let isPaddingOrMargin = key => List.mem(key, paddingAndMarginKeys);
+
+/* let paddingParameterNameTranslations = [
      {swiftName: "topPadding", lonaName: PaddingTop},
      {swiftName: "trailingPadding", lonaName: PaddingRight},
      {swiftName: "bottomPadding", lonaName: PaddingBottom},
      {swiftName: "leadingPadding", lonaName: PaddingLeft},
    ];
 
-   let marginParameters = [
+   let marginParameterNameTranslations = [
      {swiftName: "topMargin", lonaName: MarginTop},
      {swiftName: "trailingMargin", lonaName: MarginRight},
      {swiftName: "bottomMargin", lonaName: MarginBottom},

--- a/compiler/core/src/swift/swiftComponentParameter.re
+++ b/compiler/core/src/swift/swiftComponentParameter.re
@@ -1,0 +1,38 @@
+/* type directionParameter = {
+     lonaName: ParameterKey.t,
+     swiftName: string,
+   }; */
+
+let isFunction = (param: Types.parameter) => param.ltype == Types.handlerType;
+
+let isSetInitially = (layer: Types.layer, parameter) =>
+  ParameterMap.mem(parameter, layer.parameters);
+
+let get = (layer: Types.layer, parameter) =>
+  ParameterMap.find_opt(parameter, layer.parameters);
+
+let isAssigned = (assignments, layer: Types.layer, parameter) => {
+  let assignedParameters = Layer.LayerMap.find_opt(layer, assignments);
+  switch (assignedParameters) {
+  | Some(parameters) => ParameterMap.mem(parameter, parameters)
+  | None => false
+  };
+};
+
+let isUsed = (assignments, layer: Types.layer, parameter) =>
+  isAssigned(assignments, layer, parameter)
+  || isSetInitially(layer, parameter);
+
+/* let paddingParameters = [
+     {swiftName: "topPadding", lonaName: PaddingTop},
+     {swiftName: "trailingPadding", lonaName: PaddingRight},
+     {swiftName: "bottomPadding", lonaName: PaddingBottom},
+     {swiftName: "leadingPadding", lonaName: PaddingLeft},
+   ];
+
+   let marginParameters = [
+     {swiftName: "topMargin", lonaName: MarginTop},
+     {swiftName: "trailingMargin", lonaName: MarginRight},
+     {swiftName: "bottomMargin", lonaName: MarginBottom},
+     {swiftName: "leadingMargin", lonaName: MarginLeft},
+   ]; */

--- a/compiler/core/src/swift/swiftConstraint.re
+++ b/compiler/core/src/swift/swiftConstraint.re
@@ -1,0 +1,388 @@
+let negateNumber = expression =>
+  SwiftAst.PrefixExpression({"operator": "-", "expression": expression});
+
+let priorityName =
+  fun
+  | Constraint.Required => "required"
+  | Low => "defaultLow";
+
+let constantExpression =
+    (
+      rootLayer: Types.layer,
+      layer: Types.layer,
+      variable1,
+      parent: Types.layer,
+      variable2,
+    ) => {
+  let variableName = (layer: Types.layer, variable) =>
+    layer === rootLayer ?
+      variable :
+      SwiftFormat.layerName(layer.name) ++ Format.upperFirst(variable);
+  SwiftAst.(
+    BinaryExpression({
+      "left": SwiftIdentifier(variableName(layer, variable1)),
+      "operator": "+",
+      "right": SwiftIdentifier(variableName(parent, variable2)),
+    })
+  );
+};
+
+let generateWithInitialValue =
+    (layerMemberExpression, constr: Constraint.t, node) =>
+  SwiftAst.(
+    switch (constr) {
+    | Constraint.Dimension((layer: Types.layer), dimension, _, _) =>
+      layerMemberExpression(
+        layer,
+        [
+          SwiftIdentifier(Constraint.anchorToString(dimension)),
+          FunctionCallExpression({
+            "name": SwiftIdentifier("constraint"),
+            "arguments": [
+              FunctionCallArgument({
+                "name": Some(SwiftIdentifier("equalToConstant")),
+                "value": node,
+              }),
+            ],
+          }),
+        ],
+      )
+    | Constraint.Relation(
+        (layer1: Types.layer),
+        edge1,
+        relation,
+        (layer2: Types.layer),
+        edge2,
+        _,
+        _,
+      ) =>
+      layerMemberExpression(
+        layer1,
+        [
+          SwiftIdentifier(Constraint.anchorToString(edge1)),
+          FunctionCallExpression({
+            "name": SwiftIdentifier("constraint"),
+            "arguments": [
+              FunctionCallArgument({
+                "name":
+                  Some(SwiftIdentifier(Constraint.cmpToString(relation))),
+                "value":
+                  layerMemberExpression(
+                    layer2,
+                    [SwiftIdentifier(Constraint.anchorToString(edge2))],
+                  ),
+              }),
+              FunctionCallArgument({
+                "name": Some(SwiftIdentifier("constant")),
+                "value": node,
+              }),
+            ],
+          }),
+        ],
+      )
+    }
+  );
+
+let generateConstantFromConstraint =
+    (rootLayer: Types.layer, constr: Constraint.t) =>
+  SwiftAst.(
+    Constraint.(
+      switch (constr) {
+      /* Currently centering doesn't require any constants, since a centered view also
+         has a pair of before/after constraints that include the constants */
+      | Relation(_, CenterX, _, _, CenterX, _, _)
+      | Relation(_, CenterY, _, _, CenterY, _, _) =>
+        LiteralExpression(FloatingPoint(0.0))
+      | Relation(child, Top, _, layer, Top, _, PrimaryBefore)
+      | Relation(child, Top, _, layer, Top, _, SecondaryBefore) =>
+        constantExpression(rootLayer, layer, "topPadding", child, "topMargin")
+      | Relation(child, Leading, _, layer, Leading, _, PrimaryBefore)
+      | Relation(child, Leading, _, layer, Leading, _, SecondaryBefore) =>
+        constantExpression(
+          rootLayer,
+          layer,
+          "leadingPadding",
+          child,
+          "leadingMargin",
+        )
+      | Relation(child, Bottom, _, layer, Bottom, _, PrimaryAfter)
+      | Relation(child, Bottom, _, layer, Bottom, _, SecondaryAfter) =>
+        negateNumber(
+          constantExpression(
+            rootLayer,
+            layer,
+            "bottomPadding",
+            child,
+            "bottomMargin",
+          ),
+        )
+      | Relation(child, Trailing, _, layer, Trailing, _, SecondaryAfter)
+      | Relation(child, Trailing, _, layer, Trailing, _, PrimaryAfter) =>
+        negateNumber(
+          constantExpression(
+            rootLayer,
+            layer,
+            "trailingPadding",
+            child,
+            "trailingMargin",
+          ),
+        )
+      | Relation(child, Top, _, previousLayer, Bottom, _, PrimaryBetween) =>
+        constantExpression(
+          rootLayer,
+          previousLayer,
+          "bottomMargin",
+          child,
+          "topMargin",
+        )
+      | Relation(
+          child,
+          Leading,
+          _,
+          previousLayer,
+          Trailing,
+          _,
+          PrimaryBetween,
+        ) =>
+        constantExpression(
+          rootLayer,
+          previousLayer,
+          "trailingMargin",
+          child,
+          "leadingMargin",
+        )
+      | Relation(child, Width, Leq, layer, Width, _, FitContentSecondary) =>
+        negateNumber(
+          BinaryExpression({
+            "left":
+              constantExpression(
+                rootLayer,
+                layer,
+                "leadingPadding",
+                child,
+                "leadingMargin",
+              ),
+            "operator": "+",
+            "right":
+              constantExpression(
+                rootLayer,
+                layer,
+                "trailingPadding",
+                child,
+                "trailingMargin",
+              ),
+          }),
+        )
+      | Relation(child, Height, Leq, layer, Height, _, FitContentSecondary) =>
+        negateNumber(
+          BinaryExpression({
+            "left":
+              constantExpression(
+                rootLayer,
+                layer,
+                "topPadding",
+                child,
+                "topMargin",
+              ),
+            "operator": "+",
+            "right":
+              constantExpression(
+                rootLayer,
+                layer,
+                "bottomPadding",
+                child,
+                "bottomMargin",
+              ),
+          }),
+        )
+      | Relation(_, _, _, _, _, _, FlexSibling) =>
+        LiteralExpression(FloatingPoint(0.0))
+      | Dimension((layer: Types.layer), Height, _, _) =>
+        let constant = Layer.getNumberParameter(Height, layer);
+        LiteralExpression(FloatingPoint(constant));
+      | Dimension((layer: Types.layer), Width, _, _) =>
+        let constant = Layer.getNumberParameter(Width, layer);
+        LiteralExpression(FloatingPoint(constant));
+      | _ =>
+        Js.log("Unknown constraint types");
+        raise(Not_found);
+      }
+    )
+  );
+
+let formatConstraintVariableName =
+    (rootLayer: Types.layer, constr: Constraint.t) => {
+  open Constraint;
+  let formatAnchorVariableName = (layer: Types.layer, anchor, suffix) => {
+    let anchorString = Constraint.anchorToString(anchor);
+    (
+      layer === rootLayer ?
+        anchorString :
+        SwiftFormat.layerName(layer.name) ++ Format.upperFirst(anchorString)
+    )
+    ++ suffix;
+  };
+  switch (constr) {
+  | Relation(
+      (layer1: Types.layer),
+      edge1,
+      _,
+      (layer2: Types.layer),
+      _,
+      _,
+      FlexSibling,
+    ) =>
+    SwiftFormat.layerName(layer1.name)
+    ++ Format.upperFirst(SwiftFormat.layerName(layer2.name))
+    ++ Format.upperFirst(Constraint.anchorToString(edge1))
+    ++ "SiblingConstraint"
+  | Relation((layer1: Types.layer), edge1, _, _, _, _, FitContentSecondary) =>
+    formatAnchorVariableName(layer1, edge1, "ParentConstraint")
+  | Relation((layer1: Types.layer), edge1, _, _, _, _, _) =>
+    formatAnchorVariableName(layer1, edge1, "Constraint")
+  | Dimension((layer: Types.layer), dimension, _, _) =>
+    formatAnchorVariableName(layer, dimension, "Constraint")
+  };
+};
+
+let calculateConstraints = (getComponent, rootLayer: Types.layer) =>
+  Constraint.getConstraints(
+    /* For the purposes of layouts, we want to swap the custom component layer
+       with the root layer from the custom component's definition. We should
+       use the parameters of the custom component's root layer, since these
+       determine layout. We should still use the type, name, and children of
+       the custom component layer. */
+    (layer: Types.layer, name) => {
+      let component = getComponent(name);
+      let rootLayer = component |> Decode.Component.rootLayer(getComponent);
+      {
+        typeName: layer.typeName,
+        styles: layer.styles,
+        name: layer.name,
+        parameters: rootLayer.parameters,
+        children: layer.children,
+      };
+    },
+    rootLayer,
+  );
+
+let setUpFunction =
+    (
+      swiftOptions: SwiftOptions.options,
+      getComponent,
+      layerMemberExpression,
+      root: Types.layer,
+    ) => {
+  open SwiftAst;
+  let constraints = calculateConstraints(getComponent, root);
+  let translatesAutoresizingMask = (layer: Types.layer) =>
+    BinaryExpression({
+      "left":
+        layerMemberExpression(
+          layer,
+          [SwiftIdentifier("translatesAutoresizingMaskIntoConstraints")],
+        ),
+      "operator": "=",
+      "right": LiteralExpression(Boolean(false)),
+    });
+  let getInitialValue = constr =>
+    generateWithInitialValue(
+      layerMemberExpression,
+      constr,
+      generateConstantFromConstraint(root, constr),
+    );
+  let defineConstraint = def =>
+    ConstantDeclaration({
+      "modifiers": [],
+      "init": Some(getInitialValue(def)),
+      "pattern":
+        IdentifierPattern({
+          "identifier":
+            SwiftIdentifier(formatConstraintVariableName(root, def)),
+          "annotation": None,
+        }),
+    });
+  let setConstraintPriority = def =>
+    BinaryExpression({
+      "left":
+        MemberExpression([
+          SwiftIdentifier(formatConstraintVariableName(root, def)),
+          SwiftIdentifier("priority"),
+        ]),
+      "operator": "=",
+      "right":
+        MemberExpression([
+          SwiftDocument.layoutPriorityTypeDoc(swiftOptions.framework),
+          SwiftIdentifier(priorityName(Constraint.getPriority(def))),
+        ]),
+    });
+  let activateConstraints = () =>
+    FunctionCallExpression({
+      "name":
+        MemberExpression([
+          SwiftIdentifier("NSLayoutConstraint"),
+          SwiftIdentifier("activate"),
+        ]),
+      "arguments": [
+        FunctionCallArgument({
+          "name": None,
+          "value":
+            LiteralExpression(
+              Array(
+                constraints
+                |> List.map(def =>
+                     SwiftIdentifier(formatConstraintVariableName(root, def))
+                   ),
+              ),
+            ),
+        }),
+      ],
+    });
+  let assignConstraint = def =>
+    BinaryExpression({
+      "left":
+        MemberExpression([
+          SwiftIdentifier("self"),
+          SwiftIdentifier(formatConstraintVariableName(root, def)),
+        ]),
+      "operator": "=",
+      "right": SwiftIdentifier(formatConstraintVariableName(root, def)),
+    });
+  let assignConstraintIdentifier = def =>
+    BinaryExpression({
+      "left":
+        MemberExpression([
+          SwiftIdentifier(formatConstraintVariableName(root, def)),
+          SwiftIdentifier("identifier"),
+        ]),
+      "operator": "=",
+      "right":
+        LiteralExpression(String(formatConstraintVariableName(root, def))),
+    });
+  FunctionDeclaration({
+    "name": "setUpConstraints",
+    "modifiers": [AccessLevelModifier(PrivateModifier)],
+    "parameters": [],
+    "result": None,
+    "throws": false,
+    "body":
+      SwiftDocument.joinGroups(
+        Empty,
+        [
+          root |> Layer.flatmap(translatesAutoresizingMask),
+          constraints |> List.map(defineConstraint),
+          constraints
+          |> List.filter(def => Constraint.getPriority(def) == Low)
+          |> List.map(setConstraintPriority),
+          List.length(constraints) > 0 ? [activateConstraints()] : [],
+          constraints |> List.map(assignConstraint),
+          List.length(constraints) > 0 ?
+            [
+              LineComment("For debugging"),
+              ...constraints |> List.map(assignConstraintIdentifier),
+            ] :
+            [],
+        ],
+      ),
+  });
+};

--- a/compiler/core/src/swift/swiftConstraint.re
+++ b/compiler/core/src/swift/swiftConstraint.re
@@ -6,63 +6,6 @@ let priorityName =
   | Constraint.Required => "required"
   | Low => "defaultLow";
 
-let constantExpression =
-    (
-      swiftOptions: SwiftOptions.options,
-      colors,
-      textStyles,
-      assignmentsFromLayerParameters,
-      rootLayer: Types.layer,
-      layer: Types.layer,
-      variable1: ParameterKey.t,
-      parent: Types.layer,
-      variable2: ParameterKey.t,
-    )
-    : option(SwiftAst.node) => {
-  let variableName = (layer: Types.layer, variable: ParameterKey.t) => {
-    let variableNameString = variable |> ParameterKey.toString;
-
-    layer === rootLayer ?
-      variableNameString :
-      SwiftFormat.layerName(layer.name)
-      ++ Format.upperFirst(variableNameString);
-  };
-
-  switch (
-    SwiftComponentParameter.get(layer, variable1),
-    SwiftComponentParameter.get(layer, variable2),
-  ) {
-  | (None, None) => None
-  | (Some(a), None)
-  | (None, Some(a)) =>
-    Some(
-      SwiftDocument.lonaValue(swiftOptions.framework, colors, textStyles, a),
-    )
-  | (Some(a), Some(b)) =>
-    Some(
-      SwiftAst.(
-        BinaryExpression({
-          "left":
-            SwiftDocument.lonaValue(
-              swiftOptions.framework,
-              colors,
-              textStyles,
-              a,
-            ),
-          "operator": "+",
-          "right":
-            SwiftDocument.lonaValue(
-              swiftOptions.framework,
-              colors,
-              textStyles,
-              b,
-            ),
-        })
-      ),
-    )
-  };
-};
-
 let generateWithInitialValue =
     (
       layerMemberExpression,
@@ -365,7 +308,6 @@ let setUpFunction =
       colors,
       textStyles,
       getComponent,
-      assignmentsFromLayerParameters,
       assignmentsFromLogic,
       layerMemberExpression,
       root: Types.layer,

--- a/compiler/core/src/swift/swiftConstraint.re
+++ b/compiler/core/src/swift/swiftConstraint.re
@@ -78,16 +78,16 @@ let generateWithInitialValue =
           SwiftIdentifier(Constraint.anchorToString(dimension)),
           FunctionCallExpression({
             "name": SwiftIdentifier("constraint"),
-            "arguments":
-              switch (constantAst) {
-              | None => []
-              | Some(ast) => [
-                  FunctionCallArgument({
-                    "name": Some(SwiftIdentifier("equalToConstant")),
-                    "value": ast,
-                  }),
-                ]
-              },
+            "arguments": [
+              FunctionCallArgument({
+                "name": Some(SwiftIdentifier("equalToConstant")),
+                "value":
+                  switch (constantAst) {
+                  | None => LiteralExpression(FloatingPoint(0.0))
+                  | Some(ast) => ast
+                  },
+              }),
+            ],
           }),
         ],
       )

--- a/compiler/core/src/swift/swiftDocument.re
+++ b/compiler/core/src/swift/swiftDocument.re
@@ -100,6 +100,7 @@ let rec typeAnnotationDoc =
   | Types.Reference(typeName) =>
     switch (typeName) {
     | "Boolean" => TypeName("Bool")
+    | "Number" => TypeName("CGFloat")
     | "URL" =>
       typeAnnotationDoc(framework, Types.Named(typeName, Types.stringType))
     | "Color" =>

--- a/compiler/core/src/swift/swiftLogic.re
+++ b/compiler/core/src/swift/swiftLogic.re
@@ -54,7 +54,7 @@ let toSwiftAST =
           |> Js.String.includes("margin")
           || name
           |> Js.String.includes("padding") =>
-      Ast.LineComment("TODO: Margin & padding")
+      Ast.LineComment("TODO: Margin & padding: " ++ name)
     | (_, Ast.SwiftIdentifier(name))
         when name |> Js.String.endsWith("height") =>
       Ast.SwiftIdentifier(

--- a/compiler/core/src/swift/swiftOptions.re
+++ b/compiler/core/src/swift/swiftOptions.re
@@ -11,5 +11,6 @@ let frameworkToString =
 [@bs.deriving jsConverter]
 type options = {
   framework,
+  debugConstraints: bool,
   typePrefix: string,
 };

--- a/examples/LonaViewer/LonaViewer.xcodeproj/project.pbxproj
+++ b/examples/LonaViewer/LonaViewer.xcodeproj/project.pbxproj
@@ -54,6 +54,8 @@
 		301C262820C1C5BF00F18F73 /* TextStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 301C262720C1C5BF00F18F73 /* TextStyle.swift */; };
 		30F870B920864A88007ADA5B /* NestedButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30F870B820864A88007ADA5B /* NestedButtons.swift */; };
 		30F870BB20864AEE007ADA5B /* Button.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30F870BA20864AEE007ADA5B /* Button.swift */; };
+		6B3916FD21601C5900B20F9E /* BoxModelConditional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3916FC21601C5900B20F9E /* BoxModelConditional.swift */; };
+		6B3916FF2160286D00B20F9E /* BoxModelConditional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3916FE2160286D00B20F9E /* BoxModelConditional.swift */; };
 		6BA694032082E4420090CA74 /* NestedComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA694022082E4420090CA74 /* NestedComponent.swift */; };
 		6BA69406208439DB0090CA74 /* NestedComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA69405208439DB0090CA74 /* NestedComponent.swift */; };
 		6BA6940820843CE70090CA74 /* Button.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA6940720843CE70090CA74 /* Button.swift */; };
@@ -115,6 +117,8 @@
 		301C262720C1C5BF00F18F73 /* TextStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextStyle.swift; sourceTree = "<group>"; };
 		30F870B820864A88007ADA5B /* NestedButtons.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NestedButtons.swift; sourceTree = "<group>"; };
 		30F870BA20864AEE007ADA5B /* Button.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Button.swift; sourceTree = "<group>"; };
+		6B3916FC21601C5900B20F9E /* BoxModelConditional.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BoxModelConditional.swift; sourceTree = "<group>"; };
+		6B3916FE2160286D00B20F9E /* BoxModelConditional.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BoxModelConditional.swift; sourceTree = "<group>"; };
 		6BA694022082E4420090CA74 /* NestedComponent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NestedComponent.swift; sourceTree = "<group>"; };
 		6BA69405208439DB0090CA74 /* NestedComponent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NestedComponent.swift; sourceTree = "<group>"; };
 		6BA6940720843CE70090CA74 /* Button.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Button.swift; sourceTree = "<group>"; };
@@ -230,6 +234,7 @@
 			isa = PBXGroup;
 			children = (
 				12BBFDCC206B02720041620C /* BorderWidthColor.swift */,
+				6B3916FE2160286D00B20F9E /* BoxModelConditional.swift */,
 				6BD581DC208252250068FBC3 /* TextAlignment.swift */,
 				12BBFDCD206B02720041620C /* TextStylesTest.swift */,
 				12BBFDCE206B02720041620C /* TextStyleConditional.swift */,
@@ -305,6 +310,7 @@
 			isa = PBXGroup;
 			children = (
 				12BBFDF4206B02AC0041620C /* BorderWidthColor.swift */,
+				6B3916FC21601C5900B20F9E /* BoxModelConditional.swift */,
 				6BD581DA2082521A0068FBC3 /* TextAlignment.swift */,
 				12BBFDF5206B02AC0041620C /* TextStylesTest.swift */,
 				12BBFDF6206B02AC0041620C /* TextStyleConditional.swift */,
@@ -470,6 +476,7 @@
 				12BBFE0F206B02AC0041620C /* FitContentParentSecondaryChildren.swift in Sources */,
 				12BBFE10206B02AC0041620C /* PrimaryAxis.swift in Sources */,
 				128693A7204A1DC200E5E26F /* LayoutExtension.swift in Sources */,
+				6B3916FD21601C5900B20F9E /* BoxModelConditional.swift in Sources */,
 				12BBFE0A206B02AC0041620C /* TextStyleConditional.swift in Sources */,
 				1296255E204B2DC20057CDFF /* DetailVC.swift in Sources */,
 				6BA69406208439DB0090CA74 /* NestedComponent.swift in Sources */,
@@ -504,6 +511,7 @@
 				12BBFDDE206B02720041620C /* If.swift in Sources */,
 				12BBFDE0206B02720041620C /* TextStylesTest.swift in Sources */,
 				12BBFE14206B03FB0041620C /* LayoutExtension.swift in Sources */,
+				6B3916FF2160286D00B20F9E /* BoxModelConditional.swift in Sources */,
 				12869397204A1B4E00E5E26F /* ViewSelectionVc.swift in Sources */,
 				12BBFDE4206B02720041620C /* FixedParentFitChild.swift in Sources */,
 				6BA6940A208441120090CA74 /* NestedButtons.swift in Sources */,

--- a/examples/LonaViewer/MacOS/Generated.swift
+++ b/examples/LonaViewer/MacOS/Generated.swift
@@ -27,6 +27,8 @@ enum Generated: String {
     case textStyleConditionalFalse = "Text Style Conditional - False"
     case textStylesTest = "Text Styles Test"
     case textAlignment = "Text Alignment"
+    case boxModelConditionalSmall = "Box Model Conditional Small"
+    case boxModelConditionalLarge = "Box Model Conditional Large"
 
     static func allValues() -> [Generated] {
         return [
@@ -48,6 +50,8 @@ enum Generated: String {
             textStyleConditionalFalse,
             textStylesTest,
             textAlignment,
+            boxModelConditionalSmall,
+            boxModelConditionalLarge,
         ]
     }
 
@@ -61,7 +65,7 @@ enum Generated: String {
             return NestedButtons()
         case .button:
             var count = 0
-            let button = Button(label: "Tapped \(count)")
+            let button = Button(label: "Tapped \(count)", secondary: false)
             button.onTap = {
                 count += 1
                 button.label = "Tapped \(count)"
@@ -95,6 +99,10 @@ enum Generated: String {
             return TextStylesTest()
         case .textAlignment:
             return TextAlignment()
+        case .boxModelConditionalSmall:
+            return BoxModelConditional(margin: 4, size: 60)
+        case .boxModelConditionalLarge:
+            return BoxModelConditional(margin: 20, size: 120)
         }
     }
 
@@ -115,7 +123,9 @@ enum Generated: String {
              .secondaryAxis,
              .borderWidthColor,
              .textAlignment,
-             .fitContentParentSecondaryChildren:
+             .fitContentParentSecondaryChildren,
+             .boxModelConditionalSmall,
+             .boxModelConditionalLarge:
             return [
                 equal(\.topAnchor),
                 equal(\.leftAnchor),

--- a/examples/LonaViewer/iOS/Generated.swift
+++ b/examples/LonaViewer/iOS/Generated.swift
@@ -27,6 +27,8 @@ enum Generated: String {
     case textStyleConditionalFalse = "Text Style Conditional - False"
     case textStylesTest = "Text Styles Test"
     case textAlignment = "Text Alignment"
+    case boxModelConditionalSmall = "Box Model Conditional Small"
+    case boxModelConditionalLarge = "Box Model Conditional Large"
 
     static func allValues() -> [Generated] {
         return [
@@ -48,6 +50,8 @@ enum Generated: String {
             textStyleConditionalFalse,
             textStylesTest,
             textAlignment,
+            boxModelConditionalSmall,
+            boxModelConditionalLarge,
         ]
     }
     
@@ -61,7 +65,7 @@ enum Generated: String {
             return NestedButtons()
         case .button:
             var count = 0
-            let button = Button(label: "Tapped \(count)")
+            let button = Button(label: "Tapped \(count)", secondary: false)
             button.onTap = {
                 count += 1
                 button.label = "Tapped \(count)"
@@ -95,6 +99,10 @@ enum Generated: String {
             return TextStylesTest()
         case .textAlignment:
             return TextAlignment()
+        case .boxModelConditionalSmall:
+            return BoxModelConditional(margin: 4, size: 60)
+        case .boxModelConditionalLarge:
+            return BoxModelConditional(margin: 20, size: 120)
         }
     }
 
@@ -114,7 +122,9 @@ enum Generated: String {
              .secondaryAxis,
              .borderWidthColor,
              .textAlignment,
-             .fitContentParentSecondaryChildren:
+             .fitContentParentSecondaryChildren,
+             .boxModelConditionalSmall,
+             .boxModelConditionalLarge:
             return [
                 equal(\.topAnchor, \.safeAreaLayoutGuide.topAnchor),
                 equal(\.leftAnchor),

--- a/examples/generated/test/appkit/components/NestedButtons.swift
+++ b/examples/generated/test/appkit/components/NestedButtons.swift
@@ -26,35 +26,6 @@ public class NestedButtons: NSBox {
   private var view1View = NSBox()
   private var button2View = Button()
 
-  private var topPadding: CGFloat = 24
-  private var trailingPadding: CGFloat = 24
-  private var bottomPadding: CGFloat = 24
-  private var leadingPadding: CGFloat = 24
-  private var buttonViewTopMargin: CGFloat = 0
-  private var buttonViewTrailingMargin: CGFloat = 0
-  private var buttonViewBottomMargin: CGFloat = 0
-  private var buttonViewLeadingMargin: CGFloat = 0
-  private var view1ViewTopMargin: CGFloat = 0
-  private var view1ViewTrailingMargin: CGFloat = 0
-  private var view1ViewBottomMargin: CGFloat = 0
-  private var view1ViewLeadingMargin: CGFloat = 0
-  private var button2ViewTopMargin: CGFloat = 0
-  private var button2ViewTrailingMargin: CGFloat = 0
-  private var button2ViewBottomMargin: CGFloat = 0
-  private var button2ViewLeadingMargin: CGFloat = 0
-
-  private var buttonViewTopAnchorConstraint: NSLayoutConstraint?
-  private var buttonViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var buttonViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var view1ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var view1ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var view1ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var button2ViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var button2ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var button2ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var button2ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var view1ViewHeightAnchorConstraint: NSLayoutConstraint?
-
   private func setUpViews() {
     boxType = .custom
     borderType = .noBorder
@@ -77,36 +48,20 @@ public class NestedButtons: NSBox {
     view1View.translatesAutoresizingMaskIntoConstraints = false
     button2View.translatesAutoresizingMaskIntoConstraints = false
 
-    let buttonViewTopAnchorConstraint = buttonView
-      .topAnchor
-      .constraint(equalTo: topAnchor, constant: topPadding + buttonViewTopMargin)
-    let buttonViewLeadingAnchorConstraint = buttonView
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + buttonViewLeadingMargin)
+    let buttonViewTopAnchorConstraint = buttonView.topAnchor.constraint(equalTo: topAnchor, constant: 24)
+    let buttonViewLeadingAnchorConstraint = buttonView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24)
     let buttonViewTrailingAnchorConstraint = buttonView
       .trailingAnchor
-      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -(trailingPadding + buttonViewTrailingMargin))
-    let view1ViewTopAnchorConstraint = view1View
-      .topAnchor
-      .constraint(equalTo: buttonView.bottomAnchor, constant: buttonViewBottomMargin + view1ViewTopMargin)
-    let view1ViewLeadingAnchorConstraint = view1View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + view1ViewLeadingMargin)
-    let view1ViewTrailingAnchorConstraint = view1View
-      .trailingAnchor
-      .constraint(equalTo: trailingAnchor, constant: -(trailingPadding + view1ViewTrailingMargin))
-    let button2ViewBottomAnchorConstraint = button2View
-      .bottomAnchor
-      .constraint(equalTo: bottomAnchor, constant: -(bottomPadding + button2ViewBottomMargin))
-    let button2ViewTopAnchorConstraint = button2View
-      .topAnchor
-      .constraint(equalTo: view1View.bottomAnchor, constant: view1ViewBottomMargin + button2ViewTopMargin)
-    let button2ViewLeadingAnchorConstraint = button2View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + button2ViewLeadingMargin)
+      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -24)
+    let view1ViewTopAnchorConstraint = view1View.topAnchor.constraint(equalTo: buttonView.bottomAnchor)
+    let view1ViewLeadingAnchorConstraint = view1View.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24)
+    let view1ViewTrailingAnchorConstraint = view1View.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -24)
+    let button2ViewBottomAnchorConstraint = button2View.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -24)
+    let button2ViewTopAnchorConstraint = button2View.topAnchor.constraint(equalTo: view1View.bottomAnchor)
+    let button2ViewLeadingAnchorConstraint = button2View.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24)
     let button2ViewTrailingAnchorConstraint = button2View
       .trailingAnchor
-      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -(trailingPadding + button2ViewTrailingMargin))
+      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -24)
     let view1ViewHeightAnchorConstraint = view1View.heightAnchor.constraint(equalToConstant: 8)
 
     NSLayoutConstraint.activate([
@@ -122,31 +77,6 @@ public class NestedButtons: NSBox {
       button2ViewTrailingAnchorConstraint,
       view1ViewHeightAnchorConstraint
     ])
-
-    self.buttonViewTopAnchorConstraint = buttonViewTopAnchorConstraint
-    self.buttonViewLeadingAnchorConstraint = buttonViewLeadingAnchorConstraint
-    self.buttonViewTrailingAnchorConstraint = buttonViewTrailingAnchorConstraint
-    self.view1ViewTopAnchorConstraint = view1ViewTopAnchorConstraint
-    self.view1ViewLeadingAnchorConstraint = view1ViewLeadingAnchorConstraint
-    self.view1ViewTrailingAnchorConstraint = view1ViewTrailingAnchorConstraint
-    self.button2ViewBottomAnchorConstraint = button2ViewBottomAnchorConstraint
-    self.button2ViewTopAnchorConstraint = button2ViewTopAnchorConstraint
-    self.button2ViewLeadingAnchorConstraint = button2ViewLeadingAnchorConstraint
-    self.button2ViewTrailingAnchorConstraint = button2ViewTrailingAnchorConstraint
-    self.view1ViewHeightAnchorConstraint = view1ViewHeightAnchorConstraint
-
-    // For debugging
-    buttonViewTopAnchorConstraint.identifier = "buttonViewTopAnchorConstraint"
-    buttonViewLeadingAnchorConstraint.identifier = "buttonViewLeadingAnchorConstraint"
-    buttonViewTrailingAnchorConstraint.identifier = "buttonViewTrailingAnchorConstraint"
-    view1ViewTopAnchorConstraint.identifier = "view1ViewTopAnchorConstraint"
-    view1ViewLeadingAnchorConstraint.identifier = "view1ViewLeadingAnchorConstraint"
-    view1ViewTrailingAnchorConstraint.identifier = "view1ViewTrailingAnchorConstraint"
-    button2ViewBottomAnchorConstraint.identifier = "button2ViewBottomAnchorConstraint"
-    button2ViewTopAnchorConstraint.identifier = "button2ViewTopAnchorConstraint"
-    button2ViewLeadingAnchorConstraint.identifier = "button2ViewLeadingAnchorConstraint"
-    button2ViewTrailingAnchorConstraint.identifier = "button2ViewTrailingAnchorConstraint"
-    view1ViewHeightAnchorConstraint.identifier = "view1ViewHeightAnchorConstraint"
   }
 
   private func update() {}

--- a/examples/generated/test/appkit/components/NestedComponent.swift
+++ b/examples/generated/test/appkit/components/NestedComponent.swift
@@ -77,14 +77,12 @@ public class NestedComponent: NSBox {
       .constraint(equalTo: trailingAnchor, constant: -10)
     let text1ViewTopAnchorConstraint = text1View
       .topAnchor
-      .constraint(equalTo: fitContentParentSecondaryChildrenView.bottomAnchor)
+      .constraint(equalTo: fitContentParentSecondaryChildrenView.bottomAnchor, constant: 12)
     let text1ViewLeadingAnchorConstraint = text1View.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10)
     let text1ViewTrailingAnchorConstraint = text1View
       .trailingAnchor
       .constraint(lessThanOrEqualTo: trailingAnchor, constant: -10)
-    let localAssetViewTopAnchorConstraint = localAssetView
-      .topAnchor
-      .constraint(equalTo: text1View.bottomAnchor, constant: 12)
+    let localAssetViewTopAnchorConstraint = localAssetView.topAnchor.constraint(equalTo: text1View.bottomAnchor)
     let localAssetViewLeadingAnchorConstraint = localAssetView
       .leadingAnchor
       .constraint(equalTo: leadingAnchor, constant: 10)

--- a/examples/generated/test/appkit/components/NestedComponent.swift
+++ b/examples/generated/test/appkit/components/NestedComponent.swift
@@ -32,48 +32,6 @@ public class NestedComponent: NSBox {
   private var text1ViewTextStyle = TextStyles.body1
   private var text2ViewTextStyle = TextStyles.body1
 
-  private var topPadding: CGFloat = 10
-  private var trailingPadding: CGFloat = 10
-  private var bottomPadding: CGFloat = 10
-  private var leadingPadding: CGFloat = 10
-  private var textViewTopMargin: CGFloat = 0
-  private var textViewTrailingMargin: CGFloat = 0
-  private var textViewBottomMargin: CGFloat = 8
-  private var textViewLeadingMargin: CGFloat = 0
-  private var fitContentParentSecondaryChildrenViewTopMargin: CGFloat = 0
-  private var fitContentParentSecondaryChildrenViewTrailingMargin: CGFloat = 0
-  private var fitContentParentSecondaryChildrenViewBottomMargin: CGFloat = 0
-  private var fitContentParentSecondaryChildrenViewLeadingMargin: CGFloat = 0
-  private var text1ViewTopMargin: CGFloat = 12
-  private var text1ViewTrailingMargin: CGFloat = 0
-  private var text1ViewBottomMargin: CGFloat = 0
-  private var text1ViewLeadingMargin: CGFloat = 0
-  private var localAssetViewTopMargin: CGFloat = 0
-  private var localAssetViewTrailingMargin: CGFloat = 0
-  private var localAssetViewBottomMargin: CGFloat = 0
-  private var localAssetViewLeadingMargin: CGFloat = 0
-  private var text2ViewTopMargin: CGFloat = 0
-  private var text2ViewTrailingMargin: CGFloat = 0
-  private var text2ViewBottomMargin: CGFloat = 0
-  private var text2ViewLeadingMargin: CGFloat = 0
-
-  private var textViewTopAnchorConstraint: NSLayoutConstraint?
-  private var textViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var textViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var fitContentParentSecondaryChildrenViewTopAnchorConstraint: NSLayoutConstraint?
-  private var fitContentParentSecondaryChildrenViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var fitContentParentSecondaryChildrenViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var text1ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var text1ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var text1ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var localAssetViewTopAnchorConstraint: NSLayoutConstraint?
-  private var localAssetViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var localAssetViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var text2ViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var text2ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var text2ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var text2ViewTrailingAnchorConstraint: NSLayoutConstraint?
-
   private func setUpViews() {
     boxType = .custom
     borderType = .noBorder
@@ -103,60 +61,42 @@ public class NestedComponent: NSBox {
     localAssetView.translatesAutoresizingMaskIntoConstraints = false
     text2View.translatesAutoresizingMaskIntoConstraints = false
 
-    let textViewTopAnchorConstraint = textView
-      .topAnchor
-      .constraint(equalTo: topAnchor, constant: topPadding + textViewTopMargin)
-    let textViewLeadingAnchorConstraint = textView
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + textViewLeadingMargin)
+    let textViewTopAnchorConstraint = textView.topAnchor.constraint(equalTo: topAnchor, constant: 10)
+    let textViewLeadingAnchorConstraint = textView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10)
     let textViewTrailingAnchorConstraint = textView
       .trailingAnchor
-      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -(trailingPadding + textViewTrailingMargin))
+      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -10)
     let fitContentParentSecondaryChildrenViewTopAnchorConstraint = fitContentParentSecondaryChildrenView
       .topAnchor
-      .constraint(
-        equalTo: textView.bottomAnchor,
-        constant: textViewBottomMargin + fitContentParentSecondaryChildrenViewTopMargin)
+      .constraint(equalTo: textView.bottomAnchor, constant: 8)
     let fitContentParentSecondaryChildrenViewLeadingAnchorConstraint = fitContentParentSecondaryChildrenView
       .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + fitContentParentSecondaryChildrenViewLeadingMargin)
+      .constraint(equalTo: leadingAnchor, constant: 10)
     let fitContentParentSecondaryChildrenViewTrailingAnchorConstraint = fitContentParentSecondaryChildrenView
       .trailingAnchor
-      .constraint(
-        equalTo: trailingAnchor,
-        constant: -(trailingPadding + fitContentParentSecondaryChildrenViewTrailingMargin))
+      .constraint(equalTo: trailingAnchor, constant: -10)
     let text1ViewTopAnchorConstraint = text1View
       .topAnchor
-      .constraint(
-        equalTo: fitContentParentSecondaryChildrenView.bottomAnchor,
-        constant: fitContentParentSecondaryChildrenViewBottomMargin + text1ViewTopMargin)
-    let text1ViewLeadingAnchorConstraint = text1View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + text1ViewLeadingMargin)
+      .constraint(equalTo: fitContentParentSecondaryChildrenView.bottomAnchor)
+    let text1ViewLeadingAnchorConstraint = text1View.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10)
     let text1ViewTrailingAnchorConstraint = text1View
       .trailingAnchor
-      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -(trailingPadding + text1ViewTrailingMargin))
+      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -10)
     let localAssetViewTopAnchorConstraint = localAssetView
       .topAnchor
-      .constraint(equalTo: text1View.bottomAnchor, constant: text1ViewBottomMargin + localAssetViewTopMargin)
+      .constraint(equalTo: text1View.bottomAnchor, constant: 12)
     let localAssetViewLeadingAnchorConstraint = localAssetView
       .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + localAssetViewLeadingMargin)
+      .constraint(equalTo: leadingAnchor, constant: 10)
     let localAssetViewTrailingAnchorConstraint = localAssetView
       .trailingAnchor
-      .constraint(equalTo: trailingAnchor, constant: -(trailingPadding + localAssetViewTrailingMargin))
-    let text2ViewBottomAnchorConstraint = text2View
-      .bottomAnchor
-      .constraint(equalTo: bottomAnchor, constant: -(bottomPadding + text2ViewBottomMargin))
-    let text2ViewTopAnchorConstraint = text2View
-      .topAnchor
-      .constraint(equalTo: localAssetView.bottomAnchor, constant: localAssetViewBottomMargin + text2ViewTopMargin)
-    let text2ViewLeadingAnchorConstraint = text2View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + text2ViewLeadingMargin)
+      .constraint(equalTo: trailingAnchor, constant: -10)
+    let text2ViewBottomAnchorConstraint = text2View.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -10)
+    let text2ViewTopAnchorConstraint = text2View.topAnchor.constraint(equalTo: localAssetView.bottomAnchor)
+    let text2ViewLeadingAnchorConstraint = text2View.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10)
     let text2ViewTrailingAnchorConstraint = text2View
       .trailingAnchor
-      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -(trailingPadding + text2ViewTrailingMargin))
+      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -10)
 
     NSLayoutConstraint.activate([
       textViewTopAnchorConstraint,
@@ -176,47 +116,6 @@ public class NestedComponent: NSBox {
       text2ViewLeadingAnchorConstraint,
       text2ViewTrailingAnchorConstraint
     ])
-
-    self.textViewTopAnchorConstraint = textViewTopAnchorConstraint
-    self.textViewLeadingAnchorConstraint = textViewLeadingAnchorConstraint
-    self.textViewTrailingAnchorConstraint = textViewTrailingAnchorConstraint
-    self.fitContentParentSecondaryChildrenViewTopAnchorConstraint =
-      fitContentParentSecondaryChildrenViewTopAnchorConstraint
-    self.fitContentParentSecondaryChildrenViewLeadingAnchorConstraint =
-      fitContentParentSecondaryChildrenViewLeadingAnchorConstraint
-    self.fitContentParentSecondaryChildrenViewTrailingAnchorConstraint =
-      fitContentParentSecondaryChildrenViewTrailingAnchorConstraint
-    self.text1ViewTopAnchorConstraint = text1ViewTopAnchorConstraint
-    self.text1ViewLeadingAnchorConstraint = text1ViewLeadingAnchorConstraint
-    self.text1ViewTrailingAnchorConstraint = text1ViewTrailingAnchorConstraint
-    self.localAssetViewTopAnchorConstraint = localAssetViewTopAnchorConstraint
-    self.localAssetViewLeadingAnchorConstraint = localAssetViewLeadingAnchorConstraint
-    self.localAssetViewTrailingAnchorConstraint = localAssetViewTrailingAnchorConstraint
-    self.text2ViewBottomAnchorConstraint = text2ViewBottomAnchorConstraint
-    self.text2ViewTopAnchorConstraint = text2ViewTopAnchorConstraint
-    self.text2ViewLeadingAnchorConstraint = text2ViewLeadingAnchorConstraint
-    self.text2ViewTrailingAnchorConstraint = text2ViewTrailingAnchorConstraint
-
-    // For debugging
-    textViewTopAnchorConstraint.identifier = "textViewTopAnchorConstraint"
-    textViewLeadingAnchorConstraint.identifier = "textViewLeadingAnchorConstraint"
-    textViewTrailingAnchorConstraint.identifier = "textViewTrailingAnchorConstraint"
-    fitContentParentSecondaryChildrenViewTopAnchorConstraint.identifier =
-      "fitContentParentSecondaryChildrenViewTopAnchorConstraint"
-    fitContentParentSecondaryChildrenViewLeadingAnchorConstraint.identifier =
-      "fitContentParentSecondaryChildrenViewLeadingAnchorConstraint"
-    fitContentParentSecondaryChildrenViewTrailingAnchorConstraint.identifier =
-      "fitContentParentSecondaryChildrenViewTrailingAnchorConstraint"
-    text1ViewTopAnchorConstraint.identifier = "text1ViewTopAnchorConstraint"
-    text1ViewLeadingAnchorConstraint.identifier = "text1ViewLeadingAnchorConstraint"
-    text1ViewTrailingAnchorConstraint.identifier = "text1ViewTrailingAnchorConstraint"
-    localAssetViewTopAnchorConstraint.identifier = "localAssetViewTopAnchorConstraint"
-    localAssetViewLeadingAnchorConstraint.identifier = "localAssetViewLeadingAnchorConstraint"
-    localAssetViewTrailingAnchorConstraint.identifier = "localAssetViewTrailingAnchorConstraint"
-    text2ViewBottomAnchorConstraint.identifier = "text2ViewBottomAnchorConstraint"
-    text2ViewTopAnchorConstraint.identifier = "text2ViewTopAnchorConstraint"
-    text2ViewLeadingAnchorConstraint.identifier = "text2ViewLeadingAnchorConstraint"
-    text2ViewTrailingAnchorConstraint.identifier = "text2ViewTrailingAnchorConstraint"
   }
 
   private func update() {}

--- a/examples/generated/test/appkit/images/LocalAsset.swift
+++ b/examples/generated/test/appkit/images/LocalAsset.swift
@@ -37,21 +37,6 @@ public class LocalAsset: NSBox {
 
   private var imageView = ImageWithBackgroundColor()
 
-  private var topPadding: CGFloat = 0
-  private var trailingPadding: CGFloat = 0
-  private var bottomPadding: CGFloat = 0
-  private var leadingPadding: CGFloat = 0
-  private var imageViewTopMargin: CGFloat = 0
-  private var imageViewTrailingMargin: CGFloat = 0
-  private var imageViewBottomMargin: CGFloat = 0
-  private var imageViewLeadingMargin: CGFloat = 0
-
-  private var imageViewTopAnchorConstraint: NSLayoutConstraint?
-  private var imageViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var imageViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var imageViewHeightAnchorConstraint: NSLayoutConstraint?
-  private var imageViewWidthAnchorConstraint: NSLayoutConstraint?
-
   private func setUpViews() {
     boxType = .custom
     borderType = .noBorder
@@ -67,15 +52,9 @@ public class LocalAsset: NSBox {
     translatesAutoresizingMaskIntoConstraints = false
     imageView.translatesAutoresizingMaskIntoConstraints = false
 
-    let imageViewTopAnchorConstraint = imageView
-      .topAnchor
-      .constraint(equalTo: topAnchor, constant: topPadding + imageViewTopMargin)
-    let imageViewBottomAnchorConstraint = imageView
-      .bottomAnchor
-      .constraint(equalTo: bottomAnchor, constant: -(bottomPadding + imageViewBottomMargin))
-    let imageViewLeadingAnchorConstraint = imageView
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + imageViewLeadingMargin)
+    let imageViewTopAnchorConstraint = imageView.topAnchor.constraint(equalTo: topAnchor)
+    let imageViewBottomAnchorConstraint = imageView.bottomAnchor.constraint(equalTo: bottomAnchor)
+    let imageViewLeadingAnchorConstraint = imageView.leadingAnchor.constraint(equalTo: leadingAnchor)
     let imageViewHeightAnchorConstraint = imageView.heightAnchor.constraint(equalToConstant: 100)
     let imageViewWidthAnchorConstraint = imageView.widthAnchor.constraint(equalToConstant: 100)
 
@@ -86,19 +65,6 @@ public class LocalAsset: NSBox {
       imageViewHeightAnchorConstraint,
       imageViewWidthAnchorConstraint
     ])
-
-    self.imageViewTopAnchorConstraint = imageViewTopAnchorConstraint
-    self.imageViewBottomAnchorConstraint = imageViewBottomAnchorConstraint
-    self.imageViewLeadingAnchorConstraint = imageViewLeadingAnchorConstraint
-    self.imageViewHeightAnchorConstraint = imageViewHeightAnchorConstraint
-    self.imageViewWidthAnchorConstraint = imageViewWidthAnchorConstraint
-
-    // For debugging
-    imageViewTopAnchorConstraint.identifier = "imageViewTopAnchorConstraint"
-    imageViewBottomAnchorConstraint.identifier = "imageViewBottomAnchorConstraint"
-    imageViewLeadingAnchorConstraint.identifier = "imageViewLeadingAnchorConstraint"
-    imageViewHeightAnchorConstraint.identifier = "imageViewHeightAnchorConstraint"
-    imageViewWidthAnchorConstraint.identifier = "imageViewWidthAnchorConstraint"
   }
 
   private func update() {}

--- a/examples/generated/test/appkit/interactivity/Button.swift
+++ b/examples/generated/test/appkit/interactivity/Button.swift
@@ -50,24 +50,9 @@ public class Button: NSBox {
 
   private var textViewTextStyle = TextStyles.button
 
-  private var topPadding: CGFloat = 12
-  private var trailingPadding: CGFloat = 16
-  private var bottomPadding: CGFloat = 12
-  private var leadingPadding: CGFloat = 16
-  private var textViewTopMargin: CGFloat = 0
-  private var textViewTrailingMargin: CGFloat = 0
-  private var textViewBottomMargin: CGFloat = 0
-  private var textViewLeadingMargin: CGFloat = 0
-
   private var hovered = false
   private var pressed = false
   private var onPress: (() -> Void)?
-
-  private var textViewWidthAnchorParentConstraint: NSLayoutConstraint?
-  private var textViewTopAnchorConstraint: NSLayoutConstraint?
-  private var textViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var textViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var textViewTrailingAnchorConstraint: NSLayoutConstraint?
 
   private func setUpViews() {
     boxType = .custom
@@ -87,21 +72,11 @@ public class Button: NSBox {
 
     let textViewWidthAnchorParentConstraint = textView
       .widthAnchor
-      .constraint(
-        lessThanOrEqualTo: widthAnchor,
-        constant: -(leadingPadding + textViewLeadingMargin + trailingPadding + textViewTrailingMargin))
-    let textViewTopAnchorConstraint = textView
-      .topAnchor
-      .constraint(equalTo: topAnchor, constant: topPadding + textViewTopMargin)
-    let textViewBottomAnchorConstraint = textView
-      .bottomAnchor
-      .constraint(equalTo: bottomAnchor, constant: -(bottomPadding + textViewBottomMargin))
-    let textViewLeadingAnchorConstraint = textView
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + textViewLeadingMargin)
-    let textViewTrailingAnchorConstraint = textView
-      .trailingAnchor
-      .constraint(equalTo: trailingAnchor, constant: -(trailingPadding + textViewTrailingMargin))
+      .constraint(lessThanOrEqualTo: widthAnchor, constant: -(16 + 16))
+    let textViewTopAnchorConstraint = textView.topAnchor.constraint(equalTo: topAnchor, constant: 12)
+    let textViewBottomAnchorConstraint = textView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -12)
+    let textViewLeadingAnchorConstraint = textView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16)
+    let textViewTrailingAnchorConstraint = textView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16)
 
     textViewWidthAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
 
@@ -112,19 +87,6 @@ public class Button: NSBox {
       textViewLeadingAnchorConstraint,
       textViewTrailingAnchorConstraint
     ])
-
-    self.textViewWidthAnchorParentConstraint = textViewWidthAnchorParentConstraint
-    self.textViewTopAnchorConstraint = textViewTopAnchorConstraint
-    self.textViewBottomAnchorConstraint = textViewBottomAnchorConstraint
-    self.textViewLeadingAnchorConstraint = textViewLeadingAnchorConstraint
-    self.textViewTrailingAnchorConstraint = textViewTrailingAnchorConstraint
-
-    // For debugging
-    textViewWidthAnchorParentConstraint.identifier = "textViewWidthAnchorParentConstraint"
-    textViewTopAnchorConstraint.identifier = "textViewTopAnchorConstraint"
-    textViewBottomAnchorConstraint.identifier = "textViewBottomAnchorConstraint"
-    textViewLeadingAnchorConstraint.identifier = "textViewLeadingAnchorConstraint"
-    textViewTrailingAnchorConstraint.identifier = "textViewTrailingAnchorConstraint"
   }
 
   private func update() {

--- a/examples/generated/test/appkit/interactivity/Button.swift
+++ b/examples/generated/test/appkit/interactivity/Button.swift
@@ -72,7 +72,7 @@ public class Button: NSBox {
 
     let textViewWidthAnchorParentConstraint = textView
       .widthAnchor
-      .constraint(lessThanOrEqualTo: widthAnchor, constant: -(16 + 16))
+      .constraint(lessThanOrEqualTo: widthAnchor, constant: -32)
     let textViewTopAnchorConstraint = textView.topAnchor.constraint(equalTo: topAnchor, constant: 12)
     let textViewBottomAnchorConstraint = textView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -12)
     let textViewLeadingAnchorConstraint = textView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16)

--- a/examples/generated/test/appkit/interactivity/PressableRootView.swift
+++ b/examples/generated/test/appkit/interactivity/PressableRootView.swift
@@ -43,38 +43,12 @@ public class PressableRootView: NSBox {
 
   private var innerTextViewTextStyle = TextStyles.headline
 
-  private var topPadding: CGFloat = 24
-  private var trailingPadding: CGFloat = 24
-  private var bottomPadding: CGFloat = 24
-  private var leadingPadding: CGFloat = 24
-  private var innerViewTopMargin: CGFloat = 0
-  private var innerViewTrailingMargin: CGFloat = 0
-  private var innerViewBottomMargin: CGFloat = 0
-  private var innerViewLeadingMargin: CGFloat = 0
-  private var innerViewTopPadding: CGFloat = 0
-  private var innerViewTrailingPadding: CGFloat = 0
-  private var innerViewBottomPadding: CGFloat = 0
-  private var innerViewLeadingPadding: CGFloat = 0
-  private var innerTextViewTopMargin: CGFloat = 0
-  private var innerTextViewTrailingMargin: CGFloat = 0
-  private var innerTextViewBottomMargin: CGFloat = 0
-  private var innerTextViewLeadingMargin: CGFloat = 0
-
   private var hovered = false
   private var pressed = false
   private var onPress: (() -> Void)?
   private var innerViewHovered = false
   private var innerViewPressed = false
   private var innerViewOnPress: (() -> Void)?
-
-  private var innerViewTopAnchorConstraint: NSLayoutConstraint?
-  private var innerViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var innerViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var innerViewHeightAnchorConstraint: NSLayoutConstraint?
-  private var innerViewWidthAnchorConstraint: NSLayoutConstraint?
-  private var innerTextViewTopAnchorConstraint: NSLayoutConstraint?
-  private var innerTextViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var innerTextViewTrailingAnchorConstraint: NSLayoutConstraint?
 
   private func setUpViews() {
     boxType = .custom
@@ -97,28 +71,16 @@ public class PressableRootView: NSBox {
     innerView.translatesAutoresizingMaskIntoConstraints = false
     innerTextView.translatesAutoresizingMaskIntoConstraints = false
 
-    let innerViewTopAnchorConstraint = innerView
-      .topAnchor
-      .constraint(equalTo: topAnchor, constant: topPadding + innerViewTopMargin)
-    let innerViewBottomAnchorConstraint = innerView
-      .bottomAnchor
-      .constraint(equalTo: bottomAnchor, constant: -(bottomPadding + innerViewBottomMargin))
-    let innerViewLeadingAnchorConstraint = innerView
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + innerViewLeadingMargin)
+    let innerViewTopAnchorConstraint = innerView.topAnchor.constraint(equalTo: topAnchor, constant: 24)
+    let innerViewBottomAnchorConstraint = innerView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -24)
+    let innerViewLeadingAnchorConstraint = innerView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24)
     let innerViewHeightAnchorConstraint = innerView.heightAnchor.constraint(equalToConstant: 100)
     let innerViewWidthAnchorConstraint = innerView.widthAnchor.constraint(equalToConstant: 100)
-    let innerTextViewTopAnchorConstraint = innerTextView
-      .topAnchor
-      .constraint(equalTo: innerView.topAnchor, constant: innerViewTopPadding + innerTextViewTopMargin)
-    let innerTextViewLeadingAnchorConstraint = innerTextView
-      .leadingAnchor
-      .constraint(equalTo: innerView.leadingAnchor, constant: innerViewLeadingPadding + innerTextViewLeadingMargin)
+    let innerTextViewTopAnchorConstraint = innerTextView.topAnchor.constraint(equalTo: innerView.topAnchor)
+    let innerTextViewLeadingAnchorConstraint = innerTextView.leadingAnchor.constraint(equalTo: innerView.leadingAnchor)
     let innerTextViewTrailingAnchorConstraint = innerTextView
       .trailingAnchor
-      .constraint(
-        equalTo: innerView.trailingAnchor,
-        constant: -(innerViewTrailingPadding + innerTextViewTrailingMargin))
+      .constraint(equalTo: innerView.trailingAnchor)
 
     NSLayoutConstraint.activate([
       innerViewTopAnchorConstraint,
@@ -130,25 +92,6 @@ public class PressableRootView: NSBox {
       innerTextViewLeadingAnchorConstraint,
       innerTextViewTrailingAnchorConstraint
     ])
-
-    self.innerViewTopAnchorConstraint = innerViewTopAnchorConstraint
-    self.innerViewBottomAnchorConstraint = innerViewBottomAnchorConstraint
-    self.innerViewLeadingAnchorConstraint = innerViewLeadingAnchorConstraint
-    self.innerViewHeightAnchorConstraint = innerViewHeightAnchorConstraint
-    self.innerViewWidthAnchorConstraint = innerViewWidthAnchorConstraint
-    self.innerTextViewTopAnchorConstraint = innerTextViewTopAnchorConstraint
-    self.innerTextViewLeadingAnchorConstraint = innerTextViewLeadingAnchorConstraint
-    self.innerTextViewTrailingAnchorConstraint = innerTextViewTrailingAnchorConstraint
-
-    // For debugging
-    innerViewTopAnchorConstraint.identifier = "innerViewTopAnchorConstraint"
-    innerViewBottomAnchorConstraint.identifier = "innerViewBottomAnchorConstraint"
-    innerViewLeadingAnchorConstraint.identifier = "innerViewLeadingAnchorConstraint"
-    innerViewHeightAnchorConstraint.identifier = "innerViewHeightAnchorConstraint"
-    innerViewWidthAnchorConstraint.identifier = "innerViewWidthAnchorConstraint"
-    innerTextViewTopAnchorConstraint.identifier = "innerTextViewTopAnchorConstraint"
-    innerTextViewLeadingAnchorConstraint.identifier = "innerTextViewLeadingAnchorConstraint"
-    innerTextViewTrailingAnchorConstraint.identifier = "innerTextViewTrailingAnchorConstraint"
   }
 
   private func update() {

--- a/examples/generated/test/appkit/layouts/FitContentParentSecondaryChildren.swift
+++ b/examples/generated/test/appkit/layouts/FitContentParentSecondaryChildren.swift
@@ -26,39 +26,6 @@ public class FitContentParentSecondaryChildren: NSBox {
   private var view3View = NSBox()
   private var view2View = NSBox()
 
-  private var topPadding: CGFloat = 24
-  private var trailingPadding: CGFloat = 24
-  private var bottomPadding: CGFloat = 24
-  private var leadingPadding: CGFloat = 24
-  private var view1ViewTopMargin: CGFloat = 0
-  private var view1ViewTrailingMargin: CGFloat = 0
-  private var view1ViewBottomMargin: CGFloat = 0
-  private var view1ViewLeadingMargin: CGFloat = 0
-  private var view3ViewTopMargin: CGFloat = 0
-  private var view3ViewTrailingMargin: CGFloat = 0
-  private var view3ViewBottomMargin: CGFloat = 0
-  private var view3ViewLeadingMargin: CGFloat = 0
-  private var view2ViewTopMargin: CGFloat = 0
-  private var view2ViewTrailingMargin: CGFloat = 0
-  private var view2ViewBottomMargin: CGFloat = 0
-  private var view2ViewLeadingMargin: CGFloat = 0
-
-  private var view1ViewHeightAnchorParentConstraint: NSLayoutConstraint?
-  private var view3ViewHeightAnchorParentConstraint: NSLayoutConstraint?
-  private var view2ViewHeightAnchorParentConstraint: NSLayoutConstraint?
-  private var view1ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var view1ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var view3ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var view3ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var view2ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var view2ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var view1ViewHeightAnchorConstraint: NSLayoutConstraint?
-  private var view1ViewWidthAnchorConstraint: NSLayoutConstraint?
-  private var view3ViewHeightAnchorConstraint: NSLayoutConstraint?
-  private var view3ViewWidthAnchorConstraint: NSLayoutConstraint?
-  private var view2ViewHeightAnchorConstraint: NSLayoutConstraint?
-  private var view2ViewWidthAnchorConstraint: NSLayoutConstraint?
-
   private func setUpViews() {
     boxType = .custom
     borderType = .noBorder
@@ -91,37 +58,19 @@ public class FitContentParentSecondaryChildren: NSBox {
 
     let view1ViewHeightAnchorParentConstraint = view1View
       .heightAnchor
-      .constraint(
-        lessThanOrEqualTo: heightAnchor,
-        constant: -(topPadding + view1ViewTopMargin + bottomPadding + view1ViewBottomMargin))
+      .constraint(lessThanOrEqualTo: heightAnchor, constant: -(24 + 24))
     let view3ViewHeightAnchorParentConstraint = view3View
       .heightAnchor
-      .constraint(
-        lessThanOrEqualTo: heightAnchor,
-        constant: -(topPadding + view3ViewTopMargin + bottomPadding + view3ViewBottomMargin))
+      .constraint(lessThanOrEqualTo: heightAnchor, constant: -(24 + 24))
     let view2ViewHeightAnchorParentConstraint = view2View
       .heightAnchor
-      .constraint(
-        lessThanOrEqualTo: heightAnchor,
-        constant: -(topPadding + view2ViewTopMargin + bottomPadding + view2ViewBottomMargin))
-    let view1ViewLeadingAnchorConstraint = view1View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + view1ViewLeadingMargin)
-    let view1ViewTopAnchorConstraint = view1View
-      .topAnchor
-      .constraint(equalTo: topAnchor, constant: topPadding + view1ViewTopMargin)
-    let view3ViewLeadingAnchorConstraint = view3View
-      .leadingAnchor
-      .constraint(equalTo: view1View.trailingAnchor, constant: view1ViewTrailingMargin + view3ViewLeadingMargin)
-    let view3ViewTopAnchorConstraint = view3View
-      .topAnchor
-      .constraint(equalTo: topAnchor, constant: topPadding + view3ViewTopMargin)
-    let view2ViewLeadingAnchorConstraint = view2View
-      .leadingAnchor
-      .constraint(equalTo: view3View.trailingAnchor, constant: view3ViewTrailingMargin + view2ViewLeadingMargin)
-    let view2ViewTopAnchorConstraint = view2View
-      .topAnchor
-      .constraint(equalTo: topAnchor, constant: topPadding + view2ViewTopMargin)
+      .constraint(lessThanOrEqualTo: heightAnchor, constant: -(24 + 24))
+    let view1ViewLeadingAnchorConstraint = view1View.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24)
+    let view1ViewTopAnchorConstraint = view1View.topAnchor.constraint(equalTo: topAnchor, constant: 24)
+    let view3ViewLeadingAnchorConstraint = view3View.leadingAnchor.constraint(equalTo: view1View.trailingAnchor)
+    let view3ViewTopAnchorConstraint = view3View.topAnchor.constraint(equalTo: topAnchor, constant: 24)
+    let view2ViewLeadingAnchorConstraint = view2View.leadingAnchor.constraint(equalTo: view3View.trailingAnchor)
+    let view2ViewTopAnchorConstraint = view2View.topAnchor.constraint(equalTo: topAnchor, constant: 24)
     let view1ViewHeightAnchorConstraint = view1View.heightAnchor.constraint(equalToConstant: 60)
     let view1ViewWidthAnchorConstraint = view1View.widthAnchor.constraint(equalToConstant: 60)
     let view3ViewHeightAnchorConstraint = view3View.heightAnchor.constraint(equalToConstant: 120)
@@ -150,39 +99,6 @@ public class FitContentParentSecondaryChildren: NSBox {
       view2ViewHeightAnchorConstraint,
       view2ViewWidthAnchorConstraint
     ])
-
-    self.view1ViewHeightAnchorParentConstraint = view1ViewHeightAnchorParentConstraint
-    self.view3ViewHeightAnchorParentConstraint = view3ViewHeightAnchorParentConstraint
-    self.view2ViewHeightAnchorParentConstraint = view2ViewHeightAnchorParentConstraint
-    self.view1ViewLeadingAnchorConstraint = view1ViewLeadingAnchorConstraint
-    self.view1ViewTopAnchorConstraint = view1ViewTopAnchorConstraint
-    self.view3ViewLeadingAnchorConstraint = view3ViewLeadingAnchorConstraint
-    self.view3ViewTopAnchorConstraint = view3ViewTopAnchorConstraint
-    self.view2ViewLeadingAnchorConstraint = view2ViewLeadingAnchorConstraint
-    self.view2ViewTopAnchorConstraint = view2ViewTopAnchorConstraint
-    self.view1ViewHeightAnchorConstraint = view1ViewHeightAnchorConstraint
-    self.view1ViewWidthAnchorConstraint = view1ViewWidthAnchorConstraint
-    self.view3ViewHeightAnchorConstraint = view3ViewHeightAnchorConstraint
-    self.view3ViewWidthAnchorConstraint = view3ViewWidthAnchorConstraint
-    self.view2ViewHeightAnchorConstraint = view2ViewHeightAnchorConstraint
-    self.view2ViewWidthAnchorConstraint = view2ViewWidthAnchorConstraint
-
-    // For debugging
-    view1ViewHeightAnchorParentConstraint.identifier = "view1ViewHeightAnchorParentConstraint"
-    view3ViewHeightAnchorParentConstraint.identifier = "view3ViewHeightAnchorParentConstraint"
-    view2ViewHeightAnchorParentConstraint.identifier = "view2ViewHeightAnchorParentConstraint"
-    view1ViewLeadingAnchorConstraint.identifier = "view1ViewLeadingAnchorConstraint"
-    view1ViewTopAnchorConstraint.identifier = "view1ViewTopAnchorConstraint"
-    view3ViewLeadingAnchorConstraint.identifier = "view3ViewLeadingAnchorConstraint"
-    view3ViewTopAnchorConstraint.identifier = "view3ViewTopAnchorConstraint"
-    view2ViewLeadingAnchorConstraint.identifier = "view2ViewLeadingAnchorConstraint"
-    view2ViewTopAnchorConstraint.identifier = "view2ViewTopAnchorConstraint"
-    view1ViewHeightAnchorConstraint.identifier = "view1ViewHeightAnchorConstraint"
-    view1ViewWidthAnchorConstraint.identifier = "view1ViewWidthAnchorConstraint"
-    view3ViewHeightAnchorConstraint.identifier = "view3ViewHeightAnchorConstraint"
-    view3ViewWidthAnchorConstraint.identifier = "view3ViewWidthAnchorConstraint"
-    view2ViewHeightAnchorConstraint.identifier = "view2ViewHeightAnchorConstraint"
-    view2ViewWidthAnchorConstraint.identifier = "view2ViewWidthAnchorConstraint"
   }
 
   private func update() {}

--- a/examples/generated/test/appkit/layouts/FitContentParentSecondaryChildren.swift
+++ b/examples/generated/test/appkit/layouts/FitContentParentSecondaryChildren.swift
@@ -58,13 +58,13 @@ public class FitContentParentSecondaryChildren: NSBox {
 
     let view1ViewHeightAnchorParentConstraint = view1View
       .heightAnchor
-      .constraint(lessThanOrEqualTo: heightAnchor, constant: -(24 + 24))
+      .constraint(lessThanOrEqualTo: heightAnchor, constant: -48)
     let view3ViewHeightAnchorParentConstraint = view3View
       .heightAnchor
-      .constraint(lessThanOrEqualTo: heightAnchor, constant: -(24 + 24))
+      .constraint(lessThanOrEqualTo: heightAnchor, constant: -48)
     let view2ViewHeightAnchorParentConstraint = view2View
       .heightAnchor
-      .constraint(lessThanOrEqualTo: heightAnchor, constant: -(24 + 24))
+      .constraint(lessThanOrEqualTo: heightAnchor, constant: -48)
     let view1ViewLeadingAnchorConstraint = view1View.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24)
     let view1ViewTopAnchorConstraint = view1View.topAnchor.constraint(equalTo: topAnchor, constant: 24)
     let view3ViewLeadingAnchorConstraint = view3View.leadingAnchor.constraint(equalTo: view1View.trailingAnchor)

--- a/examples/generated/test/appkit/layouts/FixedParentFillAndFitChildren.swift
+++ b/examples/generated/test/appkit/layouts/FixedParentFillAndFitChildren.swift
@@ -85,15 +85,17 @@ public class FixedParentFillAndFitChildren: NSBox {
     let view3ViewTrailingAnchorConstraint = view3View.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -24)
     let view4ViewHeightAnchorParentConstraint = view4View
       .heightAnchor
-      .constraint(lessThanOrEqualTo: view1View.heightAnchor, constant: -(24 + 24))
+      .constraint(lessThanOrEqualTo: view1View.heightAnchor, constant: -48)
     let view5ViewHeightAnchorParentConstraint = view5View
       .heightAnchor
-      .constraint(lessThanOrEqualTo: view1View.heightAnchor, constant: -(24 + 24))
+      .constraint(lessThanOrEqualTo: view1View.heightAnchor, constant: -48)
     let view4ViewLeadingAnchorConstraint = view4View
       .leadingAnchor
       .constraint(equalTo: view1View.leadingAnchor, constant: 24)
     let view4ViewTopAnchorConstraint = view4View.topAnchor.constraint(equalTo: view1View.topAnchor, constant: 24)
-    let view5ViewLeadingAnchorConstraint = view5View.leadingAnchor.constraint(equalTo: view4View.trailingAnchor)
+    let view5ViewLeadingAnchorConstraint = view5View
+      .leadingAnchor
+      .constraint(equalTo: view4View.trailingAnchor, constant: 12)
     let view5ViewTopAnchorConstraint = view5View.topAnchor.constraint(equalTo: view1View.topAnchor, constant: 24)
     let view4ViewHeightAnchorConstraint = view4View.heightAnchor.constraint(equalToConstant: 100)
     let view4ViewWidthAnchorConstraint = view4View.widthAnchor.constraint(equalToConstant: 60)

--- a/examples/generated/test/appkit/layouts/FixedParentFillAndFitChildren.swift
+++ b/examples/generated/test/appkit/layouts/FixedParentFillAndFitChildren.swift
@@ -28,58 +28,6 @@ public class FixedParentFillAndFitChildren: NSBox {
   private var view2View = NSBox()
   private var view3View = NSBox()
 
-  private var topPadding: CGFloat = 24
-  private var trailingPadding: CGFloat = 24
-  private var bottomPadding: CGFloat = 24
-  private var leadingPadding: CGFloat = 24
-  private var view1ViewTopMargin: CGFloat = 0
-  private var view1ViewTrailingMargin: CGFloat = 0
-  private var view1ViewBottomMargin: CGFloat = 0
-  private var view1ViewLeadingMargin: CGFloat = 0
-  private var view1ViewTopPadding: CGFloat = 24
-  private var view1ViewTrailingPadding: CGFloat = 24
-  private var view1ViewBottomPadding: CGFloat = 24
-  private var view1ViewLeadingPadding: CGFloat = 24
-  private var view2ViewTopMargin: CGFloat = 0
-  private var view2ViewTrailingMargin: CGFloat = 0
-  private var view2ViewBottomMargin: CGFloat = 0
-  private var view2ViewLeadingMargin: CGFloat = 0
-  private var view3ViewTopMargin: CGFloat = 0
-  private var view3ViewTrailingMargin: CGFloat = 0
-  private var view3ViewBottomMargin: CGFloat = 0
-  private var view3ViewLeadingMargin: CGFloat = 0
-  private var view4ViewTopMargin: CGFloat = 0
-  private var view4ViewTrailingMargin: CGFloat = 0
-  private var view4ViewBottomMargin: CGFloat = 0
-  private var view4ViewLeadingMargin: CGFloat = 0
-  private var view5ViewTopMargin: CGFloat = 0
-  private var view5ViewTrailingMargin: CGFloat = 0
-  private var view5ViewBottomMargin: CGFloat = 0
-  private var view5ViewLeadingMargin: CGFloat = 12
-
-  private var heightAnchorConstraint: NSLayoutConstraint?
-  private var view2ViewView3ViewHeightAnchorSiblingConstraint: NSLayoutConstraint?
-  private var view1ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var view1ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var view1ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var view2ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var view2ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var view2ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var view3ViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var view3ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var view3ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var view3ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var view4ViewHeightAnchorParentConstraint: NSLayoutConstraint?
-  private var view5ViewHeightAnchorParentConstraint: NSLayoutConstraint?
-  private var view4ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var view4ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var view5ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var view5ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var view4ViewHeightAnchorConstraint: NSLayoutConstraint?
-  private var view4ViewWidthAnchorConstraint: NSLayoutConstraint?
-  private var view5ViewHeightAnchorConstraint: NSLayoutConstraint?
-  private var view5ViewWidthAnchorConstraint: NSLayoutConstraint?
-
   private func setUpViews() {
     boxType = .custom
     borderType = .noBorder
@@ -124,59 +72,29 @@ public class FixedParentFillAndFitChildren: NSBox {
     let heightAnchorConstraint = heightAnchor.constraint(equalToConstant: 600)
     let view2ViewView3ViewHeightAnchorSiblingConstraint = view2View
       .heightAnchor
-      .constraint(equalTo: view3View.heightAnchor, constant: 0)
-    let view1ViewTopAnchorConstraint = view1View
-      .topAnchor
-      .constraint(equalTo: topAnchor, constant: topPadding + view1ViewTopMargin)
-    let view1ViewLeadingAnchorConstraint = view1View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + view1ViewLeadingMargin)
-    let view1ViewTrailingAnchorConstraint = view1View
-      .trailingAnchor
-      .constraint(equalTo: trailingAnchor, constant: -(trailingPadding + view1ViewTrailingMargin))
-    let view2ViewTopAnchorConstraint = view2View
-      .topAnchor
-      .constraint(equalTo: view1View.bottomAnchor, constant: view1ViewBottomMargin + view2ViewTopMargin)
-    let view2ViewLeadingAnchorConstraint = view2View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + view2ViewLeadingMargin)
-    let view2ViewTrailingAnchorConstraint = view2View
-      .trailingAnchor
-      .constraint(equalTo: trailingAnchor, constant: -(trailingPadding + view2ViewTrailingMargin))
-    let view3ViewBottomAnchorConstraint = view3View
-      .bottomAnchor
-      .constraint(equalTo: bottomAnchor, constant: -(bottomPadding + view3ViewBottomMargin))
-    let view3ViewTopAnchorConstraint = view3View
-      .topAnchor
-      .constraint(equalTo: view2View.bottomAnchor, constant: view2ViewBottomMargin + view3ViewTopMargin)
-    let view3ViewLeadingAnchorConstraint = view3View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + view3ViewLeadingMargin)
-    let view3ViewTrailingAnchorConstraint = view3View
-      .trailingAnchor
-      .constraint(equalTo: trailingAnchor, constant: -(trailingPadding + view3ViewTrailingMargin))
+      .constraint(equalTo: view3View.heightAnchor)
+    let view1ViewTopAnchorConstraint = view1View.topAnchor.constraint(equalTo: topAnchor, constant: 24)
+    let view1ViewLeadingAnchorConstraint = view1View.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24)
+    let view1ViewTrailingAnchorConstraint = view1View.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -24)
+    let view2ViewTopAnchorConstraint = view2View.topAnchor.constraint(equalTo: view1View.bottomAnchor)
+    let view2ViewLeadingAnchorConstraint = view2View.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24)
+    let view2ViewTrailingAnchorConstraint = view2View.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -24)
+    let view3ViewBottomAnchorConstraint = view3View.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -24)
+    let view3ViewTopAnchorConstraint = view3View.topAnchor.constraint(equalTo: view2View.bottomAnchor)
+    let view3ViewLeadingAnchorConstraint = view3View.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24)
+    let view3ViewTrailingAnchorConstraint = view3View.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -24)
     let view4ViewHeightAnchorParentConstraint = view4View
       .heightAnchor
-      .constraint(
-        lessThanOrEqualTo: view1View.heightAnchor,
-        constant: -(view1ViewTopPadding + view4ViewTopMargin + view1ViewBottomPadding + view4ViewBottomMargin))
+      .constraint(lessThanOrEqualTo: view1View.heightAnchor, constant: -(24 + 24))
     let view5ViewHeightAnchorParentConstraint = view5View
       .heightAnchor
-      .constraint(
-        lessThanOrEqualTo: view1View.heightAnchor,
-        constant: -(view1ViewTopPadding + view5ViewTopMargin + view1ViewBottomPadding + view5ViewBottomMargin))
+      .constraint(lessThanOrEqualTo: view1View.heightAnchor, constant: -(24 + 24))
     let view4ViewLeadingAnchorConstraint = view4View
       .leadingAnchor
-      .constraint(equalTo: view1View.leadingAnchor, constant: view1ViewLeadingPadding + view4ViewLeadingMargin)
-    let view4ViewTopAnchorConstraint = view4View
-      .topAnchor
-      .constraint(equalTo: view1View.topAnchor, constant: view1ViewTopPadding + view4ViewTopMargin)
-    let view5ViewLeadingAnchorConstraint = view5View
-      .leadingAnchor
-      .constraint(equalTo: view4View.trailingAnchor, constant: view4ViewTrailingMargin + view5ViewLeadingMargin)
-    let view5ViewTopAnchorConstraint = view5View
-      .topAnchor
-      .constraint(equalTo: view1View.topAnchor, constant: view1ViewTopPadding + view5ViewTopMargin)
+      .constraint(equalTo: view1View.leadingAnchor, constant: 24)
+    let view4ViewTopAnchorConstraint = view4View.topAnchor.constraint(equalTo: view1View.topAnchor, constant: 24)
+    let view5ViewLeadingAnchorConstraint = view5View.leadingAnchor.constraint(equalTo: view4View.trailingAnchor)
+    let view5ViewTopAnchorConstraint = view5View.topAnchor.constraint(equalTo: view1View.topAnchor, constant: 24)
     let view4ViewHeightAnchorConstraint = view4View.heightAnchor.constraint(equalToConstant: 100)
     let view4ViewWidthAnchorConstraint = view4View.widthAnchor.constraint(equalToConstant: 60)
     let view5ViewHeightAnchorConstraint = view5View.heightAnchor.constraint(equalToConstant: 60)
@@ -209,53 +127,6 @@ public class FixedParentFillAndFitChildren: NSBox {
       view5ViewHeightAnchorConstraint,
       view5ViewWidthAnchorConstraint
     ])
-
-    self.heightAnchorConstraint = heightAnchorConstraint
-    self.view2ViewView3ViewHeightAnchorSiblingConstraint = view2ViewView3ViewHeightAnchorSiblingConstraint
-    self.view1ViewTopAnchorConstraint = view1ViewTopAnchorConstraint
-    self.view1ViewLeadingAnchorConstraint = view1ViewLeadingAnchorConstraint
-    self.view1ViewTrailingAnchorConstraint = view1ViewTrailingAnchorConstraint
-    self.view2ViewTopAnchorConstraint = view2ViewTopAnchorConstraint
-    self.view2ViewLeadingAnchorConstraint = view2ViewLeadingAnchorConstraint
-    self.view2ViewTrailingAnchorConstraint = view2ViewTrailingAnchorConstraint
-    self.view3ViewBottomAnchorConstraint = view3ViewBottomAnchorConstraint
-    self.view3ViewTopAnchorConstraint = view3ViewTopAnchorConstraint
-    self.view3ViewLeadingAnchorConstraint = view3ViewLeadingAnchorConstraint
-    self.view3ViewTrailingAnchorConstraint = view3ViewTrailingAnchorConstraint
-    self.view4ViewHeightAnchorParentConstraint = view4ViewHeightAnchorParentConstraint
-    self.view5ViewHeightAnchorParentConstraint = view5ViewHeightAnchorParentConstraint
-    self.view4ViewLeadingAnchorConstraint = view4ViewLeadingAnchorConstraint
-    self.view4ViewTopAnchorConstraint = view4ViewTopAnchorConstraint
-    self.view5ViewLeadingAnchorConstraint = view5ViewLeadingAnchorConstraint
-    self.view5ViewTopAnchorConstraint = view5ViewTopAnchorConstraint
-    self.view4ViewHeightAnchorConstraint = view4ViewHeightAnchorConstraint
-    self.view4ViewWidthAnchorConstraint = view4ViewWidthAnchorConstraint
-    self.view5ViewHeightAnchorConstraint = view5ViewHeightAnchorConstraint
-    self.view5ViewWidthAnchorConstraint = view5ViewWidthAnchorConstraint
-
-    // For debugging
-    heightAnchorConstraint.identifier = "heightAnchorConstraint"
-    view2ViewView3ViewHeightAnchorSiblingConstraint.identifier = "view2ViewView3ViewHeightAnchorSiblingConstraint"
-    view1ViewTopAnchorConstraint.identifier = "view1ViewTopAnchorConstraint"
-    view1ViewLeadingAnchorConstraint.identifier = "view1ViewLeadingAnchorConstraint"
-    view1ViewTrailingAnchorConstraint.identifier = "view1ViewTrailingAnchorConstraint"
-    view2ViewTopAnchorConstraint.identifier = "view2ViewTopAnchorConstraint"
-    view2ViewLeadingAnchorConstraint.identifier = "view2ViewLeadingAnchorConstraint"
-    view2ViewTrailingAnchorConstraint.identifier = "view2ViewTrailingAnchorConstraint"
-    view3ViewBottomAnchorConstraint.identifier = "view3ViewBottomAnchorConstraint"
-    view3ViewTopAnchorConstraint.identifier = "view3ViewTopAnchorConstraint"
-    view3ViewLeadingAnchorConstraint.identifier = "view3ViewLeadingAnchorConstraint"
-    view3ViewTrailingAnchorConstraint.identifier = "view3ViewTrailingAnchorConstraint"
-    view4ViewHeightAnchorParentConstraint.identifier = "view4ViewHeightAnchorParentConstraint"
-    view5ViewHeightAnchorParentConstraint.identifier = "view5ViewHeightAnchorParentConstraint"
-    view4ViewLeadingAnchorConstraint.identifier = "view4ViewLeadingAnchorConstraint"
-    view4ViewTopAnchorConstraint.identifier = "view4ViewTopAnchorConstraint"
-    view5ViewLeadingAnchorConstraint.identifier = "view5ViewLeadingAnchorConstraint"
-    view5ViewTopAnchorConstraint.identifier = "view5ViewTopAnchorConstraint"
-    view4ViewHeightAnchorConstraint.identifier = "view4ViewHeightAnchorConstraint"
-    view4ViewWidthAnchorConstraint.identifier = "view4ViewWidthAnchorConstraint"
-    view5ViewHeightAnchorConstraint.identifier = "view5ViewHeightAnchorConstraint"
-    view5ViewWidthAnchorConstraint.identifier = "view5ViewWidthAnchorConstraint"
   }
 
   private func update() {}

--- a/examples/generated/test/appkit/layouts/FixedParentFitChild.swift
+++ b/examples/generated/test/appkit/layouts/FixedParentFitChild.swift
@@ -26,42 +26,6 @@ public class FixedParentFitChild: NSBox {
   private var view4View = NSBox()
   private var view5View = NSBox()
 
-  private var topPadding: CGFloat = 24
-  private var trailingPadding: CGFloat = 24
-  private var bottomPadding: CGFloat = 24
-  private var leadingPadding: CGFloat = 24
-  private var view1ViewTopMargin: CGFloat = 0
-  private var view1ViewTrailingMargin: CGFloat = 0
-  private var view1ViewBottomMargin: CGFloat = 0
-  private var view1ViewLeadingMargin: CGFloat = 0
-  private var view1ViewTopPadding: CGFloat = 24
-  private var view1ViewTrailingPadding: CGFloat = 24
-  private var view1ViewBottomPadding: CGFloat = 24
-  private var view1ViewLeadingPadding: CGFloat = 24
-  private var view4ViewTopMargin: CGFloat = 0
-  private var view4ViewTrailingMargin: CGFloat = 0
-  private var view4ViewBottomMargin: CGFloat = 0
-  private var view4ViewLeadingMargin: CGFloat = 0
-  private var view5ViewTopMargin: CGFloat = 0
-  private var view5ViewTrailingMargin: CGFloat = 0
-  private var view5ViewBottomMargin: CGFloat = 0
-  private var view5ViewLeadingMargin: CGFloat = 12
-
-  private var heightAnchorConstraint: NSLayoutConstraint?
-  private var view1ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var view1ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var view1ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var view4ViewHeightAnchorParentConstraint: NSLayoutConstraint?
-  private var view5ViewHeightAnchorParentConstraint: NSLayoutConstraint?
-  private var view4ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var view4ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var view5ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var view5ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var view4ViewHeightAnchorConstraint: NSLayoutConstraint?
-  private var view4ViewWidthAnchorConstraint: NSLayoutConstraint?
-  private var view5ViewHeightAnchorConstraint: NSLayoutConstraint?
-  private var view5ViewWidthAnchorConstraint: NSLayoutConstraint?
-
   private func setUpViews() {
     boxType = .custom
     borderType = .noBorder
@@ -93,37 +57,21 @@ public class FixedParentFitChild: NSBox {
     view5View.translatesAutoresizingMaskIntoConstraints = false
 
     let heightAnchorConstraint = heightAnchor.constraint(equalToConstant: 600)
-    let view1ViewTopAnchorConstraint = view1View
-      .topAnchor
-      .constraint(equalTo: topAnchor, constant: topPadding + view1ViewTopMargin)
-    let view1ViewLeadingAnchorConstraint = view1View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + view1ViewLeadingMargin)
-    let view1ViewTrailingAnchorConstraint = view1View
-      .trailingAnchor
-      .constraint(equalTo: trailingAnchor, constant: -(trailingPadding + view1ViewTrailingMargin))
+    let view1ViewTopAnchorConstraint = view1View.topAnchor.constraint(equalTo: topAnchor, constant: 24)
+    let view1ViewLeadingAnchorConstraint = view1View.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24)
+    let view1ViewTrailingAnchorConstraint = view1View.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -24)
     let view4ViewHeightAnchorParentConstraint = view4View
       .heightAnchor
-      .constraint(
-        lessThanOrEqualTo: view1View.heightAnchor,
-        constant: -(view1ViewTopPadding + view4ViewTopMargin + view1ViewBottomPadding + view4ViewBottomMargin))
+      .constraint(lessThanOrEqualTo: view1View.heightAnchor, constant: -(24 + 24))
     let view5ViewHeightAnchorParentConstraint = view5View
       .heightAnchor
-      .constraint(
-        lessThanOrEqualTo: view1View.heightAnchor,
-        constant: -(view1ViewTopPadding + view5ViewTopMargin + view1ViewBottomPadding + view5ViewBottomMargin))
+      .constraint(lessThanOrEqualTo: view1View.heightAnchor, constant: -(24 + 24))
     let view4ViewLeadingAnchorConstraint = view4View
       .leadingAnchor
-      .constraint(equalTo: view1View.leadingAnchor, constant: view1ViewLeadingPadding + view4ViewLeadingMargin)
-    let view4ViewTopAnchorConstraint = view4View
-      .topAnchor
-      .constraint(equalTo: view1View.topAnchor, constant: view1ViewTopPadding + view4ViewTopMargin)
-    let view5ViewLeadingAnchorConstraint = view5View
-      .leadingAnchor
-      .constraint(equalTo: view4View.trailingAnchor, constant: view4ViewTrailingMargin + view5ViewLeadingMargin)
-    let view5ViewTopAnchorConstraint = view5View
-      .topAnchor
-      .constraint(equalTo: view1View.topAnchor, constant: view1ViewTopPadding + view5ViewTopMargin)
+      .constraint(equalTo: view1View.leadingAnchor, constant: 24)
+    let view4ViewTopAnchorConstraint = view4View.topAnchor.constraint(equalTo: view1View.topAnchor, constant: 24)
+    let view5ViewLeadingAnchorConstraint = view5View.leadingAnchor.constraint(equalTo: view4View.trailingAnchor)
+    let view5ViewTopAnchorConstraint = view5View.topAnchor.constraint(equalTo: view1View.topAnchor, constant: 24)
     let view4ViewHeightAnchorConstraint = view4View.heightAnchor.constraint(equalToConstant: 100)
     let view4ViewWidthAnchorConstraint = view4View.widthAnchor.constraint(equalToConstant: 60)
     let view5ViewHeightAnchorConstraint = view5View.heightAnchor.constraint(equalToConstant: 60)
@@ -148,37 +96,6 @@ public class FixedParentFitChild: NSBox {
       view5ViewHeightAnchorConstraint,
       view5ViewWidthAnchorConstraint
     ])
-
-    self.heightAnchorConstraint = heightAnchorConstraint
-    self.view1ViewTopAnchorConstraint = view1ViewTopAnchorConstraint
-    self.view1ViewLeadingAnchorConstraint = view1ViewLeadingAnchorConstraint
-    self.view1ViewTrailingAnchorConstraint = view1ViewTrailingAnchorConstraint
-    self.view4ViewHeightAnchorParentConstraint = view4ViewHeightAnchorParentConstraint
-    self.view5ViewHeightAnchorParentConstraint = view5ViewHeightAnchorParentConstraint
-    self.view4ViewLeadingAnchorConstraint = view4ViewLeadingAnchorConstraint
-    self.view4ViewTopAnchorConstraint = view4ViewTopAnchorConstraint
-    self.view5ViewLeadingAnchorConstraint = view5ViewLeadingAnchorConstraint
-    self.view5ViewTopAnchorConstraint = view5ViewTopAnchorConstraint
-    self.view4ViewHeightAnchorConstraint = view4ViewHeightAnchorConstraint
-    self.view4ViewWidthAnchorConstraint = view4ViewWidthAnchorConstraint
-    self.view5ViewHeightAnchorConstraint = view5ViewHeightAnchorConstraint
-    self.view5ViewWidthAnchorConstraint = view5ViewWidthAnchorConstraint
-
-    // For debugging
-    heightAnchorConstraint.identifier = "heightAnchorConstraint"
-    view1ViewTopAnchorConstraint.identifier = "view1ViewTopAnchorConstraint"
-    view1ViewLeadingAnchorConstraint.identifier = "view1ViewLeadingAnchorConstraint"
-    view1ViewTrailingAnchorConstraint.identifier = "view1ViewTrailingAnchorConstraint"
-    view4ViewHeightAnchorParentConstraint.identifier = "view4ViewHeightAnchorParentConstraint"
-    view5ViewHeightAnchorParentConstraint.identifier = "view5ViewHeightAnchorParentConstraint"
-    view4ViewLeadingAnchorConstraint.identifier = "view4ViewLeadingAnchorConstraint"
-    view4ViewTopAnchorConstraint.identifier = "view4ViewTopAnchorConstraint"
-    view5ViewLeadingAnchorConstraint.identifier = "view5ViewLeadingAnchorConstraint"
-    view5ViewTopAnchorConstraint.identifier = "view5ViewTopAnchorConstraint"
-    view4ViewHeightAnchorConstraint.identifier = "view4ViewHeightAnchorConstraint"
-    view4ViewWidthAnchorConstraint.identifier = "view4ViewWidthAnchorConstraint"
-    view5ViewHeightAnchorConstraint.identifier = "view5ViewHeightAnchorConstraint"
-    view5ViewWidthAnchorConstraint.identifier = "view5ViewWidthAnchorConstraint"
   }
 
   private func update() {}

--- a/examples/generated/test/appkit/layouts/FixedParentFitChild.swift
+++ b/examples/generated/test/appkit/layouts/FixedParentFitChild.swift
@@ -62,15 +62,17 @@ public class FixedParentFitChild: NSBox {
     let view1ViewTrailingAnchorConstraint = view1View.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -24)
     let view4ViewHeightAnchorParentConstraint = view4View
       .heightAnchor
-      .constraint(lessThanOrEqualTo: view1View.heightAnchor, constant: -(24 + 24))
+      .constraint(lessThanOrEqualTo: view1View.heightAnchor, constant: -48)
     let view5ViewHeightAnchorParentConstraint = view5View
       .heightAnchor
-      .constraint(lessThanOrEqualTo: view1View.heightAnchor, constant: -(24 + 24))
+      .constraint(lessThanOrEqualTo: view1View.heightAnchor, constant: -48)
     let view4ViewLeadingAnchorConstraint = view4View
       .leadingAnchor
       .constraint(equalTo: view1View.leadingAnchor, constant: 24)
     let view4ViewTopAnchorConstraint = view4View.topAnchor.constraint(equalTo: view1View.topAnchor, constant: 24)
-    let view5ViewLeadingAnchorConstraint = view5View.leadingAnchor.constraint(equalTo: view4View.trailingAnchor)
+    let view5ViewLeadingAnchorConstraint = view5View
+      .leadingAnchor
+      .constraint(equalTo: view4View.trailingAnchor, constant: 12)
     let view5ViewTopAnchorConstraint = view5View.topAnchor.constraint(equalTo: view1View.topAnchor, constant: 24)
     let view4ViewHeightAnchorConstraint = view4View.heightAnchor.constraint(equalToConstant: 100)
     let view4ViewWidthAnchorConstraint = view4View.widthAnchor.constraint(equalToConstant: 60)

--- a/examples/generated/test/appkit/layouts/PrimaryAxis.swift
+++ b/examples/generated/test/appkit/layouts/PrimaryAxis.swift
@@ -86,7 +86,7 @@ public class PrimaryAxis: NSBox {
     let fixedViewWidthAnchorConstraint = fixedView.widthAnchor.constraint(equalToConstant: 100)
     let fitViewWidthAnchorConstraint = fitView.widthAnchor.constraint(equalToConstant: 100)
     let textViewTopAnchorConstraint = textView.topAnchor.constraint(equalTo: fitView.topAnchor)
-    let textViewBottomAnchorConstraint = textView.bottomAnchor.constraint(equalTo: fitView.bottomAnchor, constant: -24)
+    let textViewBottomAnchorConstraint = textView.bottomAnchor.constraint(equalTo: fitView.bottomAnchor)
     let textViewLeadingAnchorConstraint = textView.leadingAnchor.constraint(equalTo: fitView.leadingAnchor)
     let textViewTrailingAnchorConstraint = textView.trailingAnchor.constraint(equalTo: fitView.trailingAnchor)
     let fill1ViewWidthAnchorConstraint = fill1View.widthAnchor.constraint(equalToConstant: 100)

--- a/examples/generated/test/appkit/layouts/PrimaryAxis.swift
+++ b/examples/generated/test/appkit/layouts/PrimaryAxis.swift
@@ -30,56 +30,6 @@ public class PrimaryAxis: NSBox {
 
   private var textViewTextStyle = TextStyles.body1
 
-  private var topPadding: CGFloat = 24
-  private var trailingPadding: CGFloat = 24
-  private var bottomPadding: CGFloat = 24
-  private var leadingPadding: CGFloat = 24
-  private var fixedViewTopMargin: CGFloat = 0
-  private var fixedViewTrailingMargin: CGFloat = 0
-  private var fixedViewBottomMargin: CGFloat = 24
-  private var fixedViewLeadingMargin: CGFloat = 0
-  private var fitViewTopMargin: CGFloat = 0
-  private var fitViewTrailingMargin: CGFloat = 0
-  private var fitViewBottomMargin: CGFloat = 24
-  private var fitViewLeadingMargin: CGFloat = 0
-  private var fitViewTopPadding: CGFloat = 0
-  private var fitViewTrailingPadding: CGFloat = 0
-  private var fitViewBottomPadding: CGFloat = 0
-  private var fitViewLeadingPadding: CGFloat = 0
-  private var fill1ViewTopMargin: CGFloat = 0
-  private var fill1ViewTrailingMargin: CGFloat = 0
-  private var fill1ViewBottomMargin: CGFloat = 0
-  private var fill1ViewLeadingMargin: CGFloat = 0
-  private var fill2ViewTopMargin: CGFloat = 0
-  private var fill2ViewTrailingMargin: CGFloat = 0
-  private var fill2ViewBottomMargin: CGFloat = 0
-  private var fill2ViewLeadingMargin: CGFloat = 0
-  private var textViewTopMargin: CGFloat = 0
-  private var textViewTrailingMargin: CGFloat = 0
-  private var textViewBottomMargin: CGFloat = 0
-  private var textViewLeadingMargin: CGFloat = 0
-
-  private var heightAnchorConstraint: NSLayoutConstraint?
-  private var fill1ViewFill2ViewHeightAnchorSiblingConstraint: NSLayoutConstraint?
-  private var fixedViewTopAnchorConstraint: NSLayoutConstraint?
-  private var fixedViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var fitViewTopAnchorConstraint: NSLayoutConstraint?
-  private var fitViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var fill1ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var fill1ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var fill2ViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var fill2ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var fill2ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var fixedViewHeightAnchorConstraint: NSLayoutConstraint?
-  private var fixedViewWidthAnchorConstraint: NSLayoutConstraint?
-  private var fitViewWidthAnchorConstraint: NSLayoutConstraint?
-  private var textViewTopAnchorConstraint: NSLayoutConstraint?
-  private var textViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var textViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var textViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var fill1ViewWidthAnchorConstraint: NSLayoutConstraint?
-  private var fill2ViewWidthAnchorConstraint: NSLayoutConstraint?
-
   private func setUpViews() {
     boxType = .custom
     borderType = .noBorder
@@ -122,49 +72,23 @@ public class PrimaryAxis: NSBox {
     let heightAnchorConstraint = heightAnchor.constraint(equalToConstant: 500)
     let fill1ViewFill2ViewHeightAnchorSiblingConstraint = fill1View
       .heightAnchor
-      .constraint(equalTo: fill2View.heightAnchor, constant: 0)
-    let fixedViewTopAnchorConstraint = fixedView
-      .topAnchor
-      .constraint(equalTo: topAnchor, constant: topPadding + fixedViewTopMargin)
-    let fixedViewLeadingAnchorConstraint = fixedView
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + fixedViewLeadingMargin)
-    let fitViewTopAnchorConstraint = fitView
-      .topAnchor
-      .constraint(equalTo: fixedView.bottomAnchor, constant: fixedViewBottomMargin + fitViewTopMargin)
-    let fitViewLeadingAnchorConstraint = fitView
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + fitViewLeadingMargin)
-    let fill1ViewTopAnchorConstraint = fill1View
-      .topAnchor
-      .constraint(equalTo: fitView.bottomAnchor, constant: fitViewBottomMargin + fill1ViewTopMargin)
-    let fill1ViewLeadingAnchorConstraint = fill1View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + fill1ViewLeadingMargin)
-    let fill2ViewBottomAnchorConstraint = fill2View
-      .bottomAnchor
-      .constraint(equalTo: bottomAnchor, constant: -(bottomPadding + fill2ViewBottomMargin))
-    let fill2ViewTopAnchorConstraint = fill2View
-      .topAnchor
-      .constraint(equalTo: fill1View.bottomAnchor, constant: fill1ViewBottomMargin + fill2ViewTopMargin)
-    let fill2ViewLeadingAnchorConstraint = fill2View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + fill2ViewLeadingMargin)
+      .constraint(equalTo: fill2View.heightAnchor)
+    let fixedViewTopAnchorConstraint = fixedView.topAnchor.constraint(equalTo: topAnchor, constant: 24)
+    let fixedViewLeadingAnchorConstraint = fixedView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24)
+    let fitViewTopAnchorConstraint = fitView.topAnchor.constraint(equalTo: fixedView.bottomAnchor, constant: 24)
+    let fitViewLeadingAnchorConstraint = fitView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24)
+    let fill1ViewTopAnchorConstraint = fill1View.topAnchor.constraint(equalTo: fitView.bottomAnchor, constant: 24)
+    let fill1ViewLeadingAnchorConstraint = fill1View.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24)
+    let fill2ViewBottomAnchorConstraint = fill2View.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -24)
+    let fill2ViewTopAnchorConstraint = fill2View.topAnchor.constraint(equalTo: fill1View.bottomAnchor)
+    let fill2ViewLeadingAnchorConstraint = fill2View.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24)
     let fixedViewHeightAnchorConstraint = fixedView.heightAnchor.constraint(equalToConstant: 100)
     let fixedViewWidthAnchorConstraint = fixedView.widthAnchor.constraint(equalToConstant: 100)
     let fitViewWidthAnchorConstraint = fitView.widthAnchor.constraint(equalToConstant: 100)
-    let textViewTopAnchorConstraint = textView
-      .topAnchor
-      .constraint(equalTo: fitView.topAnchor, constant: fitViewTopPadding + textViewTopMargin)
-    let textViewBottomAnchorConstraint = textView
-      .bottomAnchor
-      .constraint(equalTo: fitView.bottomAnchor, constant: -(fitViewBottomPadding + textViewBottomMargin))
-    let textViewLeadingAnchorConstraint = textView
-      .leadingAnchor
-      .constraint(equalTo: fitView.leadingAnchor, constant: fitViewLeadingPadding + textViewLeadingMargin)
-    let textViewTrailingAnchorConstraint = textView
-      .trailingAnchor
-      .constraint(equalTo: fitView.trailingAnchor, constant: -(fitViewTrailingPadding + textViewTrailingMargin))
+    let textViewTopAnchorConstraint = textView.topAnchor.constraint(equalTo: fitView.topAnchor)
+    let textViewBottomAnchorConstraint = textView.bottomAnchor.constraint(equalTo: fitView.bottomAnchor, constant: -24)
+    let textViewLeadingAnchorConstraint = textView.leadingAnchor.constraint(equalTo: fitView.leadingAnchor)
+    let textViewTrailingAnchorConstraint = textView.trailingAnchor.constraint(equalTo: fitView.trailingAnchor)
     let fill1ViewWidthAnchorConstraint = fill1View.widthAnchor.constraint(equalToConstant: 100)
     let fill2ViewWidthAnchorConstraint = fill2View.widthAnchor.constraint(equalToConstant: 100)
 
@@ -190,49 +114,6 @@ public class PrimaryAxis: NSBox {
       fill1ViewWidthAnchorConstraint,
       fill2ViewWidthAnchorConstraint
     ])
-
-    self.heightAnchorConstraint = heightAnchorConstraint
-    self.fill1ViewFill2ViewHeightAnchorSiblingConstraint = fill1ViewFill2ViewHeightAnchorSiblingConstraint
-    self.fixedViewTopAnchorConstraint = fixedViewTopAnchorConstraint
-    self.fixedViewLeadingAnchorConstraint = fixedViewLeadingAnchorConstraint
-    self.fitViewTopAnchorConstraint = fitViewTopAnchorConstraint
-    self.fitViewLeadingAnchorConstraint = fitViewLeadingAnchorConstraint
-    self.fill1ViewTopAnchorConstraint = fill1ViewTopAnchorConstraint
-    self.fill1ViewLeadingAnchorConstraint = fill1ViewLeadingAnchorConstraint
-    self.fill2ViewBottomAnchorConstraint = fill2ViewBottomAnchorConstraint
-    self.fill2ViewTopAnchorConstraint = fill2ViewTopAnchorConstraint
-    self.fill2ViewLeadingAnchorConstraint = fill2ViewLeadingAnchorConstraint
-    self.fixedViewHeightAnchorConstraint = fixedViewHeightAnchorConstraint
-    self.fixedViewWidthAnchorConstraint = fixedViewWidthAnchorConstraint
-    self.fitViewWidthAnchorConstraint = fitViewWidthAnchorConstraint
-    self.textViewTopAnchorConstraint = textViewTopAnchorConstraint
-    self.textViewBottomAnchorConstraint = textViewBottomAnchorConstraint
-    self.textViewLeadingAnchorConstraint = textViewLeadingAnchorConstraint
-    self.textViewTrailingAnchorConstraint = textViewTrailingAnchorConstraint
-    self.fill1ViewWidthAnchorConstraint = fill1ViewWidthAnchorConstraint
-    self.fill2ViewWidthAnchorConstraint = fill2ViewWidthAnchorConstraint
-
-    // For debugging
-    heightAnchorConstraint.identifier = "heightAnchorConstraint"
-    fill1ViewFill2ViewHeightAnchorSiblingConstraint.identifier = "fill1ViewFill2ViewHeightAnchorSiblingConstraint"
-    fixedViewTopAnchorConstraint.identifier = "fixedViewTopAnchorConstraint"
-    fixedViewLeadingAnchorConstraint.identifier = "fixedViewLeadingAnchorConstraint"
-    fitViewTopAnchorConstraint.identifier = "fitViewTopAnchorConstraint"
-    fitViewLeadingAnchorConstraint.identifier = "fitViewLeadingAnchorConstraint"
-    fill1ViewTopAnchorConstraint.identifier = "fill1ViewTopAnchorConstraint"
-    fill1ViewLeadingAnchorConstraint.identifier = "fill1ViewLeadingAnchorConstraint"
-    fill2ViewBottomAnchorConstraint.identifier = "fill2ViewBottomAnchorConstraint"
-    fill2ViewTopAnchorConstraint.identifier = "fill2ViewTopAnchorConstraint"
-    fill2ViewLeadingAnchorConstraint.identifier = "fill2ViewLeadingAnchorConstraint"
-    fixedViewHeightAnchorConstraint.identifier = "fixedViewHeightAnchorConstraint"
-    fixedViewWidthAnchorConstraint.identifier = "fixedViewWidthAnchorConstraint"
-    fitViewWidthAnchorConstraint.identifier = "fitViewWidthAnchorConstraint"
-    textViewTopAnchorConstraint.identifier = "textViewTopAnchorConstraint"
-    textViewBottomAnchorConstraint.identifier = "textViewBottomAnchorConstraint"
-    textViewLeadingAnchorConstraint.identifier = "textViewLeadingAnchorConstraint"
-    textViewTrailingAnchorConstraint.identifier = "textViewTrailingAnchorConstraint"
-    fill1ViewWidthAnchorConstraint.identifier = "fill1ViewWidthAnchorConstraint"
-    fill2ViewWidthAnchorConstraint.identifier = "fill2ViewWidthAnchorConstraint"
   }
 
   private func update() {}

--- a/examples/generated/test/appkit/layouts/SecondaryAxis.swift
+++ b/examples/generated/test/appkit/layouts/SecondaryAxis.swift
@@ -29,49 +29,6 @@ public class SecondaryAxis: NSBox {
 
   private var textViewTextStyle = TextStyles.body1
 
-  private var topPadding: CGFloat = 24
-  private var trailingPadding: CGFloat = 24
-  private var bottomPadding: CGFloat = 24
-  private var leadingPadding: CGFloat = 24
-  private var fixedViewTopMargin: CGFloat = 0
-  private var fixedViewTrailingMargin: CGFloat = 0
-  private var fixedViewBottomMargin: CGFloat = 24
-  private var fixedViewLeadingMargin: CGFloat = 0
-  private var fitViewTopMargin: CGFloat = 0
-  private var fitViewTrailingMargin: CGFloat = 0
-  private var fitViewBottomMargin: CGFloat = 24
-  private var fitViewLeadingMargin: CGFloat = 0
-  private var fitViewTopPadding: CGFloat = 12
-  private var fitViewTrailingPadding: CGFloat = 12
-  private var fitViewBottomPadding: CGFloat = 12
-  private var fitViewLeadingPadding: CGFloat = 12
-  private var fillViewTopMargin: CGFloat = 0
-  private var fillViewTrailingMargin: CGFloat = 0
-  private var fillViewBottomMargin: CGFloat = 0
-  private var fillViewLeadingMargin: CGFloat = 0
-  private var textViewTopMargin: CGFloat = 0
-  private var textViewTrailingMargin: CGFloat = 0
-  private var textViewBottomMargin: CGFloat = 0
-  private var textViewLeadingMargin: CGFloat = 0
-
-  private var fixedViewTopAnchorConstraint: NSLayoutConstraint?
-  private var fixedViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var fitViewTopAnchorConstraint: NSLayoutConstraint?
-  private var fitViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var fitViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var fillViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var fillViewTopAnchorConstraint: NSLayoutConstraint?
-  private var fillViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var fillViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var fixedViewHeightAnchorConstraint: NSLayoutConstraint?
-  private var fixedViewWidthAnchorConstraint: NSLayoutConstraint?
-  private var fitViewHeightAnchorConstraint: NSLayoutConstraint?
-  private var textViewWidthAnchorParentConstraint: NSLayoutConstraint?
-  private var textViewTopAnchorConstraint: NSLayoutConstraint?
-  private var textViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var textViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var fillViewHeightAnchorConstraint: NSLayoutConstraint?
-
   private func setUpViews() {
     boxType = .custom
     borderType = .noBorder
@@ -105,50 +62,30 @@ public class SecondaryAxis: NSBox {
     fillView.translatesAutoresizingMaskIntoConstraints = false
     textView.translatesAutoresizingMaskIntoConstraints = false
 
-    let fixedViewTopAnchorConstraint = fixedView
-      .topAnchor
-      .constraint(equalTo: topAnchor, constant: topPadding + fixedViewTopMargin)
-    let fixedViewLeadingAnchorConstraint = fixedView
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + fixedViewLeadingMargin)
-    let fitViewTopAnchorConstraint = fitView
-      .topAnchor
-      .constraint(equalTo: fixedView.bottomAnchor, constant: fixedViewBottomMargin + fitViewTopMargin)
-    let fitViewLeadingAnchorConstraint = fitView
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + fitViewLeadingMargin)
+    let fixedViewTopAnchorConstraint = fixedView.topAnchor.constraint(equalTo: topAnchor, constant: 24)
+    let fixedViewLeadingAnchorConstraint = fixedView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24)
+    let fitViewTopAnchorConstraint = fitView.topAnchor.constraint(equalTo: fixedView.bottomAnchor, constant: 24)
+    let fitViewLeadingAnchorConstraint = fitView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24)
     let fitViewTrailingAnchorConstraint = fitView
       .trailingAnchor
-      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -(trailingPadding + fitViewTrailingMargin))
-    let fillViewBottomAnchorConstraint = fillView
-      .bottomAnchor
-      .constraint(equalTo: bottomAnchor, constant: -(bottomPadding + fillViewBottomMargin))
-    let fillViewTopAnchorConstraint = fillView
-      .topAnchor
-      .constraint(equalTo: fitView.bottomAnchor, constant: fitViewBottomMargin + fillViewTopMargin)
-    let fillViewLeadingAnchorConstraint = fillView
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + fillViewLeadingMargin)
-    let fillViewTrailingAnchorConstraint = fillView
-      .trailingAnchor
-      .constraint(equalTo: trailingAnchor, constant: -(trailingPadding + fillViewTrailingMargin))
+      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -24)
+    let fillViewBottomAnchorConstraint = fillView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -24)
+    let fillViewTopAnchorConstraint = fillView.topAnchor.constraint(equalTo: fitView.bottomAnchor, constant: 24)
+    let fillViewLeadingAnchorConstraint = fillView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24)
+    let fillViewTrailingAnchorConstraint = fillView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -24)
     let fixedViewHeightAnchorConstraint = fixedView.heightAnchor.constraint(equalToConstant: 100)
     let fixedViewWidthAnchorConstraint = fixedView.widthAnchor.constraint(equalToConstant: 100)
     let fitViewHeightAnchorConstraint = fitView.heightAnchor.constraint(equalToConstant: 100)
     let textViewWidthAnchorParentConstraint = textView
       .widthAnchor
-      .constraint(
-        lessThanOrEqualTo: fitView.widthAnchor,
-        constant: -(fitViewLeadingPadding + textViewLeadingMargin + fitViewTrailingPadding + textViewTrailingMargin))
-    let textViewTopAnchorConstraint = textView
-      .topAnchor
-      .constraint(equalTo: fitView.topAnchor, constant: fitViewTopPadding + textViewTopMargin)
+      .constraint(lessThanOrEqualTo: fitView.widthAnchor, constant: -(12 + 12))
+    let textViewTopAnchorConstraint = textView.topAnchor.constraint(equalTo: fitView.topAnchor, constant: 12)
     let textViewLeadingAnchorConstraint = textView
       .leadingAnchor
-      .constraint(equalTo: fitView.leadingAnchor, constant: fitViewLeadingPadding + textViewLeadingMargin)
+      .constraint(equalTo: fitView.leadingAnchor, constant: 12)
     let textViewTrailingAnchorConstraint = textView
       .trailingAnchor
-      .constraint(equalTo: fitView.trailingAnchor, constant: -(fitViewTrailingPadding + textViewTrailingMargin))
+      .constraint(equalTo: fitView.trailingAnchor, constant: -12)
     let fillViewHeightAnchorConstraint = fillView.heightAnchor.constraint(equalToConstant: 100)
 
     textViewWidthAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
@@ -172,43 +109,6 @@ public class SecondaryAxis: NSBox {
       textViewTrailingAnchorConstraint,
       fillViewHeightAnchorConstraint
     ])
-
-    self.fixedViewTopAnchorConstraint = fixedViewTopAnchorConstraint
-    self.fixedViewLeadingAnchorConstraint = fixedViewLeadingAnchorConstraint
-    self.fitViewTopAnchorConstraint = fitViewTopAnchorConstraint
-    self.fitViewLeadingAnchorConstraint = fitViewLeadingAnchorConstraint
-    self.fitViewTrailingAnchorConstraint = fitViewTrailingAnchorConstraint
-    self.fillViewBottomAnchorConstraint = fillViewBottomAnchorConstraint
-    self.fillViewTopAnchorConstraint = fillViewTopAnchorConstraint
-    self.fillViewLeadingAnchorConstraint = fillViewLeadingAnchorConstraint
-    self.fillViewTrailingAnchorConstraint = fillViewTrailingAnchorConstraint
-    self.fixedViewHeightAnchorConstraint = fixedViewHeightAnchorConstraint
-    self.fixedViewWidthAnchorConstraint = fixedViewWidthAnchorConstraint
-    self.fitViewHeightAnchorConstraint = fitViewHeightAnchorConstraint
-    self.textViewWidthAnchorParentConstraint = textViewWidthAnchorParentConstraint
-    self.textViewTopAnchorConstraint = textViewTopAnchorConstraint
-    self.textViewLeadingAnchorConstraint = textViewLeadingAnchorConstraint
-    self.textViewTrailingAnchorConstraint = textViewTrailingAnchorConstraint
-    self.fillViewHeightAnchorConstraint = fillViewHeightAnchorConstraint
-
-    // For debugging
-    fixedViewTopAnchorConstraint.identifier = "fixedViewTopAnchorConstraint"
-    fixedViewLeadingAnchorConstraint.identifier = "fixedViewLeadingAnchorConstraint"
-    fitViewTopAnchorConstraint.identifier = "fitViewTopAnchorConstraint"
-    fitViewLeadingAnchorConstraint.identifier = "fitViewLeadingAnchorConstraint"
-    fitViewTrailingAnchorConstraint.identifier = "fitViewTrailingAnchorConstraint"
-    fillViewBottomAnchorConstraint.identifier = "fillViewBottomAnchorConstraint"
-    fillViewTopAnchorConstraint.identifier = "fillViewTopAnchorConstraint"
-    fillViewLeadingAnchorConstraint.identifier = "fillViewLeadingAnchorConstraint"
-    fillViewTrailingAnchorConstraint.identifier = "fillViewTrailingAnchorConstraint"
-    fixedViewHeightAnchorConstraint.identifier = "fixedViewHeightAnchorConstraint"
-    fixedViewWidthAnchorConstraint.identifier = "fixedViewWidthAnchorConstraint"
-    fitViewHeightAnchorConstraint.identifier = "fitViewHeightAnchorConstraint"
-    textViewWidthAnchorParentConstraint.identifier = "textViewWidthAnchorParentConstraint"
-    textViewTopAnchorConstraint.identifier = "textViewTopAnchorConstraint"
-    textViewLeadingAnchorConstraint.identifier = "textViewLeadingAnchorConstraint"
-    textViewTrailingAnchorConstraint.identifier = "textViewTrailingAnchorConstraint"
-    fillViewHeightAnchorConstraint.identifier = "fillViewHeightAnchorConstraint"
   }
 
   private func update() {}

--- a/examples/generated/test/appkit/layouts/SecondaryAxis.swift
+++ b/examples/generated/test/appkit/layouts/SecondaryAxis.swift
@@ -78,7 +78,7 @@ public class SecondaryAxis: NSBox {
     let fitViewHeightAnchorConstraint = fitView.heightAnchor.constraint(equalToConstant: 100)
     let textViewWidthAnchorParentConstraint = textView
       .widthAnchor
-      .constraint(lessThanOrEqualTo: fitView.widthAnchor, constant: -(12 + 12))
+      .constraint(lessThanOrEqualTo: fitView.widthAnchor, constant: -24)
     let textViewTopAnchorConstraint = textView.topAnchor.constraint(equalTo: fitView.topAnchor, constant: 12)
     let textViewLeadingAnchorConstraint = textView
       .leadingAnchor

--- a/examples/generated/test/appkit/logic/Assign.swift
+++ b/examples/generated/test/appkit/logic/Assign.swift
@@ -36,20 +36,6 @@ public class Assign: NSBox {
 
   private var textViewTextStyle = TextStyles.body1
 
-  private var topPadding: CGFloat = 0
-  private var trailingPadding: CGFloat = 0
-  private var bottomPadding: CGFloat = 0
-  private var leadingPadding: CGFloat = 0
-  private var textViewTopMargin: CGFloat = 0
-  private var textViewTrailingMargin: CGFloat = 0
-  private var textViewBottomMargin: CGFloat = 0
-  private var textViewLeadingMargin: CGFloat = 0
-
-  private var textViewTopAnchorConstraint: NSLayoutConstraint?
-  private var textViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var textViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var textViewTrailingAnchorConstraint: NSLayoutConstraint?
-
   private func setUpViews() {
     boxType = .custom
     borderType = .noBorder
@@ -63,18 +49,10 @@ public class Assign: NSBox {
     translatesAutoresizingMaskIntoConstraints = false
     textView.translatesAutoresizingMaskIntoConstraints = false
 
-    let textViewTopAnchorConstraint = textView
-      .topAnchor
-      .constraint(equalTo: topAnchor, constant: topPadding + textViewTopMargin)
-    let textViewBottomAnchorConstraint = textView
-      .bottomAnchor
-      .constraint(equalTo: bottomAnchor, constant: -(bottomPadding + textViewBottomMargin))
-    let textViewLeadingAnchorConstraint = textView
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + textViewLeadingMargin)
-    let textViewTrailingAnchorConstraint = textView
-      .trailingAnchor
-      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -(trailingPadding + textViewTrailingMargin))
+    let textViewTopAnchorConstraint = textView.topAnchor.constraint(equalTo: topAnchor)
+    let textViewBottomAnchorConstraint = textView.bottomAnchor.constraint(equalTo: bottomAnchor)
+    let textViewLeadingAnchorConstraint = textView.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let textViewTrailingAnchorConstraint = textView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor)
 
     NSLayoutConstraint.activate([
       textViewTopAnchorConstraint,
@@ -82,17 +60,6 @@ public class Assign: NSBox {
       textViewLeadingAnchorConstraint,
       textViewTrailingAnchorConstraint
     ])
-
-    self.textViewTopAnchorConstraint = textViewTopAnchorConstraint
-    self.textViewBottomAnchorConstraint = textViewBottomAnchorConstraint
-    self.textViewLeadingAnchorConstraint = textViewLeadingAnchorConstraint
-    self.textViewTrailingAnchorConstraint = textViewTrailingAnchorConstraint
-
-    // For debugging
-    textViewTopAnchorConstraint.identifier = "textViewTopAnchorConstraint"
-    textViewBottomAnchorConstraint.identifier = "textViewBottomAnchorConstraint"
-    textViewLeadingAnchorConstraint.identifier = "textViewLeadingAnchorConstraint"
-    textViewTrailingAnchorConstraint.identifier = "textViewTrailingAnchorConstraint"
   }
 
   private func update() {

--- a/examples/generated/test/appkit/style/BorderWidthColor.swift
+++ b/examples/generated/test/appkit/style/BorderWidthColor.swift
@@ -24,21 +24,6 @@ public class BorderWidthColor: NSBox {
 
   private var view1View = NSBox()
 
-  private var topPadding: CGFloat = 0
-  private var trailingPadding: CGFloat = 0
-  private var bottomPadding: CGFloat = 0
-  private var leadingPadding: CGFloat = 0
-  private var view1ViewTopMargin: CGFloat = 0
-  private var view1ViewTrailingMargin: CGFloat = 0
-  private var view1ViewBottomMargin: CGFloat = 0
-  private var view1ViewLeadingMargin: CGFloat = 0
-
-  private var view1ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var view1ViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var view1ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var view1ViewHeightAnchorConstraint: NSLayoutConstraint?
-  private var view1ViewWidthAnchorConstraint: NSLayoutConstraint?
-
   private func setUpViews() {
     boxType = .custom
     borderType = .noBorder
@@ -58,15 +43,9 @@ public class BorderWidthColor: NSBox {
     translatesAutoresizingMaskIntoConstraints = false
     view1View.translatesAutoresizingMaskIntoConstraints = false
 
-    let view1ViewTopAnchorConstraint = view1View
-      .topAnchor
-      .constraint(equalTo: topAnchor, constant: topPadding + view1ViewTopMargin)
-    let view1ViewBottomAnchorConstraint = view1View
-      .bottomAnchor
-      .constraint(equalTo: bottomAnchor, constant: -(bottomPadding + view1ViewBottomMargin))
-    let view1ViewLeadingAnchorConstraint = view1View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + view1ViewLeadingMargin)
+    let view1ViewTopAnchorConstraint = view1View.topAnchor.constraint(equalTo: topAnchor)
+    let view1ViewBottomAnchorConstraint = view1View.bottomAnchor.constraint(equalTo: bottomAnchor)
+    let view1ViewLeadingAnchorConstraint = view1View.leadingAnchor.constraint(equalTo: leadingAnchor)
     let view1ViewHeightAnchorConstraint = view1View.heightAnchor.constraint(equalToConstant: 100)
     let view1ViewWidthAnchorConstraint = view1View.widthAnchor.constraint(equalToConstant: 100)
 
@@ -77,19 +56,6 @@ public class BorderWidthColor: NSBox {
       view1ViewHeightAnchorConstraint,
       view1ViewWidthAnchorConstraint
     ])
-
-    self.view1ViewTopAnchorConstraint = view1ViewTopAnchorConstraint
-    self.view1ViewBottomAnchorConstraint = view1ViewBottomAnchorConstraint
-    self.view1ViewLeadingAnchorConstraint = view1ViewLeadingAnchorConstraint
-    self.view1ViewHeightAnchorConstraint = view1ViewHeightAnchorConstraint
-    self.view1ViewWidthAnchorConstraint = view1ViewWidthAnchorConstraint
-
-    // For debugging
-    view1ViewTopAnchorConstraint.identifier = "view1ViewTopAnchorConstraint"
-    view1ViewBottomAnchorConstraint.identifier = "view1ViewBottomAnchorConstraint"
-    view1ViewLeadingAnchorConstraint.identifier = "view1ViewLeadingAnchorConstraint"
-    view1ViewHeightAnchorConstraint.identifier = "view1ViewHeightAnchorConstraint"
-    view1ViewWidthAnchorConstraint.identifier = "view1ViewWidthAnchorConstraint"
   }
 
   private func update() {}

--- a/examples/generated/test/appkit/style/BoxModelConditional.swift
+++ b/examples/generated/test/appkit/style/BoxModelConditional.swift
@@ -1,0 +1,91 @@
+import AppKit
+import Foundation
+
+// MARK: - BoxModelConditional
+
+public class BoxModelConditional: NSBox {
+
+  // MARK: Lifecycle
+
+  public init(margin: CGFloat, size: CGFloat) {
+    self.margin = margin
+    self.size = size
+
+    super.init(frame: .zero)
+
+    setUpViews()
+    setUpConstraints()
+
+    update()
+  }
+
+  public convenience init() {
+    self.init(margin: 0, size: 0)
+  }
+
+  public required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: Public
+
+  public var margin: CGFloat { didSet { update() } }
+  public var size: CGFloat { didSet { update() } }
+
+  // MARK: Private
+
+  private var innerView = NSBox()
+
+  private var innerViewTopAnchorConstraint: NSLayoutConstraint?
+  private var innerViewBottomAnchorConstraint: NSLayoutConstraint?
+  private var innerViewLeadingAnchorConstraint: NSLayoutConstraint?
+  private var innerViewHeightAnchorConstraint: NSLayoutConstraint?
+  private var innerViewWidthAnchorConstraint: NSLayoutConstraint?
+
+  private func setUpViews() {
+    boxType = .custom
+    borderType = .noBorder
+    contentViewMargins = .zero
+    innerView.boxType = .custom
+    innerView.borderType = .noBorder
+    innerView.contentViewMargins = .zero
+
+    addSubview(innerView)
+
+    innerView.fillColor = #colorLiteral(red: 0.847058823529, green: 0.847058823529, blue: 0.847058823529, alpha: 1)
+  }
+
+  private func setUpConstraints() {
+    translatesAutoresizingMaskIntoConstraints = false
+    innerView.translatesAutoresizingMaskIntoConstraints = false
+
+    let innerViewTopAnchorConstraint = innerView.topAnchor.constraint(equalTo: topAnchor, constant: 4)
+    let innerViewBottomAnchorConstraint = innerView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -4)
+    let innerViewLeadingAnchorConstraint = innerView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 4)
+    let innerViewHeightAnchorConstraint = innerView.heightAnchor.constraint(equalToConstant: 60)
+    let innerViewWidthAnchorConstraint = innerView.widthAnchor.constraint(equalToConstant: 60)
+
+    NSLayoutConstraint.activate([
+      innerViewTopAnchorConstraint,
+      innerViewBottomAnchorConstraint,
+      innerViewLeadingAnchorConstraint,
+      innerViewHeightAnchorConstraint,
+      innerViewWidthAnchorConstraint
+    ])
+
+    self.innerViewTopAnchorConstraint = innerViewTopAnchorConstraint
+    self.innerViewBottomAnchorConstraint = innerViewBottomAnchorConstraint
+    self.innerViewLeadingAnchorConstraint = innerViewLeadingAnchorConstraint
+    self.innerViewHeightAnchorConstraint = innerViewHeightAnchorConstraint
+    self.innerViewWidthAnchorConstraint = innerViewWidthAnchorConstraint
+  }
+
+  private func update() {
+    // TODO: Margin & padding: innerView.marginTop = // TODO: Margin & padding: margin
+    // TODO: Margin & padding: innerView.marginRight = // TODO: Margin & padding: margin
+    // TODO: Margin & padding: innerView.marginBottom = // TODO: Margin & padding: margin
+    // TODO: Margin & padding: innerView.marginLeft = // TODO: Margin & padding: margin
+    innerViewHeightAnchorConstraint?.constant = size
+    innerViewWidthAnchorConstraint?.constant = size
+  }
+}

--- a/examples/generated/test/appkit/style/TextAlignment.swift
+++ b/examples/generated/test/appkit/style/TextAlignment.swift
@@ -55,194 +55,6 @@ public class TextAlignment: NSBox {
   private var text9ViewTextStyle = TextStyles.body1
   private var text10ViewTextStyle = TextStyles.body1.with(alignment: .center)
 
-  private var topPadding: CGFloat = 10
-  private var trailingPadding: CGFloat = 10
-  private var bottomPadding: CGFloat = 10
-  private var leadingPadding: CGFloat = 10
-  private var view1ViewTopMargin: CGFloat = 0
-  private var view1ViewTrailingMargin: CGFloat = 0
-  private var view1ViewBottomMargin: CGFloat = 0
-  private var view1ViewLeadingMargin: CGFloat = 0
-  private var view1ViewTopPadding: CGFloat = 0
-  private var view1ViewTrailingPadding: CGFloat = 0
-  private var view1ViewBottomPadding: CGFloat = 0
-  private var view1ViewLeadingPadding: CGFloat = 0
-  private var view3ViewTopMargin: CGFloat = 0
-  private var view3ViewTrailingMargin: CGFloat = 0
-  private var view3ViewBottomMargin: CGFloat = 0
-  private var view3ViewLeadingMargin: CGFloat = 0
-  private var view3ViewTopPadding: CGFloat = 0
-  private var view3ViewTrailingPadding: CGFloat = 12
-  private var view3ViewBottomPadding: CGFloat = 0
-  private var view3ViewLeadingPadding: CGFloat = 12
-  private var view4ViewTopMargin: CGFloat = 0
-  private var view4ViewTrailingMargin: CGFloat = 0
-  private var view4ViewBottomMargin: CGFloat = 0
-  private var view4ViewLeadingMargin: CGFloat = 0
-  private var view4ViewTopPadding: CGFloat = 0
-  private var view4ViewTrailingPadding: CGFloat = 12
-  private var view4ViewBottomPadding: CGFloat = 0
-  private var view4ViewLeadingPadding: CGFloat = 12
-  private var view5ViewTopMargin: CGFloat = 0
-  private var view5ViewTrailingMargin: CGFloat = 0
-  private var view5ViewBottomMargin: CGFloat = 0
-  private var view5ViewLeadingMargin: CGFloat = 0
-  private var view5ViewTopPadding: CGFloat = 0
-  private var view5ViewTrailingPadding: CGFloat = 12
-  private var view5ViewBottomPadding: CGFloat = 0
-  private var view5ViewLeadingPadding: CGFloat = 12
-  private var view6ViewTopMargin: CGFloat = 0
-  private var view6ViewTrailingMargin: CGFloat = 0
-  private var view6ViewBottomMargin: CGFloat = 0
-  private var view6ViewLeadingMargin: CGFloat = 0
-  private var view6ViewTopPadding: CGFloat = 0
-  private var view6ViewTrailingPadding: CGFloat = 12
-  private var view6ViewBottomPadding: CGFloat = 0
-  private var view6ViewLeadingPadding: CGFloat = 12
-  private var rightAlignmentContainerViewTopMargin: CGFloat = 0
-  private var rightAlignmentContainerViewTrailingMargin: CGFloat = 0
-  private var rightAlignmentContainerViewBottomMargin: CGFloat = 0
-  private var rightAlignmentContainerViewLeadingMargin: CGFloat = 0
-  private var rightAlignmentContainerViewTopPadding: CGFloat = 0
-  private var rightAlignmentContainerViewTrailingPadding: CGFloat = 0
-  private var rightAlignmentContainerViewBottomPadding: CGFloat = 0
-  private var rightAlignmentContainerViewLeadingPadding: CGFloat = 0
-  private var imageViewTopMargin: CGFloat = 0
-  private var imageViewTrailingMargin: CGFloat = 0
-  private var imageViewBottomMargin: CGFloat = 0
-  private var imageViewLeadingMargin: CGFloat = 0
-  private var view2ViewTopMargin: CGFloat = 0
-  private var view2ViewTrailingMargin: CGFloat = 0
-  private var view2ViewBottomMargin: CGFloat = 0
-  private var view2ViewLeadingMargin: CGFloat = 0
-  private var textViewTopMargin: CGFloat = 16
-  private var textViewTrailingMargin: CGFloat = 0
-  private var textViewBottomMargin: CGFloat = 0
-  private var textViewLeadingMargin: CGFloat = 0
-  private var text1ViewTopMargin: CGFloat = 16
-  private var text1ViewTrailingMargin: CGFloat = 0
-  private var text1ViewBottomMargin: CGFloat = 0
-  private var text1ViewLeadingMargin: CGFloat = 0
-  private var text2ViewTopMargin: CGFloat = 12
-  private var text2ViewTrailingMargin: CGFloat = 0
-  private var text2ViewBottomMargin: CGFloat = 0
-  private var text2ViewLeadingMargin: CGFloat = 0
-  private var text3ViewTopMargin: CGFloat = 0
-  private var text3ViewTrailingMargin: CGFloat = 0
-  private var text3ViewBottomMargin: CGFloat = 0
-  private var text3ViewLeadingMargin: CGFloat = 0
-  private var text4ViewTopMargin: CGFloat = 0
-  private var text4ViewTrailingMargin: CGFloat = 0
-  private var text4ViewBottomMargin: CGFloat = 0
-  private var text4ViewLeadingMargin: CGFloat = 0
-  private var text5ViewTopMargin: CGFloat = 0
-  private var text5ViewTrailingMargin: CGFloat = 0
-  private var text5ViewBottomMargin: CGFloat = 0
-  private var text5ViewLeadingMargin: CGFloat = 0
-  private var text6ViewTopMargin: CGFloat = 0
-  private var text6ViewTrailingMargin: CGFloat = 0
-  private var text6ViewBottomMargin: CGFloat = 0
-  private var text6ViewLeadingMargin: CGFloat = 0
-  private var text7ViewTopMargin: CGFloat = 0
-  private var text7ViewTrailingMargin: CGFloat = 0
-  private var text7ViewBottomMargin: CGFloat = 0
-  private var text7ViewLeadingMargin: CGFloat = 0
-  private var text8ViewTopMargin: CGFloat = 0
-  private var text8ViewTrailingMargin: CGFloat = 0
-  private var text8ViewBottomMargin: CGFloat = 0
-  private var text8ViewLeadingMargin: CGFloat = 0
-  private var text9ViewTopMargin: CGFloat = 0
-  private var text9ViewTrailingMargin: CGFloat = 0
-  private var text9ViewBottomMargin: CGFloat = 0
-  private var text9ViewLeadingMargin: CGFloat = 0
-  private var text10ViewTopMargin: CGFloat = 0
-  private var text10ViewTrailingMargin: CGFloat = 0
-  private var text10ViewBottomMargin: CGFloat = 0
-  private var text10ViewLeadingMargin: CGFloat = 0
-  private var image1ViewTopMargin: CGFloat = 0
-  private var image1ViewTrailingMargin: CGFloat = 0
-  private var image1ViewBottomMargin: CGFloat = 0
-  private var image1ViewLeadingMargin: CGFloat = 0
-
-  private var view1ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var view1ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var view1ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var view3ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var view3ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var view3ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var view4ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var view4ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var view5ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var view5ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var view5ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var view6ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var view6ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var rightAlignmentContainerViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var rightAlignmentContainerViewTopAnchorConstraint: NSLayoutConstraint?
-  private var rightAlignmentContainerViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var rightAlignmentContainerViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var imageViewTopAnchorConstraint: NSLayoutConstraint?
-  private var imageViewCenterXAnchorConstraint: NSLayoutConstraint?
-  private var view2ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var view2ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var view2ViewCenterXAnchorConstraint: NSLayoutConstraint?
-  private var view2ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var textViewTopAnchorConstraint: NSLayoutConstraint?
-  private var textViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var textViewCenterXAnchorConstraint: NSLayoutConstraint?
-  private var textViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var text1ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var text1ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var text1ViewCenterXAnchorConstraint: NSLayoutConstraint?
-  private var text1ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var text2ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var text2ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var text2ViewCenterXAnchorConstraint: NSLayoutConstraint?
-  private var text2ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var text3ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var text3ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var text3ViewCenterXAnchorConstraint: NSLayoutConstraint?
-  private var text3ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var text4ViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var text4ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var text4ViewCenterXAnchorConstraint: NSLayoutConstraint?
-  private var text5ViewWidthAnchorParentConstraint: NSLayoutConstraint?
-  private var text5ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var text5ViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var text5ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var text5ViewCenterXAnchorConstraint: NSLayoutConstraint?
-  private var text5ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var view4ViewWidthAnchorConstraint: NSLayoutConstraint?
-  private var text6ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var text6ViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var text6ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var text6ViewCenterXAnchorConstraint: NSLayoutConstraint?
-  private var text6ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var text7ViewWidthAnchorParentConstraint: NSLayoutConstraint?
-  private var text7ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var text7ViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var text7ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var text7ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var view6ViewWidthAnchorConstraint: NSLayoutConstraint?
-  private var text8ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var text8ViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var text8ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var text8ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var text9ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var text9ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var text9ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var text10ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var text10ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var text10ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var image1ViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var image1ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var image1ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var imageViewHeightAnchorConstraint: NSLayoutConstraint?
-  private var imageViewWidthAnchorConstraint: NSLayoutConstraint?
-  private var text4ViewWidthAnchorConstraint: NSLayoutConstraint?
-  private var image1ViewHeightAnchorConstraint: NSLayoutConstraint?
-  private var image1ViewWidthAnchorConstraint: NSLayoutConstraint?
-
   private func setUpViews() {
     boxType = .custom
     borderType = .noBorder
@@ -350,251 +162,131 @@ public class TextAlignment: NSBox {
     text10View.translatesAutoresizingMaskIntoConstraints = false
     image1View.translatesAutoresizingMaskIntoConstraints = false
 
-    let view1ViewTopAnchorConstraint = view1View
-      .topAnchor
-      .constraint(equalTo: topAnchor, constant: topPadding + view1ViewTopMargin)
-    let view1ViewLeadingAnchorConstraint = view1View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + view1ViewLeadingMargin)
-    let view1ViewTrailingAnchorConstraint = view1View
-      .trailingAnchor
-      .constraint(equalTo: trailingAnchor, constant: -(trailingPadding + view1ViewTrailingMargin))
-    let view3ViewTopAnchorConstraint = view3View
-      .topAnchor
-      .constraint(equalTo: view1View.bottomAnchor, constant: view1ViewBottomMargin + view3ViewTopMargin)
-    let view3ViewLeadingAnchorConstraint = view3View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + view3ViewLeadingMargin)
+    let view1ViewTopAnchorConstraint = view1View.topAnchor.constraint(equalTo: topAnchor, constant: 10)
+    let view1ViewLeadingAnchorConstraint = view1View.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10)
+    let view1ViewTrailingAnchorConstraint = view1View.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -10)
+    let view3ViewTopAnchorConstraint = view3View.topAnchor.constraint(equalTo: view1View.bottomAnchor)
+    let view3ViewLeadingAnchorConstraint = view3View.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10)
     let view3ViewTrailingAnchorConstraint = view3View
       .trailingAnchor
-      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -(trailingPadding + view3ViewTrailingMargin))
-    let view4ViewTopAnchorConstraint = view4View
-      .topAnchor
-      .constraint(equalTo: view3View.bottomAnchor, constant: view3ViewBottomMargin + view4ViewTopMargin)
-    let view4ViewLeadingAnchorConstraint = view4View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + view4ViewLeadingMargin)
-    let view5ViewTopAnchorConstraint = view5View
-      .topAnchor
-      .constraint(equalTo: view4View.bottomAnchor, constant: view4ViewBottomMargin + view5ViewTopMargin)
-    let view5ViewLeadingAnchorConstraint = view5View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + view5ViewLeadingMargin)
+      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -10)
+    let view4ViewTopAnchorConstraint = view4View.topAnchor.constraint(equalTo: view3View.bottomAnchor)
+    let view4ViewLeadingAnchorConstraint = view4View.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10)
+    let view5ViewTopAnchorConstraint = view5View.topAnchor.constraint(equalTo: view4View.bottomAnchor)
+    let view5ViewLeadingAnchorConstraint = view5View.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10)
     let view5ViewTrailingAnchorConstraint = view5View
       .trailingAnchor
-      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -(trailingPadding + view5ViewTrailingMargin))
-    let view6ViewTopAnchorConstraint = view6View
-      .topAnchor
-      .constraint(equalTo: view5View.bottomAnchor, constant: view5ViewBottomMargin + view6ViewTopMargin)
-    let view6ViewLeadingAnchorConstraint = view6View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + view6ViewLeadingMargin)
+      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -10)
+    let view6ViewTopAnchorConstraint = view6View.topAnchor.constraint(equalTo: view5View.bottomAnchor)
+    let view6ViewLeadingAnchorConstraint = view6View.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10)
     let rightAlignmentContainerViewBottomAnchorConstraint = rightAlignmentContainerView
       .bottomAnchor
-      .constraint(equalTo: bottomAnchor, constant: -(bottomPadding + rightAlignmentContainerViewBottomMargin))
+      .constraint(equalTo: bottomAnchor, constant: -10)
     let rightAlignmentContainerViewTopAnchorConstraint = rightAlignmentContainerView
       .topAnchor
-      .constraint(
-        equalTo: view6View.bottomAnchor,
-        constant: view6ViewBottomMargin + rightAlignmentContainerViewTopMargin)
+      .constraint(equalTo: view6View.bottomAnchor)
     let rightAlignmentContainerViewLeadingAnchorConstraint = rightAlignmentContainerView
       .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + rightAlignmentContainerViewLeadingMargin)
+      .constraint(equalTo: leadingAnchor, constant: 10)
     let rightAlignmentContainerViewTrailingAnchorConstraint = rightAlignmentContainerView
       .trailingAnchor
-      .constraint(equalTo: trailingAnchor, constant: -(trailingPadding + rightAlignmentContainerViewTrailingMargin))
-    let imageViewTopAnchorConstraint = imageView
-      .topAnchor
-      .constraint(equalTo: view1View.topAnchor, constant: view1ViewTopPadding + imageViewTopMargin)
-    let imageViewCenterXAnchorConstraint = imageView
-      .centerXAnchor
-      .constraint(equalTo: view1View.centerXAnchor, constant: 0)
-    let view2ViewTopAnchorConstraint = view2View
-      .topAnchor
-      .constraint(equalTo: imageView.bottomAnchor, constant: imageViewBottomMargin + view2ViewTopMargin)
+      .constraint(equalTo: trailingAnchor, constant: -10)
+    let imageViewTopAnchorConstraint = imageView.topAnchor.constraint(equalTo: view1View.topAnchor)
+    let imageViewCenterXAnchorConstraint = imageView.centerXAnchor.constraint(equalTo: view1View.centerXAnchor)
+    let view2ViewTopAnchorConstraint = view2View.topAnchor.constraint(equalTo: imageView.bottomAnchor)
     let view2ViewLeadingAnchorConstraint = view2View
       .leadingAnchor
-      .constraint(
-        greaterThanOrEqualTo: view1View.leadingAnchor,
-        constant: view1ViewLeadingPadding + view2ViewLeadingMargin)
-    let view2ViewCenterXAnchorConstraint = view2View
-      .centerXAnchor
-      .constraint(equalTo: view1View.centerXAnchor, constant: 0)
+      .constraint(greaterThanOrEqualTo: view1View.leadingAnchor)
+    let view2ViewCenterXAnchorConstraint = view2View.centerXAnchor.constraint(equalTo: view1View.centerXAnchor)
     let view2ViewTrailingAnchorConstraint = view2View
       .trailingAnchor
-      .constraint(
-        lessThanOrEqualTo: view1View.trailingAnchor,
-        constant: -(view1ViewTrailingPadding + view2ViewTrailingMargin))
-    let textViewTopAnchorConstraint = textView
-      .topAnchor
-      .constraint(equalTo: view2View.bottomAnchor, constant: view2ViewBottomMargin + textViewTopMargin)
-    let textViewLeadingAnchorConstraint = textView
-      .leadingAnchor
-      .constraint(equalTo: view1View.leadingAnchor, constant: view1ViewLeadingPadding + textViewLeadingMargin)
-    let textViewCenterXAnchorConstraint = textView
-      .centerXAnchor
-      .constraint(equalTo: view1View.centerXAnchor, constant: 0)
-    let textViewTrailingAnchorConstraint = textView
-      .trailingAnchor
-      .constraint(equalTo: view1View.trailingAnchor, constant: -(view1ViewTrailingPadding + textViewTrailingMargin))
-    let text1ViewTopAnchorConstraint = text1View
-      .topAnchor
-      .constraint(equalTo: textView.bottomAnchor, constant: textViewBottomMargin + text1ViewTopMargin)
+      .constraint(lessThanOrEqualTo: view1View.trailingAnchor)
+    let textViewTopAnchorConstraint = textView.topAnchor.constraint(equalTo: view2View.bottomAnchor)
+    let textViewLeadingAnchorConstraint = textView.leadingAnchor.constraint(equalTo: view1View.leadingAnchor)
+    let textViewCenterXAnchorConstraint = textView.centerXAnchor.constraint(equalTo: view1View.centerXAnchor)
+    let textViewTrailingAnchorConstraint = textView.trailingAnchor.constraint(equalTo: view1View.trailingAnchor)
+    let text1ViewTopAnchorConstraint = text1View.topAnchor.constraint(equalTo: textView.bottomAnchor, constant: 16)
     let text1ViewLeadingAnchorConstraint = text1View
       .leadingAnchor
-      .constraint(
-        greaterThanOrEqualTo: view1View.leadingAnchor,
-        constant: view1ViewLeadingPadding + text1ViewLeadingMargin)
-    let text1ViewCenterXAnchorConstraint = text1View
-      .centerXAnchor
-      .constraint(equalTo: view1View.centerXAnchor, constant: 0)
+      .constraint(greaterThanOrEqualTo: view1View.leadingAnchor)
+    let text1ViewCenterXAnchorConstraint = text1View.centerXAnchor.constraint(equalTo: view1View.centerXAnchor)
     let text1ViewTrailingAnchorConstraint = text1View
       .trailingAnchor
-      .constraint(
-        lessThanOrEqualTo: view1View.trailingAnchor,
-        constant: -(view1ViewTrailingPadding + text1ViewTrailingMargin))
-    let text2ViewTopAnchorConstraint = text2View
-      .topAnchor
-      .constraint(equalTo: text1View.bottomAnchor, constant: text1ViewBottomMargin + text2ViewTopMargin)
-    let text2ViewLeadingAnchorConstraint = text2View
-      .leadingAnchor
-      .constraint(equalTo: view1View.leadingAnchor, constant: view1ViewLeadingPadding + text2ViewLeadingMargin)
-    let text2ViewCenterXAnchorConstraint = text2View
-      .centerXAnchor
-      .constraint(equalTo: view1View.centerXAnchor, constant: 0)
-    let text2ViewTrailingAnchorConstraint = text2View
-      .trailingAnchor
-      .constraint(equalTo: view1View.trailingAnchor, constant: -(view1ViewTrailingPadding + text2ViewTrailingMargin))
-    let text3ViewTopAnchorConstraint = text3View
-      .topAnchor
-      .constraint(equalTo: text2View.bottomAnchor, constant: text2ViewBottomMargin + text3ViewTopMargin)
-    let text3ViewLeadingAnchorConstraint = text3View
-      .leadingAnchor
-      .constraint(equalTo: view1View.leadingAnchor, constant: view1ViewLeadingPadding + text3ViewLeadingMargin)
-    let text3ViewCenterXAnchorConstraint = text3View
-      .centerXAnchor
-      .constraint(equalTo: view1View.centerXAnchor, constant: 0)
-    let text3ViewTrailingAnchorConstraint = text3View
-      .trailingAnchor
-      .constraint(equalTo: view1View.trailingAnchor, constant: -(view1ViewTrailingPadding + text3ViewTrailingMargin))
-    let text4ViewBottomAnchorConstraint = text4View
-      .bottomAnchor
-      .constraint(equalTo: view1View.bottomAnchor, constant: -(view1ViewBottomPadding + text4ViewBottomMargin))
-    let text4ViewTopAnchorConstraint = text4View
-      .topAnchor
-      .constraint(equalTo: text3View.bottomAnchor, constant: text3ViewBottomMargin + text4ViewTopMargin)
-    let text4ViewCenterXAnchorConstraint = text4View
-      .centerXAnchor
-      .constraint(equalTo: view1View.centerXAnchor, constant: 0)
+      .constraint(lessThanOrEqualTo: view1View.trailingAnchor)
+    let text2ViewTopAnchorConstraint = text2View.topAnchor.constraint(equalTo: text1View.bottomAnchor, constant: 16)
+    let text2ViewLeadingAnchorConstraint = text2View.leadingAnchor.constraint(equalTo: view1View.leadingAnchor)
+    let text2ViewCenterXAnchorConstraint = text2View.centerXAnchor.constraint(equalTo: view1View.centerXAnchor)
+    let text2ViewTrailingAnchorConstraint = text2View.trailingAnchor.constraint(equalTo: view1View.trailingAnchor)
+    let text3ViewTopAnchorConstraint = text3View.topAnchor.constraint(equalTo: text2View.bottomAnchor, constant: 12)
+    let text3ViewLeadingAnchorConstraint = text3View.leadingAnchor.constraint(equalTo: view1View.leadingAnchor)
+    let text3ViewCenterXAnchorConstraint = text3View.centerXAnchor.constraint(equalTo: view1View.centerXAnchor)
+    let text3ViewTrailingAnchorConstraint = text3View.trailingAnchor.constraint(equalTo: view1View.trailingAnchor)
+    let text4ViewBottomAnchorConstraint = text4View.bottomAnchor.constraint(equalTo: view1View.bottomAnchor)
+    let text4ViewTopAnchorConstraint = text4View.topAnchor.constraint(equalTo: text3View.bottomAnchor)
+    let text4ViewCenterXAnchorConstraint = text4View.centerXAnchor.constraint(equalTo: view1View.centerXAnchor)
     let text5ViewWidthAnchorParentConstraint = text5View
       .widthAnchor
-      .constraint(
-        lessThanOrEqualTo: view3View.widthAnchor,
-        constant:
-        -(view3ViewLeadingPadding + text5ViewLeadingMargin + view3ViewTrailingPadding + text5ViewTrailingMargin))
-    let text5ViewTopAnchorConstraint = text5View
-      .topAnchor
-      .constraint(equalTo: view3View.topAnchor, constant: view3ViewTopPadding + text5ViewTopMargin)
-    let text5ViewBottomAnchorConstraint = text5View
-      .bottomAnchor
-      .constraint(equalTo: view3View.bottomAnchor, constant: -(view3ViewBottomPadding + text5ViewBottomMargin))
+      .constraint(lessThanOrEqualTo: view3View.widthAnchor, constant: -(12 + 12))
+    let text5ViewTopAnchorConstraint = text5View.topAnchor.constraint(equalTo: view3View.topAnchor)
+    let text5ViewBottomAnchorConstraint = text5View.bottomAnchor.constraint(equalTo: view3View.bottomAnchor)
     let text5ViewLeadingAnchorConstraint = text5View
       .leadingAnchor
-      .constraint(equalTo: view3View.leadingAnchor, constant: view3ViewLeadingPadding + text5ViewLeadingMargin)
-    let text5ViewCenterXAnchorConstraint = text5View
-      .centerXAnchor
-      .constraint(equalTo: view3View.centerXAnchor, constant: 0)
+      .constraint(equalTo: view3View.leadingAnchor, constant: 12)
+    let text5ViewCenterXAnchorConstraint = text5View.centerXAnchor.constraint(equalTo: view3View.centerXAnchor)
     let text5ViewTrailingAnchorConstraint = text5View
       .trailingAnchor
-      .constraint(equalTo: view3View.trailingAnchor, constant: -(view3ViewTrailingPadding + text5ViewTrailingMargin))
+      .constraint(equalTo: view3View.trailingAnchor, constant: -12)
     let view4ViewWidthAnchorConstraint = view4View.widthAnchor.constraint(equalToConstant: 400)
-    let text6ViewTopAnchorConstraint = text6View
-      .topAnchor
-      .constraint(equalTo: view4View.topAnchor, constant: view4ViewTopPadding + text6ViewTopMargin)
-    let text6ViewBottomAnchorConstraint = text6View
-      .bottomAnchor
-      .constraint(equalTo: view4View.bottomAnchor, constant: -(view4ViewBottomPadding + text6ViewBottomMargin))
+    let text6ViewTopAnchorConstraint = text6View.topAnchor.constraint(equalTo: view4View.topAnchor)
+    let text6ViewBottomAnchorConstraint = text6View.bottomAnchor.constraint(equalTo: view4View.bottomAnchor)
     let text6ViewLeadingAnchorConstraint = text6View
       .leadingAnchor
-      .constraint(equalTo: view4View.leadingAnchor, constant: view4ViewLeadingPadding + text6ViewLeadingMargin)
-    let text6ViewCenterXAnchorConstraint = text6View
-      .centerXAnchor
-      .constraint(equalTo: view4View.centerXAnchor, constant: 0)
+      .constraint(equalTo: view4View.leadingAnchor, constant: 12)
+    let text6ViewCenterXAnchorConstraint = text6View.centerXAnchor.constraint(equalTo: view4View.centerXAnchor)
     let text6ViewTrailingAnchorConstraint = text6View
       .trailingAnchor
-      .constraint(equalTo: view4View.trailingAnchor, constant: -(view4ViewTrailingPadding + text6ViewTrailingMargin))
+      .constraint(equalTo: view4View.trailingAnchor, constant: -12)
     let text7ViewWidthAnchorParentConstraint = text7View
       .widthAnchor
-      .constraint(
-        lessThanOrEqualTo: view5View.widthAnchor,
-        constant:
-        -(view5ViewLeadingPadding + text7ViewLeadingMargin + view5ViewTrailingPadding + text7ViewTrailingMargin))
-    let text7ViewTopAnchorConstraint = text7View
-      .topAnchor
-      .constraint(equalTo: view5View.topAnchor, constant: view5ViewTopPadding + text7ViewTopMargin)
-    let text7ViewBottomAnchorConstraint = text7View
-      .bottomAnchor
-      .constraint(equalTo: view5View.bottomAnchor, constant: -(view5ViewBottomPadding + text7ViewBottomMargin))
+      .constraint(lessThanOrEqualTo: view5View.widthAnchor, constant: -(12 + 12))
+    let text7ViewTopAnchorConstraint = text7View.topAnchor.constraint(equalTo: view5View.topAnchor)
+    let text7ViewBottomAnchorConstraint = text7View.bottomAnchor.constraint(equalTo: view5View.bottomAnchor)
     let text7ViewLeadingAnchorConstraint = text7View
       .leadingAnchor
-      .constraint(equalTo: view5View.leadingAnchor, constant: view5ViewLeadingPadding + text7ViewLeadingMargin)
+      .constraint(equalTo: view5View.leadingAnchor, constant: 12)
     let text7ViewTrailingAnchorConstraint = text7View
       .trailingAnchor
-      .constraint(equalTo: view5View.trailingAnchor, constant: -(view5ViewTrailingPadding + text7ViewTrailingMargin))
+      .constraint(equalTo: view5View.trailingAnchor, constant: -12)
     let view6ViewWidthAnchorConstraint = view6View.widthAnchor.constraint(equalToConstant: 400)
-    let text8ViewTopAnchorConstraint = text8View
-      .topAnchor
-      .constraint(equalTo: view6View.topAnchor, constant: view6ViewTopPadding + text8ViewTopMargin)
-    let text8ViewBottomAnchorConstraint = text8View
-      .bottomAnchor
-      .constraint(equalTo: view6View.bottomAnchor, constant: -(view6ViewBottomPadding + text8ViewBottomMargin))
+    let text8ViewTopAnchorConstraint = text8View.topAnchor.constraint(equalTo: view6View.topAnchor)
+    let text8ViewBottomAnchorConstraint = text8View.bottomAnchor.constraint(equalTo: view6View.bottomAnchor)
     let text8ViewLeadingAnchorConstraint = text8View
       .leadingAnchor
-      .constraint(equalTo: view6View.leadingAnchor, constant: view6ViewLeadingPadding + text8ViewLeadingMargin)
+      .constraint(equalTo: view6View.leadingAnchor, constant: 12)
     let text8ViewTrailingAnchorConstraint = text8View
       .trailingAnchor
-      .constraint(equalTo: view6View.trailingAnchor, constant: -(view6ViewTrailingPadding + text8ViewTrailingMargin))
-    let text9ViewTopAnchorConstraint = text9View
-      .topAnchor
-      .constraint(
-        equalTo: rightAlignmentContainerView.topAnchor,
-        constant: rightAlignmentContainerViewTopPadding + text9ViewTopMargin)
+      .constraint(equalTo: view6View.trailingAnchor, constant: -12)
+    let text9ViewTopAnchorConstraint = text9View.topAnchor.constraint(equalTo: rightAlignmentContainerView.topAnchor)
     let text9ViewLeadingAnchorConstraint = text9View
       .leadingAnchor
-      .constraint(
-        greaterThanOrEqualTo: rightAlignmentContainerView.leadingAnchor,
-        constant: rightAlignmentContainerViewLeadingPadding + text9ViewLeadingMargin)
+      .constraint(greaterThanOrEqualTo: rightAlignmentContainerView.leadingAnchor)
     let text9ViewTrailingAnchorConstraint = text9View
       .trailingAnchor
-      .constraint(
-        equalTo: rightAlignmentContainerView.trailingAnchor,
-        constant: -(rightAlignmentContainerViewTrailingPadding + text9ViewTrailingMargin))
-    let text10ViewTopAnchorConstraint = text10View
-      .topAnchor
-      .constraint(equalTo: text9View.bottomAnchor, constant: text9ViewBottomMargin + text10ViewTopMargin)
+      .constraint(equalTo: rightAlignmentContainerView.trailingAnchor)
+    let text10ViewTopAnchorConstraint = text10View.topAnchor.constraint(equalTo: text9View.bottomAnchor)
     let text10ViewLeadingAnchorConstraint = text10View
       .leadingAnchor
-      .constraint(
-        equalTo: rightAlignmentContainerView.leadingAnchor,
-        constant: rightAlignmentContainerViewLeadingPadding + text10ViewLeadingMargin)
+      .constraint(equalTo: rightAlignmentContainerView.leadingAnchor)
     let text10ViewTrailingAnchorConstraint = text10View
       .trailingAnchor
-      .constraint(
-        equalTo: rightAlignmentContainerView.trailingAnchor,
-        constant: -(rightAlignmentContainerViewTrailingPadding + text10ViewTrailingMargin))
+      .constraint(equalTo: rightAlignmentContainerView.trailingAnchor)
     let image1ViewBottomAnchorConstraint = image1View
       .bottomAnchor
-      .constraint(
-        equalTo: rightAlignmentContainerView.bottomAnchor,
-        constant: -(rightAlignmentContainerViewBottomPadding + image1ViewBottomMargin))
-    let image1ViewTopAnchorConstraint = image1View
-      .topAnchor
-      .constraint(equalTo: text10View.bottomAnchor, constant: text10ViewBottomMargin + image1ViewTopMargin)
+      .constraint(equalTo: rightAlignmentContainerView.bottomAnchor)
+    let image1ViewTopAnchorConstraint = image1View.topAnchor.constraint(equalTo: text10View.bottomAnchor)
     let image1ViewTrailingAnchorConstraint = image1View
       .trailingAnchor
-      .constraint(
-        equalTo: rightAlignmentContainerView.trailingAnchor,
-        constant: -(rightAlignmentContainerViewTrailingPadding + image1ViewTrailingMargin))
+      .constraint(equalTo: rightAlignmentContainerView.trailingAnchor)
     let imageViewHeightAnchorConstraint = imageView.heightAnchor.constraint(equalToConstant: 100)
     let imageViewWidthAnchorConstraint = imageView.widthAnchor.constraint(equalToConstant: 100)
     let text4ViewWidthAnchorConstraint = text4View.widthAnchor.constraint(equalToConstant: 80)
@@ -684,166 +376,6 @@ public class TextAlignment: NSBox {
       image1ViewHeightAnchorConstraint,
       image1ViewWidthAnchorConstraint
     ])
-
-    self.view1ViewTopAnchorConstraint = view1ViewTopAnchorConstraint
-    self.view1ViewLeadingAnchorConstraint = view1ViewLeadingAnchorConstraint
-    self.view1ViewTrailingAnchorConstraint = view1ViewTrailingAnchorConstraint
-    self.view3ViewTopAnchorConstraint = view3ViewTopAnchorConstraint
-    self.view3ViewLeadingAnchorConstraint = view3ViewLeadingAnchorConstraint
-    self.view3ViewTrailingAnchorConstraint = view3ViewTrailingAnchorConstraint
-    self.view4ViewTopAnchorConstraint = view4ViewTopAnchorConstraint
-    self.view4ViewLeadingAnchorConstraint = view4ViewLeadingAnchorConstraint
-    self.view5ViewTopAnchorConstraint = view5ViewTopAnchorConstraint
-    self.view5ViewLeadingAnchorConstraint = view5ViewLeadingAnchorConstraint
-    self.view5ViewTrailingAnchorConstraint = view5ViewTrailingAnchorConstraint
-    self.view6ViewTopAnchorConstraint = view6ViewTopAnchorConstraint
-    self.view6ViewLeadingAnchorConstraint = view6ViewLeadingAnchorConstraint
-    self.rightAlignmentContainerViewBottomAnchorConstraint = rightAlignmentContainerViewBottomAnchorConstraint
-    self.rightAlignmentContainerViewTopAnchorConstraint = rightAlignmentContainerViewTopAnchorConstraint
-    self.rightAlignmentContainerViewLeadingAnchorConstraint = rightAlignmentContainerViewLeadingAnchorConstraint
-    self.rightAlignmentContainerViewTrailingAnchorConstraint = rightAlignmentContainerViewTrailingAnchorConstraint
-    self.imageViewTopAnchorConstraint = imageViewTopAnchorConstraint
-    self.imageViewCenterXAnchorConstraint = imageViewCenterXAnchorConstraint
-    self.view2ViewTopAnchorConstraint = view2ViewTopAnchorConstraint
-    self.view2ViewLeadingAnchorConstraint = view2ViewLeadingAnchorConstraint
-    self.view2ViewCenterXAnchorConstraint = view2ViewCenterXAnchorConstraint
-    self.view2ViewTrailingAnchorConstraint = view2ViewTrailingAnchorConstraint
-    self.textViewTopAnchorConstraint = textViewTopAnchorConstraint
-    self.textViewLeadingAnchorConstraint = textViewLeadingAnchorConstraint
-    self.textViewCenterXAnchorConstraint = textViewCenterXAnchorConstraint
-    self.textViewTrailingAnchorConstraint = textViewTrailingAnchorConstraint
-    self.text1ViewTopAnchorConstraint = text1ViewTopAnchorConstraint
-    self.text1ViewLeadingAnchorConstraint = text1ViewLeadingAnchorConstraint
-    self.text1ViewCenterXAnchorConstraint = text1ViewCenterXAnchorConstraint
-    self.text1ViewTrailingAnchorConstraint = text1ViewTrailingAnchorConstraint
-    self.text2ViewTopAnchorConstraint = text2ViewTopAnchorConstraint
-    self.text2ViewLeadingAnchorConstraint = text2ViewLeadingAnchorConstraint
-    self.text2ViewCenterXAnchorConstraint = text2ViewCenterXAnchorConstraint
-    self.text2ViewTrailingAnchorConstraint = text2ViewTrailingAnchorConstraint
-    self.text3ViewTopAnchorConstraint = text3ViewTopAnchorConstraint
-    self.text3ViewLeadingAnchorConstraint = text3ViewLeadingAnchorConstraint
-    self.text3ViewCenterXAnchorConstraint = text3ViewCenterXAnchorConstraint
-    self.text3ViewTrailingAnchorConstraint = text3ViewTrailingAnchorConstraint
-    self.text4ViewBottomAnchorConstraint = text4ViewBottomAnchorConstraint
-    self.text4ViewTopAnchorConstraint = text4ViewTopAnchorConstraint
-    self.text4ViewCenterXAnchorConstraint = text4ViewCenterXAnchorConstraint
-    self.text5ViewWidthAnchorParentConstraint = text5ViewWidthAnchorParentConstraint
-    self.text5ViewTopAnchorConstraint = text5ViewTopAnchorConstraint
-    self.text5ViewBottomAnchorConstraint = text5ViewBottomAnchorConstraint
-    self.text5ViewLeadingAnchorConstraint = text5ViewLeadingAnchorConstraint
-    self.text5ViewCenterXAnchorConstraint = text5ViewCenterXAnchorConstraint
-    self.text5ViewTrailingAnchorConstraint = text5ViewTrailingAnchorConstraint
-    self.view4ViewWidthAnchorConstraint = view4ViewWidthAnchorConstraint
-    self.text6ViewTopAnchorConstraint = text6ViewTopAnchorConstraint
-    self.text6ViewBottomAnchorConstraint = text6ViewBottomAnchorConstraint
-    self.text6ViewLeadingAnchorConstraint = text6ViewLeadingAnchorConstraint
-    self.text6ViewCenterXAnchorConstraint = text6ViewCenterXAnchorConstraint
-    self.text6ViewTrailingAnchorConstraint = text6ViewTrailingAnchorConstraint
-    self.text7ViewWidthAnchorParentConstraint = text7ViewWidthAnchorParentConstraint
-    self.text7ViewTopAnchorConstraint = text7ViewTopAnchorConstraint
-    self.text7ViewBottomAnchorConstraint = text7ViewBottomAnchorConstraint
-    self.text7ViewLeadingAnchorConstraint = text7ViewLeadingAnchorConstraint
-    self.text7ViewTrailingAnchorConstraint = text7ViewTrailingAnchorConstraint
-    self.view6ViewWidthAnchorConstraint = view6ViewWidthAnchorConstraint
-    self.text8ViewTopAnchorConstraint = text8ViewTopAnchorConstraint
-    self.text8ViewBottomAnchorConstraint = text8ViewBottomAnchorConstraint
-    self.text8ViewLeadingAnchorConstraint = text8ViewLeadingAnchorConstraint
-    self.text8ViewTrailingAnchorConstraint = text8ViewTrailingAnchorConstraint
-    self.text9ViewTopAnchorConstraint = text9ViewTopAnchorConstraint
-    self.text9ViewLeadingAnchorConstraint = text9ViewLeadingAnchorConstraint
-    self.text9ViewTrailingAnchorConstraint = text9ViewTrailingAnchorConstraint
-    self.text10ViewTopAnchorConstraint = text10ViewTopAnchorConstraint
-    self.text10ViewLeadingAnchorConstraint = text10ViewLeadingAnchorConstraint
-    self.text10ViewTrailingAnchorConstraint = text10ViewTrailingAnchorConstraint
-    self.image1ViewBottomAnchorConstraint = image1ViewBottomAnchorConstraint
-    self.image1ViewTopAnchorConstraint = image1ViewTopAnchorConstraint
-    self.image1ViewTrailingAnchorConstraint = image1ViewTrailingAnchorConstraint
-    self.imageViewHeightAnchorConstraint = imageViewHeightAnchorConstraint
-    self.imageViewWidthAnchorConstraint = imageViewWidthAnchorConstraint
-    self.text4ViewWidthAnchorConstraint = text4ViewWidthAnchorConstraint
-    self.image1ViewHeightAnchorConstraint = image1ViewHeightAnchorConstraint
-    self.image1ViewWidthAnchorConstraint = image1ViewWidthAnchorConstraint
-
-    // For debugging
-    view1ViewTopAnchorConstraint.identifier = "view1ViewTopAnchorConstraint"
-    view1ViewLeadingAnchorConstraint.identifier = "view1ViewLeadingAnchorConstraint"
-    view1ViewTrailingAnchorConstraint.identifier = "view1ViewTrailingAnchorConstraint"
-    view3ViewTopAnchorConstraint.identifier = "view3ViewTopAnchorConstraint"
-    view3ViewLeadingAnchorConstraint.identifier = "view3ViewLeadingAnchorConstraint"
-    view3ViewTrailingAnchorConstraint.identifier = "view3ViewTrailingAnchorConstraint"
-    view4ViewTopAnchorConstraint.identifier = "view4ViewTopAnchorConstraint"
-    view4ViewLeadingAnchorConstraint.identifier = "view4ViewLeadingAnchorConstraint"
-    view5ViewTopAnchorConstraint.identifier = "view5ViewTopAnchorConstraint"
-    view5ViewLeadingAnchorConstraint.identifier = "view5ViewLeadingAnchorConstraint"
-    view5ViewTrailingAnchorConstraint.identifier = "view5ViewTrailingAnchorConstraint"
-    view6ViewTopAnchorConstraint.identifier = "view6ViewTopAnchorConstraint"
-    view6ViewLeadingAnchorConstraint.identifier = "view6ViewLeadingAnchorConstraint"
-    rightAlignmentContainerViewBottomAnchorConstraint.identifier = "rightAlignmentContainerViewBottomAnchorConstraint"
-    rightAlignmentContainerViewTopAnchorConstraint.identifier = "rightAlignmentContainerViewTopAnchorConstraint"
-    rightAlignmentContainerViewLeadingAnchorConstraint.identifier = "rightAlignmentContainerViewLeadingAnchorConstraint"
-    rightAlignmentContainerViewTrailingAnchorConstraint.identifier =
-      "rightAlignmentContainerViewTrailingAnchorConstraint"
-    imageViewTopAnchorConstraint.identifier = "imageViewTopAnchorConstraint"
-    imageViewCenterXAnchorConstraint.identifier = "imageViewCenterXAnchorConstraint"
-    view2ViewTopAnchorConstraint.identifier = "view2ViewTopAnchorConstraint"
-    view2ViewLeadingAnchorConstraint.identifier = "view2ViewLeadingAnchorConstraint"
-    view2ViewCenterXAnchorConstraint.identifier = "view2ViewCenterXAnchorConstraint"
-    view2ViewTrailingAnchorConstraint.identifier = "view2ViewTrailingAnchorConstraint"
-    textViewTopAnchorConstraint.identifier = "textViewTopAnchorConstraint"
-    textViewLeadingAnchorConstraint.identifier = "textViewLeadingAnchorConstraint"
-    textViewCenterXAnchorConstraint.identifier = "textViewCenterXAnchorConstraint"
-    textViewTrailingAnchorConstraint.identifier = "textViewTrailingAnchorConstraint"
-    text1ViewTopAnchorConstraint.identifier = "text1ViewTopAnchorConstraint"
-    text1ViewLeadingAnchorConstraint.identifier = "text1ViewLeadingAnchorConstraint"
-    text1ViewCenterXAnchorConstraint.identifier = "text1ViewCenterXAnchorConstraint"
-    text1ViewTrailingAnchorConstraint.identifier = "text1ViewTrailingAnchorConstraint"
-    text2ViewTopAnchorConstraint.identifier = "text2ViewTopAnchorConstraint"
-    text2ViewLeadingAnchorConstraint.identifier = "text2ViewLeadingAnchorConstraint"
-    text2ViewCenterXAnchorConstraint.identifier = "text2ViewCenterXAnchorConstraint"
-    text2ViewTrailingAnchorConstraint.identifier = "text2ViewTrailingAnchorConstraint"
-    text3ViewTopAnchorConstraint.identifier = "text3ViewTopAnchorConstraint"
-    text3ViewLeadingAnchorConstraint.identifier = "text3ViewLeadingAnchorConstraint"
-    text3ViewCenterXAnchorConstraint.identifier = "text3ViewCenterXAnchorConstraint"
-    text3ViewTrailingAnchorConstraint.identifier = "text3ViewTrailingAnchorConstraint"
-    text4ViewBottomAnchorConstraint.identifier = "text4ViewBottomAnchorConstraint"
-    text4ViewTopAnchorConstraint.identifier = "text4ViewTopAnchorConstraint"
-    text4ViewCenterXAnchorConstraint.identifier = "text4ViewCenterXAnchorConstraint"
-    text5ViewWidthAnchorParentConstraint.identifier = "text5ViewWidthAnchorParentConstraint"
-    text5ViewTopAnchorConstraint.identifier = "text5ViewTopAnchorConstraint"
-    text5ViewBottomAnchorConstraint.identifier = "text5ViewBottomAnchorConstraint"
-    text5ViewLeadingAnchorConstraint.identifier = "text5ViewLeadingAnchorConstraint"
-    text5ViewCenterXAnchorConstraint.identifier = "text5ViewCenterXAnchorConstraint"
-    text5ViewTrailingAnchorConstraint.identifier = "text5ViewTrailingAnchorConstraint"
-    view4ViewWidthAnchorConstraint.identifier = "view4ViewWidthAnchorConstraint"
-    text6ViewTopAnchorConstraint.identifier = "text6ViewTopAnchorConstraint"
-    text6ViewBottomAnchorConstraint.identifier = "text6ViewBottomAnchorConstraint"
-    text6ViewLeadingAnchorConstraint.identifier = "text6ViewLeadingAnchorConstraint"
-    text6ViewCenterXAnchorConstraint.identifier = "text6ViewCenterXAnchorConstraint"
-    text6ViewTrailingAnchorConstraint.identifier = "text6ViewTrailingAnchorConstraint"
-    text7ViewWidthAnchorParentConstraint.identifier = "text7ViewWidthAnchorParentConstraint"
-    text7ViewTopAnchorConstraint.identifier = "text7ViewTopAnchorConstraint"
-    text7ViewBottomAnchorConstraint.identifier = "text7ViewBottomAnchorConstraint"
-    text7ViewLeadingAnchorConstraint.identifier = "text7ViewLeadingAnchorConstraint"
-    text7ViewTrailingAnchorConstraint.identifier = "text7ViewTrailingAnchorConstraint"
-    view6ViewWidthAnchorConstraint.identifier = "view6ViewWidthAnchorConstraint"
-    text8ViewTopAnchorConstraint.identifier = "text8ViewTopAnchorConstraint"
-    text8ViewBottomAnchorConstraint.identifier = "text8ViewBottomAnchorConstraint"
-    text8ViewLeadingAnchorConstraint.identifier = "text8ViewLeadingAnchorConstraint"
-    text8ViewTrailingAnchorConstraint.identifier = "text8ViewTrailingAnchorConstraint"
-    text9ViewTopAnchorConstraint.identifier = "text9ViewTopAnchorConstraint"
-    text9ViewLeadingAnchorConstraint.identifier = "text9ViewLeadingAnchorConstraint"
-    text9ViewTrailingAnchorConstraint.identifier = "text9ViewTrailingAnchorConstraint"
-    text10ViewTopAnchorConstraint.identifier = "text10ViewTopAnchorConstraint"
-    text10ViewLeadingAnchorConstraint.identifier = "text10ViewLeadingAnchorConstraint"
-    text10ViewTrailingAnchorConstraint.identifier = "text10ViewTrailingAnchorConstraint"
-    image1ViewBottomAnchorConstraint.identifier = "image1ViewBottomAnchorConstraint"
-    image1ViewTopAnchorConstraint.identifier = "image1ViewTopAnchorConstraint"
-    image1ViewTrailingAnchorConstraint.identifier = "image1ViewTrailingAnchorConstraint"
-    imageViewHeightAnchorConstraint.identifier = "imageViewHeightAnchorConstraint"
-    imageViewWidthAnchorConstraint.identifier = "imageViewWidthAnchorConstraint"
-    text4ViewWidthAnchorConstraint.identifier = "text4ViewWidthAnchorConstraint"
-    image1ViewHeightAnchorConstraint.identifier = "image1ViewHeightAnchorConstraint"
-    image1ViewWidthAnchorConstraint.identifier = "image1ViewWidthAnchorConstraint"
   }
 
   private func update() {}

--- a/examples/generated/test/appkit/style/TextAlignment.swift
+++ b/examples/generated/test/appkit/style/TextAlignment.swift
@@ -201,7 +201,7 @@ public class TextAlignment: NSBox {
     let view2ViewTrailingAnchorConstraint = view2View
       .trailingAnchor
       .constraint(lessThanOrEqualTo: view1View.trailingAnchor)
-    let textViewTopAnchorConstraint = textView.topAnchor.constraint(equalTo: view2View.bottomAnchor)
+    let textViewTopAnchorConstraint = textView.topAnchor.constraint(equalTo: view2View.bottomAnchor, constant: 16)
     let textViewLeadingAnchorConstraint = textView.leadingAnchor.constraint(equalTo: view1View.leadingAnchor)
     let textViewCenterXAnchorConstraint = textView.centerXAnchor.constraint(equalTo: view1View.centerXAnchor)
     let textViewTrailingAnchorConstraint = textView.trailingAnchor.constraint(equalTo: view1View.trailingAnchor)
@@ -213,11 +213,11 @@ public class TextAlignment: NSBox {
     let text1ViewTrailingAnchorConstraint = text1View
       .trailingAnchor
       .constraint(lessThanOrEqualTo: view1View.trailingAnchor)
-    let text2ViewTopAnchorConstraint = text2View.topAnchor.constraint(equalTo: text1View.bottomAnchor, constant: 16)
+    let text2ViewTopAnchorConstraint = text2View.topAnchor.constraint(equalTo: text1View.bottomAnchor, constant: 12)
     let text2ViewLeadingAnchorConstraint = text2View.leadingAnchor.constraint(equalTo: view1View.leadingAnchor)
     let text2ViewCenterXAnchorConstraint = text2View.centerXAnchor.constraint(equalTo: view1View.centerXAnchor)
     let text2ViewTrailingAnchorConstraint = text2View.trailingAnchor.constraint(equalTo: view1View.trailingAnchor)
-    let text3ViewTopAnchorConstraint = text3View.topAnchor.constraint(equalTo: text2View.bottomAnchor, constant: 12)
+    let text3ViewTopAnchorConstraint = text3View.topAnchor.constraint(equalTo: text2View.bottomAnchor)
     let text3ViewLeadingAnchorConstraint = text3View.leadingAnchor.constraint(equalTo: view1View.leadingAnchor)
     let text3ViewCenterXAnchorConstraint = text3View.centerXAnchor.constraint(equalTo: view1View.centerXAnchor)
     let text3ViewTrailingAnchorConstraint = text3View.trailingAnchor.constraint(equalTo: view1View.trailingAnchor)
@@ -226,7 +226,7 @@ public class TextAlignment: NSBox {
     let text4ViewCenterXAnchorConstraint = text4View.centerXAnchor.constraint(equalTo: view1View.centerXAnchor)
     let text5ViewWidthAnchorParentConstraint = text5View
       .widthAnchor
-      .constraint(lessThanOrEqualTo: view3View.widthAnchor, constant: -(12 + 12))
+      .constraint(lessThanOrEqualTo: view3View.widthAnchor, constant: -24)
     let text5ViewTopAnchorConstraint = text5View.topAnchor.constraint(equalTo: view3View.topAnchor)
     let text5ViewBottomAnchorConstraint = text5View.bottomAnchor.constraint(equalTo: view3View.bottomAnchor)
     let text5ViewLeadingAnchorConstraint = text5View
@@ -248,7 +248,7 @@ public class TextAlignment: NSBox {
       .constraint(equalTo: view4View.trailingAnchor, constant: -12)
     let text7ViewWidthAnchorParentConstraint = text7View
       .widthAnchor
-      .constraint(lessThanOrEqualTo: view5View.widthAnchor, constant: -(12 + 12))
+      .constraint(lessThanOrEqualTo: view5View.widthAnchor, constant: -24)
     let text7ViewTopAnchorConstraint = text7View.topAnchor.constraint(equalTo: view5View.topAnchor)
     let text7ViewBottomAnchorConstraint = text7View.bottomAnchor.constraint(equalTo: view5View.bottomAnchor)
     let text7ViewLeadingAnchorConstraint = text7View

--- a/examples/generated/test/appkit/style/TextStyleConditional.swift
+++ b/examples/generated/test/appkit/style/TextStyleConditional.swift
@@ -36,20 +36,6 @@ public class TextStyleConditional: NSBox {
 
   private var textViewTextStyle = TextStyles.headline
 
-  private var topPadding: CGFloat = 0
-  private var trailingPadding: CGFloat = 0
-  private var bottomPadding: CGFloat = 0
-  private var leadingPadding: CGFloat = 0
-  private var textViewTopMargin: CGFloat = 0
-  private var textViewTrailingMargin: CGFloat = 0
-  private var textViewBottomMargin: CGFloat = 0
-  private var textViewLeadingMargin: CGFloat = 0
-
-  private var textViewTopAnchorConstraint: NSLayoutConstraint?
-  private var textViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var textViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var textViewTrailingAnchorConstraint: NSLayoutConstraint?
-
   private func setUpViews() {
     boxType = .custom
     borderType = .noBorder
@@ -65,18 +51,10 @@ public class TextStyleConditional: NSBox {
     translatesAutoresizingMaskIntoConstraints = false
     textView.translatesAutoresizingMaskIntoConstraints = false
 
-    let textViewTopAnchorConstraint = textView
-      .topAnchor
-      .constraint(equalTo: topAnchor, constant: topPadding + textViewTopMargin)
-    let textViewBottomAnchorConstraint = textView
-      .bottomAnchor
-      .constraint(equalTo: bottomAnchor, constant: -(bottomPadding + textViewBottomMargin))
-    let textViewLeadingAnchorConstraint = textView
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + textViewLeadingMargin)
-    let textViewTrailingAnchorConstraint = textView
-      .trailingAnchor
-      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -(trailingPadding + textViewTrailingMargin))
+    let textViewTopAnchorConstraint = textView.topAnchor.constraint(equalTo: topAnchor)
+    let textViewBottomAnchorConstraint = textView.bottomAnchor.constraint(equalTo: bottomAnchor)
+    let textViewLeadingAnchorConstraint = textView.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let textViewTrailingAnchorConstraint = textView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor)
 
     NSLayoutConstraint.activate([
       textViewTopAnchorConstraint,
@@ -84,17 +62,6 @@ public class TextStyleConditional: NSBox {
       textViewLeadingAnchorConstraint,
       textViewTrailingAnchorConstraint
     ])
-
-    self.textViewTopAnchorConstraint = textViewTopAnchorConstraint
-    self.textViewBottomAnchorConstraint = textViewBottomAnchorConstraint
-    self.textViewLeadingAnchorConstraint = textViewLeadingAnchorConstraint
-    self.textViewTrailingAnchorConstraint = textViewTrailingAnchorConstraint
-
-    // For debugging
-    textViewTopAnchorConstraint.identifier = "textViewTopAnchorConstraint"
-    textViewBottomAnchorConstraint.identifier = "textViewBottomAnchorConstraint"
-    textViewLeadingAnchorConstraint.identifier = "textViewLeadingAnchorConstraint"
-    textViewTrailingAnchorConstraint.identifier = "textViewTrailingAnchorConstraint"
   }
 
   private func update() {

--- a/examples/generated/test/appkit/style/TextStylesTest.swift
+++ b/examples/generated/test/appkit/style/TextStylesTest.swift
@@ -44,83 +44,6 @@ public class TextStylesTest: NSBox {
   private var text8ViewTextStyle = TextStyles.body1
   private var text9ViewTextStyle = TextStyles.caption
 
-  private var topPadding: CGFloat = 0
-  private var trailingPadding: CGFloat = 0
-  private var bottomPadding: CGFloat = 0
-  private var leadingPadding: CGFloat = 0
-  private var textViewTopMargin: CGFloat = 0
-  private var textViewTrailingMargin: CGFloat = 0
-  private var textViewBottomMargin: CGFloat = 0
-  private var textViewLeadingMargin: CGFloat = 0
-  private var text1ViewTopMargin: CGFloat = 0
-  private var text1ViewTrailingMargin: CGFloat = 0
-  private var text1ViewBottomMargin: CGFloat = 0
-  private var text1ViewLeadingMargin: CGFloat = 0
-  private var text2ViewTopMargin: CGFloat = 0
-  private var text2ViewTrailingMargin: CGFloat = 0
-  private var text2ViewBottomMargin: CGFloat = 0
-  private var text2ViewLeadingMargin: CGFloat = 0
-  private var text3ViewTopMargin: CGFloat = 0
-  private var text3ViewTrailingMargin: CGFloat = 0
-  private var text3ViewBottomMargin: CGFloat = 0
-  private var text3ViewLeadingMargin: CGFloat = 0
-  private var text4ViewTopMargin: CGFloat = 0
-  private var text4ViewTrailingMargin: CGFloat = 0
-  private var text4ViewBottomMargin: CGFloat = 0
-  private var text4ViewLeadingMargin: CGFloat = 0
-  private var text5ViewTopMargin: CGFloat = 0
-  private var text5ViewTrailingMargin: CGFloat = 0
-  private var text5ViewBottomMargin: CGFloat = 0
-  private var text5ViewLeadingMargin: CGFloat = 0
-  private var text6ViewTopMargin: CGFloat = 0
-  private var text6ViewTrailingMargin: CGFloat = 0
-  private var text6ViewBottomMargin: CGFloat = 0
-  private var text6ViewLeadingMargin: CGFloat = 0
-  private var text7ViewTopMargin: CGFloat = 0
-  private var text7ViewTrailingMargin: CGFloat = 0
-  private var text7ViewBottomMargin: CGFloat = 0
-  private var text7ViewLeadingMargin: CGFloat = 0
-  private var text8ViewTopMargin: CGFloat = 0
-  private var text8ViewTrailingMargin: CGFloat = 0
-  private var text8ViewBottomMargin: CGFloat = 0
-  private var text8ViewLeadingMargin: CGFloat = 0
-  private var text9ViewTopMargin: CGFloat = 0
-  private var text9ViewTrailingMargin: CGFloat = 0
-  private var text9ViewBottomMargin: CGFloat = 0
-  private var text9ViewLeadingMargin: CGFloat = 0
-
-  private var textViewTopAnchorConstraint: NSLayoutConstraint?
-  private var textViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var textViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var text1ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var text1ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var text1ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var text2ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var text2ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var text2ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var text3ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var text3ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var text3ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var text4ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var text4ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var text4ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var text5ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var text5ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var text5ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var text6ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var text6ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var text6ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var text7ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var text7ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var text7ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var text8ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var text8ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var text8ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var text9ViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var text9ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var text9ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var text9ViewTrailingAnchorConstraint: NSLayoutConstraint?
-
   private func setUpViews() {
     boxType = .custom
     borderType = .noBorder
@@ -192,99 +115,37 @@ public class TextStylesTest: NSBox {
     text8View.translatesAutoresizingMaskIntoConstraints = false
     text9View.translatesAutoresizingMaskIntoConstraints = false
 
-    let textViewTopAnchorConstraint = textView
-      .topAnchor
-      .constraint(equalTo: topAnchor, constant: topPadding + textViewTopMargin)
-    let textViewLeadingAnchorConstraint = textView
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + textViewLeadingMargin)
-    let textViewTrailingAnchorConstraint = textView
-      .trailingAnchor
-      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -(trailingPadding + textViewTrailingMargin))
-    let text1ViewTopAnchorConstraint = text1View
-      .topAnchor
-      .constraint(equalTo: textView.bottomAnchor, constant: textViewBottomMargin + text1ViewTopMargin)
-    let text1ViewLeadingAnchorConstraint = text1View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + text1ViewLeadingMargin)
-    let text1ViewTrailingAnchorConstraint = text1View
-      .trailingAnchor
-      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -(trailingPadding + text1ViewTrailingMargin))
-    let text2ViewTopAnchorConstraint = text2View
-      .topAnchor
-      .constraint(equalTo: text1View.bottomAnchor, constant: text1ViewBottomMargin + text2ViewTopMargin)
-    let text2ViewLeadingAnchorConstraint = text2View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + text2ViewLeadingMargin)
-    let text2ViewTrailingAnchorConstraint = text2View
-      .trailingAnchor
-      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -(trailingPadding + text2ViewTrailingMargin))
-    let text3ViewTopAnchorConstraint = text3View
-      .topAnchor
-      .constraint(equalTo: text2View.bottomAnchor, constant: text2ViewBottomMargin + text3ViewTopMargin)
-    let text3ViewLeadingAnchorConstraint = text3View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + text3ViewLeadingMargin)
-    let text3ViewTrailingAnchorConstraint = text3View
-      .trailingAnchor
-      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -(trailingPadding + text3ViewTrailingMargin))
-    let text4ViewTopAnchorConstraint = text4View
-      .topAnchor
-      .constraint(equalTo: text3View.bottomAnchor, constant: text3ViewBottomMargin + text4ViewTopMargin)
-    let text4ViewLeadingAnchorConstraint = text4View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + text4ViewLeadingMargin)
-    let text4ViewTrailingAnchorConstraint = text4View
-      .trailingAnchor
-      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -(trailingPadding + text4ViewTrailingMargin))
-    let text5ViewTopAnchorConstraint = text5View
-      .topAnchor
-      .constraint(equalTo: text4View.bottomAnchor, constant: text4ViewBottomMargin + text5ViewTopMargin)
-    let text5ViewLeadingAnchorConstraint = text5View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + text5ViewLeadingMargin)
-    let text5ViewTrailingAnchorConstraint = text5View
-      .trailingAnchor
-      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -(trailingPadding + text5ViewTrailingMargin))
-    let text6ViewTopAnchorConstraint = text6View
-      .topAnchor
-      .constraint(equalTo: text5View.bottomAnchor, constant: text5ViewBottomMargin + text6ViewTopMargin)
-    let text6ViewLeadingAnchorConstraint = text6View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + text6ViewLeadingMargin)
-    let text6ViewTrailingAnchorConstraint = text6View
-      .trailingAnchor
-      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -(trailingPadding + text6ViewTrailingMargin))
-    let text7ViewTopAnchorConstraint = text7View
-      .topAnchor
-      .constraint(equalTo: text6View.bottomAnchor, constant: text6ViewBottomMargin + text7ViewTopMargin)
-    let text7ViewLeadingAnchorConstraint = text7View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + text7ViewLeadingMargin)
-    let text7ViewTrailingAnchorConstraint = text7View
-      .trailingAnchor
-      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -(trailingPadding + text7ViewTrailingMargin))
-    let text8ViewTopAnchorConstraint = text8View
-      .topAnchor
-      .constraint(equalTo: text7View.bottomAnchor, constant: text7ViewBottomMargin + text8ViewTopMargin)
-    let text8ViewLeadingAnchorConstraint = text8View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + text8ViewLeadingMargin)
-    let text8ViewTrailingAnchorConstraint = text8View
-      .trailingAnchor
-      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -(trailingPadding + text8ViewTrailingMargin))
-    let text9ViewBottomAnchorConstraint = text9View
-      .bottomAnchor
-      .constraint(equalTo: bottomAnchor, constant: -(bottomPadding + text9ViewBottomMargin))
-    let text9ViewTopAnchorConstraint = text9View
-      .topAnchor
-      .constraint(equalTo: text8View.bottomAnchor, constant: text8ViewBottomMargin + text9ViewTopMargin)
-    let text9ViewLeadingAnchorConstraint = text9View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + text9ViewLeadingMargin)
-    let text9ViewTrailingAnchorConstraint = text9View
-      .trailingAnchor
-      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -(trailingPadding + text9ViewTrailingMargin))
+    let textViewTopAnchorConstraint = textView.topAnchor.constraint(equalTo: topAnchor)
+    let textViewLeadingAnchorConstraint = textView.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let textViewTrailingAnchorConstraint = textView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor)
+    let text1ViewTopAnchorConstraint = text1View.topAnchor.constraint(equalTo: textView.bottomAnchor)
+    let text1ViewLeadingAnchorConstraint = text1View.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let text1ViewTrailingAnchorConstraint = text1View.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor)
+    let text2ViewTopAnchorConstraint = text2View.topAnchor.constraint(equalTo: text1View.bottomAnchor)
+    let text2ViewLeadingAnchorConstraint = text2View.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let text2ViewTrailingAnchorConstraint = text2View.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor)
+    let text3ViewTopAnchorConstraint = text3View.topAnchor.constraint(equalTo: text2View.bottomAnchor)
+    let text3ViewLeadingAnchorConstraint = text3View.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let text3ViewTrailingAnchorConstraint = text3View.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor)
+    let text4ViewTopAnchorConstraint = text4View.topAnchor.constraint(equalTo: text3View.bottomAnchor)
+    let text4ViewLeadingAnchorConstraint = text4View.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let text4ViewTrailingAnchorConstraint = text4View.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor)
+    let text5ViewTopAnchorConstraint = text5View.topAnchor.constraint(equalTo: text4View.bottomAnchor)
+    let text5ViewLeadingAnchorConstraint = text5View.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let text5ViewTrailingAnchorConstraint = text5View.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor)
+    let text6ViewTopAnchorConstraint = text6View.topAnchor.constraint(equalTo: text5View.bottomAnchor)
+    let text6ViewLeadingAnchorConstraint = text6View.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let text6ViewTrailingAnchorConstraint = text6View.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor)
+    let text7ViewTopAnchorConstraint = text7View.topAnchor.constraint(equalTo: text6View.bottomAnchor)
+    let text7ViewLeadingAnchorConstraint = text7View.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let text7ViewTrailingAnchorConstraint = text7View.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor)
+    let text8ViewTopAnchorConstraint = text8View.topAnchor.constraint(equalTo: text7View.bottomAnchor)
+    let text8ViewLeadingAnchorConstraint = text8View.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let text8ViewTrailingAnchorConstraint = text8View.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor)
+    let text9ViewBottomAnchorConstraint = text9View.bottomAnchor.constraint(equalTo: bottomAnchor)
+    let text9ViewTopAnchorConstraint = text9View.topAnchor.constraint(equalTo: text8View.bottomAnchor)
+    let text9ViewLeadingAnchorConstraint = text9View.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let text9ViewTrailingAnchorConstraint = text9View.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor)
 
     NSLayoutConstraint.activate([
       textViewTopAnchorConstraint,
@@ -319,71 +180,6 @@ public class TextStylesTest: NSBox {
       text9ViewLeadingAnchorConstraint,
       text9ViewTrailingAnchorConstraint
     ])
-
-    self.textViewTopAnchorConstraint = textViewTopAnchorConstraint
-    self.textViewLeadingAnchorConstraint = textViewLeadingAnchorConstraint
-    self.textViewTrailingAnchorConstraint = textViewTrailingAnchorConstraint
-    self.text1ViewTopAnchorConstraint = text1ViewTopAnchorConstraint
-    self.text1ViewLeadingAnchorConstraint = text1ViewLeadingAnchorConstraint
-    self.text1ViewTrailingAnchorConstraint = text1ViewTrailingAnchorConstraint
-    self.text2ViewTopAnchorConstraint = text2ViewTopAnchorConstraint
-    self.text2ViewLeadingAnchorConstraint = text2ViewLeadingAnchorConstraint
-    self.text2ViewTrailingAnchorConstraint = text2ViewTrailingAnchorConstraint
-    self.text3ViewTopAnchorConstraint = text3ViewTopAnchorConstraint
-    self.text3ViewLeadingAnchorConstraint = text3ViewLeadingAnchorConstraint
-    self.text3ViewTrailingAnchorConstraint = text3ViewTrailingAnchorConstraint
-    self.text4ViewTopAnchorConstraint = text4ViewTopAnchorConstraint
-    self.text4ViewLeadingAnchorConstraint = text4ViewLeadingAnchorConstraint
-    self.text4ViewTrailingAnchorConstraint = text4ViewTrailingAnchorConstraint
-    self.text5ViewTopAnchorConstraint = text5ViewTopAnchorConstraint
-    self.text5ViewLeadingAnchorConstraint = text5ViewLeadingAnchorConstraint
-    self.text5ViewTrailingAnchorConstraint = text5ViewTrailingAnchorConstraint
-    self.text6ViewTopAnchorConstraint = text6ViewTopAnchorConstraint
-    self.text6ViewLeadingAnchorConstraint = text6ViewLeadingAnchorConstraint
-    self.text6ViewTrailingAnchorConstraint = text6ViewTrailingAnchorConstraint
-    self.text7ViewTopAnchorConstraint = text7ViewTopAnchorConstraint
-    self.text7ViewLeadingAnchorConstraint = text7ViewLeadingAnchorConstraint
-    self.text7ViewTrailingAnchorConstraint = text7ViewTrailingAnchorConstraint
-    self.text8ViewTopAnchorConstraint = text8ViewTopAnchorConstraint
-    self.text8ViewLeadingAnchorConstraint = text8ViewLeadingAnchorConstraint
-    self.text8ViewTrailingAnchorConstraint = text8ViewTrailingAnchorConstraint
-    self.text9ViewBottomAnchorConstraint = text9ViewBottomAnchorConstraint
-    self.text9ViewTopAnchorConstraint = text9ViewTopAnchorConstraint
-    self.text9ViewLeadingAnchorConstraint = text9ViewLeadingAnchorConstraint
-    self.text9ViewTrailingAnchorConstraint = text9ViewTrailingAnchorConstraint
-
-    // For debugging
-    textViewTopAnchorConstraint.identifier = "textViewTopAnchorConstraint"
-    textViewLeadingAnchorConstraint.identifier = "textViewLeadingAnchorConstraint"
-    textViewTrailingAnchorConstraint.identifier = "textViewTrailingAnchorConstraint"
-    text1ViewTopAnchorConstraint.identifier = "text1ViewTopAnchorConstraint"
-    text1ViewLeadingAnchorConstraint.identifier = "text1ViewLeadingAnchorConstraint"
-    text1ViewTrailingAnchorConstraint.identifier = "text1ViewTrailingAnchorConstraint"
-    text2ViewTopAnchorConstraint.identifier = "text2ViewTopAnchorConstraint"
-    text2ViewLeadingAnchorConstraint.identifier = "text2ViewLeadingAnchorConstraint"
-    text2ViewTrailingAnchorConstraint.identifier = "text2ViewTrailingAnchorConstraint"
-    text3ViewTopAnchorConstraint.identifier = "text3ViewTopAnchorConstraint"
-    text3ViewLeadingAnchorConstraint.identifier = "text3ViewLeadingAnchorConstraint"
-    text3ViewTrailingAnchorConstraint.identifier = "text3ViewTrailingAnchorConstraint"
-    text4ViewTopAnchorConstraint.identifier = "text4ViewTopAnchorConstraint"
-    text4ViewLeadingAnchorConstraint.identifier = "text4ViewLeadingAnchorConstraint"
-    text4ViewTrailingAnchorConstraint.identifier = "text4ViewTrailingAnchorConstraint"
-    text5ViewTopAnchorConstraint.identifier = "text5ViewTopAnchorConstraint"
-    text5ViewLeadingAnchorConstraint.identifier = "text5ViewLeadingAnchorConstraint"
-    text5ViewTrailingAnchorConstraint.identifier = "text5ViewTrailingAnchorConstraint"
-    text6ViewTopAnchorConstraint.identifier = "text6ViewTopAnchorConstraint"
-    text6ViewLeadingAnchorConstraint.identifier = "text6ViewLeadingAnchorConstraint"
-    text6ViewTrailingAnchorConstraint.identifier = "text6ViewTrailingAnchorConstraint"
-    text7ViewTopAnchorConstraint.identifier = "text7ViewTopAnchorConstraint"
-    text7ViewLeadingAnchorConstraint.identifier = "text7ViewLeadingAnchorConstraint"
-    text7ViewTrailingAnchorConstraint.identifier = "text7ViewTrailingAnchorConstraint"
-    text8ViewTopAnchorConstraint.identifier = "text8ViewTopAnchorConstraint"
-    text8ViewLeadingAnchorConstraint.identifier = "text8ViewLeadingAnchorConstraint"
-    text8ViewTrailingAnchorConstraint.identifier = "text8ViewTrailingAnchorConstraint"
-    text9ViewBottomAnchorConstraint.identifier = "text9ViewBottomAnchorConstraint"
-    text9ViewTopAnchorConstraint.identifier = "text9ViewTopAnchorConstraint"
-    text9ViewLeadingAnchorConstraint.identifier = "text9ViewLeadingAnchorConstraint"
-    text9ViewTrailingAnchorConstraint.identifier = "text9ViewTrailingAnchorConstraint"
   }
 
   private func update() {}

--- a/examples/generated/test/react-dom/style/BoxModelConditional.js
+++ b/examples/generated/test/react-dom/style/BoxModelConditional.js
@@ -1,0 +1,59 @@
+import React from "react"
+import styled, { ThemeProvider } from "styled-components"
+
+import colors from "../colors"
+import textStyles from "../textStyles"
+
+export default class BoxModelConditional extends React.Component {
+  render() {
+
+    let Inner$height
+    let Inner$marginBottom
+    let Inner$marginLeft
+    let Inner$marginRight
+    let Inner$marginTop
+    let Inner$width
+
+    Inner$marginTop = this.props.margin
+    Inner$marginRight = this.props.margin
+    Inner$marginBottom = this.props.margin
+    Inner$marginLeft = this.props.margin
+    Inner$height = this.props.size
+    Inner$width = this.props.size
+    let theme = { "outer": { "normal": {} }, "inner": { "normal": {} } }
+    return (
+      <ThemeProvider theme={theme}>
+        <div style={Object.assign(styles.outer, {})}>
+          <div
+            style={Object.assign(styles.inner, {
+              marginTop: Inner$marginTop,
+              marginRight: Inner$marginRight,
+              marginBottom: Inner$marginBottom,
+              marginLeft: Inner$marginLeft,
+              width: Inner$width,
+              height: Inner$height
+            })}
+
+          />
+        </div>
+      </ThemeProvider>
+    );
+  }
+};
+
+let styles = {
+  outer: {
+    alignSelf: "stretch",
+    display: "flex",
+    paddingTop: "4px",
+    paddingRight: "4px",
+    paddingBottom: "4px",
+    paddingLeft: "4px"
+  },
+  inner: {
+    backgroundColor: "#D8D8D8",
+    display: "flex",
+    width: "60px",
+    height: "60px"
+  }
+}

--- a/examples/generated/test/react-native/style/BoxModelConditional.js
+++ b/examples/generated/test/react-native/style/BoxModelConditional.js
@@ -1,0 +1,53 @@
+import React from "react"
+import { View, StyleSheet } from "react-native"
+
+import colors from "../colors"
+import textStyles from "../textStyles"
+
+export default class BoxModelConditional extends React.Component {
+  render() {
+
+    let Inner$height
+    let Inner$marginBottom
+    let Inner$marginLeft
+    let Inner$marginRight
+    let Inner$marginTop
+    let Inner$width
+
+    Inner$marginTop = this.props.margin
+    Inner$marginRight = this.props.margin
+    Inner$marginBottom = this.props.margin
+    Inner$marginLeft = this.props.margin
+    Inner$height = this.props.size
+    Inner$width = this.props.size
+    return (
+      <View style={[ styles.outer, {} ]}>
+        <View
+          style={[
+            styles.inner,
+            {
+              marginTop: Inner$marginTop,
+              marginRight: Inner$marginRight,
+              marginBottom: Inner$marginBottom,
+              marginLeft: Inner$marginLeft,
+              width: Inner$width,
+              height: Inner$height
+            }
+          ]}
+
+        />
+      </View>
+    );
+  }
+};
+
+let styles = StyleSheet.create({
+  outer: {
+    alignSelf: "stretch",
+    paddingTop: 4,
+    paddingRight: 4,
+    paddingBottom: 4,
+    paddingLeft: 4
+  },
+  inner: { backgroundColor: "#D8D8D8", width: 60, height: 60 }
+})

--- a/examples/generated/test/sketchJs/style/BoxModelConditional.js
+++ b/examples/generated/test/sketchJs/style/BoxModelConditional.js
@@ -1,0 +1,53 @@
+import React from "react"
+import { View, StyleSheet, TextStyles } from "@mathieudutour/react-sketchapp"
+
+import colors from "../colors"
+import textStyles from "../textStyles"
+
+export default class BoxModelConditional extends React.Component {
+  render() {
+
+    let Inner$height
+    let Inner$marginBottom
+    let Inner$marginLeft
+    let Inner$marginRight
+    let Inner$marginTop
+    let Inner$width
+
+    Inner$marginTop = this.props.margin
+    Inner$marginRight = this.props.margin
+    Inner$marginBottom = this.props.margin
+    Inner$marginLeft = this.props.margin
+    Inner$height = this.props.size
+    Inner$width = this.props.size
+    return (
+      <View style={[ styles.outer, {} ]}>
+        <View
+          style={[
+            styles.inner,
+            {
+              marginTop: Inner$marginTop,
+              marginRight: Inner$marginRight,
+              marginBottom: Inner$marginBottom,
+              marginLeft: Inner$marginLeft,
+              width: Inner$width,
+              height: Inner$height
+            }
+          ]}
+
+        />
+      </View>
+    );
+  }
+};
+
+let styles = StyleSheet.create({
+  outer: {
+    alignSelf: "stretch",
+    paddingTop: 4,
+    paddingRight: 4,
+    paddingBottom: 4,
+    paddingLeft: 4
+  },
+  inner: { backgroundColor: "#D8D8D8", width: 60, height: 60 }
+})

--- a/examples/generated/test/swift/components/NestedButtons.swift
+++ b/examples/generated/test/swift/components/NestedButtons.swift
@@ -26,35 +26,6 @@ public class NestedButtons: UIView {
   private var view1View = UIView(frame: .zero)
   private var button2View = Button()
 
-  private var topPadding: CGFloat = 24
-  private var trailingPadding: CGFloat = 24
-  private var bottomPadding: CGFloat = 24
-  private var leadingPadding: CGFloat = 24
-  private var buttonViewTopMargin: CGFloat = 0
-  private var buttonViewTrailingMargin: CGFloat = 0
-  private var buttonViewBottomMargin: CGFloat = 0
-  private var buttonViewLeadingMargin: CGFloat = 0
-  private var view1ViewTopMargin: CGFloat = 0
-  private var view1ViewTrailingMargin: CGFloat = 0
-  private var view1ViewBottomMargin: CGFloat = 0
-  private var view1ViewLeadingMargin: CGFloat = 0
-  private var button2ViewTopMargin: CGFloat = 0
-  private var button2ViewTrailingMargin: CGFloat = 0
-  private var button2ViewBottomMargin: CGFloat = 0
-  private var button2ViewLeadingMargin: CGFloat = 0
-
-  private var buttonViewTopAnchorConstraint: NSLayoutConstraint?
-  private var buttonViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var buttonViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var view1ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var view1ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var view1ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var button2ViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var button2ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var button2ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var button2ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var view1ViewHeightAnchorConstraint: NSLayoutConstraint?
-
   private func setUpViews() {
     addSubview(buttonView)
     addSubview(view1View)
@@ -70,36 +41,20 @@ public class NestedButtons: UIView {
     view1View.translatesAutoresizingMaskIntoConstraints = false
     button2View.translatesAutoresizingMaskIntoConstraints = false
 
-    let buttonViewTopAnchorConstraint = buttonView
-      .topAnchor
-      .constraint(equalTo: topAnchor, constant: topPadding + buttonViewTopMargin)
-    let buttonViewLeadingAnchorConstraint = buttonView
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + buttonViewLeadingMargin)
+    let buttonViewTopAnchorConstraint = buttonView.topAnchor.constraint(equalTo: topAnchor, constant: 24)
+    let buttonViewLeadingAnchorConstraint = buttonView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24)
     let buttonViewTrailingAnchorConstraint = buttonView
       .trailingAnchor
-      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -(trailingPadding + buttonViewTrailingMargin))
-    let view1ViewTopAnchorConstraint = view1View
-      .topAnchor
-      .constraint(equalTo: buttonView.bottomAnchor, constant: buttonViewBottomMargin + view1ViewTopMargin)
-    let view1ViewLeadingAnchorConstraint = view1View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + view1ViewLeadingMargin)
-    let view1ViewTrailingAnchorConstraint = view1View
-      .trailingAnchor
-      .constraint(equalTo: trailingAnchor, constant: -(trailingPadding + view1ViewTrailingMargin))
-    let button2ViewBottomAnchorConstraint = button2View
-      .bottomAnchor
-      .constraint(equalTo: bottomAnchor, constant: -(bottomPadding + button2ViewBottomMargin))
-    let button2ViewTopAnchorConstraint = button2View
-      .topAnchor
-      .constraint(equalTo: view1View.bottomAnchor, constant: view1ViewBottomMargin + button2ViewTopMargin)
-    let button2ViewLeadingAnchorConstraint = button2View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + button2ViewLeadingMargin)
+      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -24)
+    let view1ViewTopAnchorConstraint = view1View.topAnchor.constraint(equalTo: buttonView.bottomAnchor)
+    let view1ViewLeadingAnchorConstraint = view1View.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24)
+    let view1ViewTrailingAnchorConstraint = view1View.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -24)
+    let button2ViewBottomAnchorConstraint = button2View.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -24)
+    let button2ViewTopAnchorConstraint = button2View.topAnchor.constraint(equalTo: view1View.bottomAnchor)
+    let button2ViewLeadingAnchorConstraint = button2View.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24)
     let button2ViewTrailingAnchorConstraint = button2View
       .trailingAnchor
-      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -(trailingPadding + button2ViewTrailingMargin))
+      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -24)
     let view1ViewHeightAnchorConstraint = view1View.heightAnchor.constraint(equalToConstant: 8)
 
     NSLayoutConstraint.activate([
@@ -115,31 +70,6 @@ public class NestedButtons: UIView {
       button2ViewTrailingAnchorConstraint,
       view1ViewHeightAnchorConstraint
     ])
-
-    self.buttonViewTopAnchorConstraint = buttonViewTopAnchorConstraint
-    self.buttonViewLeadingAnchorConstraint = buttonViewLeadingAnchorConstraint
-    self.buttonViewTrailingAnchorConstraint = buttonViewTrailingAnchorConstraint
-    self.view1ViewTopAnchorConstraint = view1ViewTopAnchorConstraint
-    self.view1ViewLeadingAnchorConstraint = view1ViewLeadingAnchorConstraint
-    self.view1ViewTrailingAnchorConstraint = view1ViewTrailingAnchorConstraint
-    self.button2ViewBottomAnchorConstraint = button2ViewBottomAnchorConstraint
-    self.button2ViewTopAnchorConstraint = button2ViewTopAnchorConstraint
-    self.button2ViewLeadingAnchorConstraint = button2ViewLeadingAnchorConstraint
-    self.button2ViewTrailingAnchorConstraint = button2ViewTrailingAnchorConstraint
-    self.view1ViewHeightAnchorConstraint = view1ViewHeightAnchorConstraint
-
-    // For debugging
-    buttonViewTopAnchorConstraint.identifier = "buttonViewTopAnchorConstraint"
-    buttonViewLeadingAnchorConstraint.identifier = "buttonViewLeadingAnchorConstraint"
-    buttonViewTrailingAnchorConstraint.identifier = "buttonViewTrailingAnchorConstraint"
-    view1ViewTopAnchorConstraint.identifier = "view1ViewTopAnchorConstraint"
-    view1ViewLeadingAnchorConstraint.identifier = "view1ViewLeadingAnchorConstraint"
-    view1ViewTrailingAnchorConstraint.identifier = "view1ViewTrailingAnchorConstraint"
-    button2ViewBottomAnchorConstraint.identifier = "button2ViewBottomAnchorConstraint"
-    button2ViewTopAnchorConstraint.identifier = "button2ViewTopAnchorConstraint"
-    button2ViewLeadingAnchorConstraint.identifier = "button2ViewLeadingAnchorConstraint"
-    button2ViewTrailingAnchorConstraint.identifier = "button2ViewTrailingAnchorConstraint"
-    view1ViewHeightAnchorConstraint.identifier = "view1ViewHeightAnchorConstraint"
   }
 
   private func update() {}

--- a/examples/generated/test/swift/components/NestedComponent.swift
+++ b/examples/generated/test/swift/components/NestedComponent.swift
@@ -74,14 +74,12 @@ public class NestedComponent: UIView {
       .constraint(equalTo: trailingAnchor, constant: -10)
     let text1ViewTopAnchorConstraint = text1View
       .topAnchor
-      .constraint(equalTo: fitContentParentSecondaryChildrenView.bottomAnchor)
+      .constraint(equalTo: fitContentParentSecondaryChildrenView.bottomAnchor, constant: 12)
     let text1ViewLeadingAnchorConstraint = text1View.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10)
     let text1ViewTrailingAnchorConstraint = text1View
       .trailingAnchor
       .constraint(lessThanOrEqualTo: trailingAnchor, constant: -10)
-    let localAssetViewTopAnchorConstraint = localAssetView
-      .topAnchor
-      .constraint(equalTo: text1View.bottomAnchor, constant: 12)
+    let localAssetViewTopAnchorConstraint = localAssetView.topAnchor.constraint(equalTo: text1View.bottomAnchor)
     let localAssetViewLeadingAnchorConstraint = localAssetView
       .leadingAnchor
       .constraint(equalTo: leadingAnchor, constant: 10)

--- a/examples/generated/test/swift/components/NestedComponent.swift
+++ b/examples/generated/test/swift/components/NestedComponent.swift
@@ -32,48 +32,6 @@ public class NestedComponent: UIView {
   private var text1ViewTextStyle = TextStyles.body1
   private var text2ViewTextStyle = TextStyles.body1
 
-  private var topPadding: CGFloat = 10
-  private var trailingPadding: CGFloat = 10
-  private var bottomPadding: CGFloat = 10
-  private var leadingPadding: CGFloat = 10
-  private var textViewTopMargin: CGFloat = 0
-  private var textViewTrailingMargin: CGFloat = 0
-  private var textViewBottomMargin: CGFloat = 8
-  private var textViewLeadingMargin: CGFloat = 0
-  private var fitContentParentSecondaryChildrenViewTopMargin: CGFloat = 0
-  private var fitContentParentSecondaryChildrenViewTrailingMargin: CGFloat = 0
-  private var fitContentParentSecondaryChildrenViewBottomMargin: CGFloat = 0
-  private var fitContentParentSecondaryChildrenViewLeadingMargin: CGFloat = 0
-  private var text1ViewTopMargin: CGFloat = 12
-  private var text1ViewTrailingMargin: CGFloat = 0
-  private var text1ViewBottomMargin: CGFloat = 0
-  private var text1ViewLeadingMargin: CGFloat = 0
-  private var localAssetViewTopMargin: CGFloat = 0
-  private var localAssetViewTrailingMargin: CGFloat = 0
-  private var localAssetViewBottomMargin: CGFloat = 0
-  private var localAssetViewLeadingMargin: CGFloat = 0
-  private var text2ViewTopMargin: CGFloat = 0
-  private var text2ViewTrailingMargin: CGFloat = 0
-  private var text2ViewBottomMargin: CGFloat = 0
-  private var text2ViewLeadingMargin: CGFloat = 0
-
-  private var textViewTopAnchorConstraint: NSLayoutConstraint?
-  private var textViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var textViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var fitContentParentSecondaryChildrenViewTopAnchorConstraint: NSLayoutConstraint?
-  private var fitContentParentSecondaryChildrenViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var fitContentParentSecondaryChildrenViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var text1ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var text1ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var text1ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var localAssetViewTopAnchorConstraint: NSLayoutConstraint?
-  private var localAssetViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var localAssetViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var text2ViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var text2ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var text2ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var text2ViewTrailingAnchorConstraint: NSLayoutConstraint?
-
   private func setUpViews() {
     textView.numberOfLines = 0
     text1View.numberOfLines = 0
@@ -100,60 +58,42 @@ public class NestedComponent: UIView {
     localAssetView.translatesAutoresizingMaskIntoConstraints = false
     text2View.translatesAutoresizingMaskIntoConstraints = false
 
-    let textViewTopAnchorConstraint = textView
-      .topAnchor
-      .constraint(equalTo: topAnchor, constant: topPadding + textViewTopMargin)
-    let textViewLeadingAnchorConstraint = textView
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + textViewLeadingMargin)
+    let textViewTopAnchorConstraint = textView.topAnchor.constraint(equalTo: topAnchor, constant: 10)
+    let textViewLeadingAnchorConstraint = textView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10)
     let textViewTrailingAnchorConstraint = textView
       .trailingAnchor
-      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -(trailingPadding + textViewTrailingMargin))
+      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -10)
     let fitContentParentSecondaryChildrenViewTopAnchorConstraint = fitContentParentSecondaryChildrenView
       .topAnchor
-      .constraint(
-        equalTo: textView.bottomAnchor,
-        constant: textViewBottomMargin + fitContentParentSecondaryChildrenViewTopMargin)
+      .constraint(equalTo: textView.bottomAnchor, constant: 8)
     let fitContentParentSecondaryChildrenViewLeadingAnchorConstraint = fitContentParentSecondaryChildrenView
       .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + fitContentParentSecondaryChildrenViewLeadingMargin)
+      .constraint(equalTo: leadingAnchor, constant: 10)
     let fitContentParentSecondaryChildrenViewTrailingAnchorConstraint = fitContentParentSecondaryChildrenView
       .trailingAnchor
-      .constraint(
-        equalTo: trailingAnchor,
-        constant: -(trailingPadding + fitContentParentSecondaryChildrenViewTrailingMargin))
+      .constraint(equalTo: trailingAnchor, constant: -10)
     let text1ViewTopAnchorConstraint = text1View
       .topAnchor
-      .constraint(
-        equalTo: fitContentParentSecondaryChildrenView.bottomAnchor,
-        constant: fitContentParentSecondaryChildrenViewBottomMargin + text1ViewTopMargin)
-    let text1ViewLeadingAnchorConstraint = text1View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + text1ViewLeadingMargin)
+      .constraint(equalTo: fitContentParentSecondaryChildrenView.bottomAnchor)
+    let text1ViewLeadingAnchorConstraint = text1View.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10)
     let text1ViewTrailingAnchorConstraint = text1View
       .trailingAnchor
-      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -(trailingPadding + text1ViewTrailingMargin))
+      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -10)
     let localAssetViewTopAnchorConstraint = localAssetView
       .topAnchor
-      .constraint(equalTo: text1View.bottomAnchor, constant: text1ViewBottomMargin + localAssetViewTopMargin)
+      .constraint(equalTo: text1View.bottomAnchor, constant: 12)
     let localAssetViewLeadingAnchorConstraint = localAssetView
       .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + localAssetViewLeadingMargin)
+      .constraint(equalTo: leadingAnchor, constant: 10)
     let localAssetViewTrailingAnchorConstraint = localAssetView
       .trailingAnchor
-      .constraint(equalTo: trailingAnchor, constant: -(trailingPadding + localAssetViewTrailingMargin))
-    let text2ViewBottomAnchorConstraint = text2View
-      .bottomAnchor
-      .constraint(equalTo: bottomAnchor, constant: -(bottomPadding + text2ViewBottomMargin))
-    let text2ViewTopAnchorConstraint = text2View
-      .topAnchor
-      .constraint(equalTo: localAssetView.bottomAnchor, constant: localAssetViewBottomMargin + text2ViewTopMargin)
-    let text2ViewLeadingAnchorConstraint = text2View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + text2ViewLeadingMargin)
+      .constraint(equalTo: trailingAnchor, constant: -10)
+    let text2ViewBottomAnchorConstraint = text2View.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -10)
+    let text2ViewTopAnchorConstraint = text2View.topAnchor.constraint(equalTo: localAssetView.bottomAnchor)
+    let text2ViewLeadingAnchorConstraint = text2View.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10)
     let text2ViewTrailingAnchorConstraint = text2View
       .trailingAnchor
-      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -(trailingPadding + text2ViewTrailingMargin))
+      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -10)
 
     NSLayoutConstraint.activate([
       textViewTopAnchorConstraint,
@@ -173,47 +113,6 @@ public class NestedComponent: UIView {
       text2ViewLeadingAnchorConstraint,
       text2ViewTrailingAnchorConstraint
     ])
-
-    self.textViewTopAnchorConstraint = textViewTopAnchorConstraint
-    self.textViewLeadingAnchorConstraint = textViewLeadingAnchorConstraint
-    self.textViewTrailingAnchorConstraint = textViewTrailingAnchorConstraint
-    self.fitContentParentSecondaryChildrenViewTopAnchorConstraint =
-      fitContentParentSecondaryChildrenViewTopAnchorConstraint
-    self.fitContentParentSecondaryChildrenViewLeadingAnchorConstraint =
-      fitContentParentSecondaryChildrenViewLeadingAnchorConstraint
-    self.fitContentParentSecondaryChildrenViewTrailingAnchorConstraint =
-      fitContentParentSecondaryChildrenViewTrailingAnchorConstraint
-    self.text1ViewTopAnchorConstraint = text1ViewTopAnchorConstraint
-    self.text1ViewLeadingAnchorConstraint = text1ViewLeadingAnchorConstraint
-    self.text1ViewTrailingAnchorConstraint = text1ViewTrailingAnchorConstraint
-    self.localAssetViewTopAnchorConstraint = localAssetViewTopAnchorConstraint
-    self.localAssetViewLeadingAnchorConstraint = localAssetViewLeadingAnchorConstraint
-    self.localAssetViewTrailingAnchorConstraint = localAssetViewTrailingAnchorConstraint
-    self.text2ViewBottomAnchorConstraint = text2ViewBottomAnchorConstraint
-    self.text2ViewTopAnchorConstraint = text2ViewTopAnchorConstraint
-    self.text2ViewLeadingAnchorConstraint = text2ViewLeadingAnchorConstraint
-    self.text2ViewTrailingAnchorConstraint = text2ViewTrailingAnchorConstraint
-
-    // For debugging
-    textViewTopAnchorConstraint.identifier = "textViewTopAnchorConstraint"
-    textViewLeadingAnchorConstraint.identifier = "textViewLeadingAnchorConstraint"
-    textViewTrailingAnchorConstraint.identifier = "textViewTrailingAnchorConstraint"
-    fitContentParentSecondaryChildrenViewTopAnchorConstraint.identifier =
-      "fitContentParentSecondaryChildrenViewTopAnchorConstraint"
-    fitContentParentSecondaryChildrenViewLeadingAnchorConstraint.identifier =
-      "fitContentParentSecondaryChildrenViewLeadingAnchorConstraint"
-    fitContentParentSecondaryChildrenViewTrailingAnchorConstraint.identifier =
-      "fitContentParentSecondaryChildrenViewTrailingAnchorConstraint"
-    text1ViewTopAnchorConstraint.identifier = "text1ViewTopAnchorConstraint"
-    text1ViewLeadingAnchorConstraint.identifier = "text1ViewLeadingAnchorConstraint"
-    text1ViewTrailingAnchorConstraint.identifier = "text1ViewTrailingAnchorConstraint"
-    localAssetViewTopAnchorConstraint.identifier = "localAssetViewTopAnchorConstraint"
-    localAssetViewLeadingAnchorConstraint.identifier = "localAssetViewLeadingAnchorConstraint"
-    localAssetViewTrailingAnchorConstraint.identifier = "localAssetViewTrailingAnchorConstraint"
-    text2ViewBottomAnchorConstraint.identifier = "text2ViewBottomAnchorConstraint"
-    text2ViewTopAnchorConstraint.identifier = "text2ViewTopAnchorConstraint"
-    text2ViewLeadingAnchorConstraint.identifier = "text2ViewLeadingAnchorConstraint"
-    text2ViewTrailingAnchorConstraint.identifier = "text2ViewTrailingAnchorConstraint"
   }
 
   private func update() {}

--- a/examples/generated/test/swift/images/LocalAsset.swift
+++ b/examples/generated/test/swift/images/LocalAsset.swift
@@ -24,21 +24,6 @@ public class LocalAsset: UIView {
 
   private var imageView = UIImageView(frame: .zero)
 
-  private var topPadding: CGFloat = 0
-  private var trailingPadding: CGFloat = 0
-  private var bottomPadding: CGFloat = 0
-  private var leadingPadding: CGFloat = 0
-  private var imageViewTopMargin: CGFloat = 0
-  private var imageViewTrailingMargin: CGFloat = 0
-  private var imageViewBottomMargin: CGFloat = 0
-  private var imageViewLeadingMargin: CGFloat = 0
-
-  private var imageViewTopAnchorConstraint: NSLayoutConstraint?
-  private var imageViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var imageViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var imageViewHeightAnchorConstraint: NSLayoutConstraint?
-  private var imageViewWidthAnchorConstraint: NSLayoutConstraint?
-
   private func setUpViews() {
     addSubview(imageView)
 
@@ -50,15 +35,9 @@ public class LocalAsset: UIView {
     translatesAutoresizingMaskIntoConstraints = false
     imageView.translatesAutoresizingMaskIntoConstraints = false
 
-    let imageViewTopAnchorConstraint = imageView
-      .topAnchor
-      .constraint(equalTo: topAnchor, constant: topPadding + imageViewTopMargin)
-    let imageViewBottomAnchorConstraint = imageView
-      .bottomAnchor
-      .constraint(equalTo: bottomAnchor, constant: -(bottomPadding + imageViewBottomMargin))
-    let imageViewLeadingAnchorConstraint = imageView
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + imageViewLeadingMargin)
+    let imageViewTopAnchorConstraint = imageView.topAnchor.constraint(equalTo: topAnchor)
+    let imageViewBottomAnchorConstraint = imageView.bottomAnchor.constraint(equalTo: bottomAnchor)
+    let imageViewLeadingAnchorConstraint = imageView.leadingAnchor.constraint(equalTo: leadingAnchor)
     let imageViewHeightAnchorConstraint = imageView.heightAnchor.constraint(equalToConstant: 100)
     let imageViewWidthAnchorConstraint = imageView.widthAnchor.constraint(equalToConstant: 100)
 
@@ -69,19 +48,6 @@ public class LocalAsset: UIView {
       imageViewHeightAnchorConstraint,
       imageViewWidthAnchorConstraint
     ])
-
-    self.imageViewTopAnchorConstraint = imageViewTopAnchorConstraint
-    self.imageViewBottomAnchorConstraint = imageViewBottomAnchorConstraint
-    self.imageViewLeadingAnchorConstraint = imageViewLeadingAnchorConstraint
-    self.imageViewHeightAnchorConstraint = imageViewHeightAnchorConstraint
-    self.imageViewWidthAnchorConstraint = imageViewWidthAnchorConstraint
-
-    // For debugging
-    imageViewTopAnchorConstraint.identifier = "imageViewTopAnchorConstraint"
-    imageViewBottomAnchorConstraint.identifier = "imageViewBottomAnchorConstraint"
-    imageViewLeadingAnchorConstraint.identifier = "imageViewLeadingAnchorConstraint"
-    imageViewHeightAnchorConstraint.identifier = "imageViewHeightAnchorConstraint"
-    imageViewWidthAnchorConstraint.identifier = "imageViewWidthAnchorConstraint"
   }
 
   private func update() {}

--- a/examples/generated/test/swift/interactivity/Button.swift
+++ b/examples/generated/test/swift/interactivity/Button.swift
@@ -39,24 +39,9 @@ public class Button: UIView {
 
   private var textViewTextStyle = TextStyles.button
 
-  private var topPadding: CGFloat = 12
-  private var trailingPadding: CGFloat = 16
-  private var bottomPadding: CGFloat = 12
-  private var leadingPadding: CGFloat = 16
-  private var textViewTopMargin: CGFloat = 0
-  private var textViewTrailingMargin: CGFloat = 0
-  private var textViewBottomMargin: CGFloat = 0
-  private var textViewLeadingMargin: CGFloat = 0
-
   private var hovered = false
   private var pressed = false
   private var onPress: (() -> Void)?
-
-  private var textViewWidthAnchorParentConstraint: NSLayoutConstraint?
-  private var textViewTopAnchorConstraint: NSLayoutConstraint?
-  private var textViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var textViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var textViewTrailingAnchorConstraint: NSLayoutConstraint?
 
   private func setUpViews() {
     textView.numberOfLines = 0
@@ -73,21 +58,11 @@ public class Button: UIView {
 
     let textViewWidthAnchorParentConstraint = textView
       .widthAnchor
-      .constraint(
-        lessThanOrEqualTo: widthAnchor,
-        constant: -(leadingPadding + textViewLeadingMargin + trailingPadding + textViewTrailingMargin))
-    let textViewTopAnchorConstraint = textView
-      .topAnchor
-      .constraint(equalTo: topAnchor, constant: topPadding + textViewTopMargin)
-    let textViewBottomAnchorConstraint = textView
-      .bottomAnchor
-      .constraint(equalTo: bottomAnchor, constant: -(bottomPadding + textViewBottomMargin))
-    let textViewLeadingAnchorConstraint = textView
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + textViewLeadingMargin)
-    let textViewTrailingAnchorConstraint = textView
-      .trailingAnchor
-      .constraint(equalTo: trailingAnchor, constant: -(trailingPadding + textViewTrailingMargin))
+      .constraint(lessThanOrEqualTo: widthAnchor, constant: -(16 + 16))
+    let textViewTopAnchorConstraint = textView.topAnchor.constraint(equalTo: topAnchor, constant: 12)
+    let textViewBottomAnchorConstraint = textView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -12)
+    let textViewLeadingAnchorConstraint = textView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16)
+    let textViewTrailingAnchorConstraint = textView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16)
 
     textViewWidthAnchorParentConstraint.priority = UILayoutPriority.defaultLow
 
@@ -98,19 +73,6 @@ public class Button: UIView {
       textViewLeadingAnchorConstraint,
       textViewTrailingAnchorConstraint
     ])
-
-    self.textViewWidthAnchorParentConstraint = textViewWidthAnchorParentConstraint
-    self.textViewTopAnchorConstraint = textViewTopAnchorConstraint
-    self.textViewBottomAnchorConstraint = textViewBottomAnchorConstraint
-    self.textViewLeadingAnchorConstraint = textViewLeadingAnchorConstraint
-    self.textViewTrailingAnchorConstraint = textViewTrailingAnchorConstraint
-
-    // For debugging
-    textViewWidthAnchorParentConstraint.identifier = "textViewWidthAnchorParentConstraint"
-    textViewTopAnchorConstraint.identifier = "textViewTopAnchorConstraint"
-    textViewBottomAnchorConstraint.identifier = "textViewBottomAnchorConstraint"
-    textViewLeadingAnchorConstraint.identifier = "textViewLeadingAnchorConstraint"
-    textViewTrailingAnchorConstraint.identifier = "textViewTrailingAnchorConstraint"
   }
 
   private func update() {

--- a/examples/generated/test/swift/interactivity/Button.swift
+++ b/examples/generated/test/swift/interactivity/Button.swift
@@ -58,7 +58,7 @@ public class Button: UIView {
 
     let textViewWidthAnchorParentConstraint = textView
       .widthAnchor
-      .constraint(lessThanOrEqualTo: widthAnchor, constant: -(16 + 16))
+      .constraint(lessThanOrEqualTo: widthAnchor, constant: -32)
     let textViewTopAnchorConstraint = textView.topAnchor.constraint(equalTo: topAnchor, constant: 12)
     let textViewBottomAnchorConstraint = textView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -12)
     let textViewLeadingAnchorConstraint = textView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16)

--- a/examples/generated/test/swift/interactivity/PressableRootView.swift
+++ b/examples/generated/test/swift/interactivity/PressableRootView.swift
@@ -32,38 +32,12 @@ public class PressableRootView: UIView {
 
   private var innerTextViewTextStyle = TextStyles.headline
 
-  private var topPadding: CGFloat = 24
-  private var trailingPadding: CGFloat = 24
-  private var bottomPadding: CGFloat = 24
-  private var leadingPadding: CGFloat = 24
-  private var innerViewTopMargin: CGFloat = 0
-  private var innerViewTrailingMargin: CGFloat = 0
-  private var innerViewBottomMargin: CGFloat = 0
-  private var innerViewLeadingMargin: CGFloat = 0
-  private var innerViewTopPadding: CGFloat = 0
-  private var innerViewTrailingPadding: CGFloat = 0
-  private var innerViewBottomPadding: CGFloat = 0
-  private var innerViewLeadingPadding: CGFloat = 0
-  private var innerTextViewTopMargin: CGFloat = 0
-  private var innerTextViewTrailingMargin: CGFloat = 0
-  private var innerTextViewBottomMargin: CGFloat = 0
-  private var innerTextViewLeadingMargin: CGFloat = 0
-
   private var hovered = false
   private var pressed = false
   private var onPress: (() -> Void)?
   private var innerViewHovered = false
   private var innerViewPressed = false
   private var innerViewOnPress: (() -> Void)?
-
-  private var innerViewTopAnchorConstraint: NSLayoutConstraint?
-  private var innerViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var innerViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var innerViewHeightAnchorConstraint: NSLayoutConstraint?
-  private var innerViewWidthAnchorConstraint: NSLayoutConstraint?
-  private var innerTextViewTopAnchorConstraint: NSLayoutConstraint?
-  private var innerTextViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var innerTextViewTrailingAnchorConstraint: NSLayoutConstraint?
 
   private func setUpViews() {
     innerTextView.numberOfLines = 0
@@ -81,28 +55,16 @@ public class PressableRootView: UIView {
     innerView.translatesAutoresizingMaskIntoConstraints = false
     innerTextView.translatesAutoresizingMaskIntoConstraints = false
 
-    let innerViewTopAnchorConstraint = innerView
-      .topAnchor
-      .constraint(equalTo: topAnchor, constant: topPadding + innerViewTopMargin)
-    let innerViewBottomAnchorConstraint = innerView
-      .bottomAnchor
-      .constraint(equalTo: bottomAnchor, constant: -(bottomPadding + innerViewBottomMargin))
-    let innerViewLeadingAnchorConstraint = innerView
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + innerViewLeadingMargin)
+    let innerViewTopAnchorConstraint = innerView.topAnchor.constraint(equalTo: topAnchor, constant: 24)
+    let innerViewBottomAnchorConstraint = innerView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -24)
+    let innerViewLeadingAnchorConstraint = innerView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24)
     let innerViewHeightAnchorConstraint = innerView.heightAnchor.constraint(equalToConstant: 100)
     let innerViewWidthAnchorConstraint = innerView.widthAnchor.constraint(equalToConstant: 100)
-    let innerTextViewTopAnchorConstraint = innerTextView
-      .topAnchor
-      .constraint(equalTo: innerView.topAnchor, constant: innerViewTopPadding + innerTextViewTopMargin)
-    let innerTextViewLeadingAnchorConstraint = innerTextView
-      .leadingAnchor
-      .constraint(equalTo: innerView.leadingAnchor, constant: innerViewLeadingPadding + innerTextViewLeadingMargin)
+    let innerTextViewTopAnchorConstraint = innerTextView.topAnchor.constraint(equalTo: innerView.topAnchor)
+    let innerTextViewLeadingAnchorConstraint = innerTextView.leadingAnchor.constraint(equalTo: innerView.leadingAnchor)
     let innerTextViewTrailingAnchorConstraint = innerTextView
       .trailingAnchor
-      .constraint(
-        equalTo: innerView.trailingAnchor,
-        constant: -(innerViewTrailingPadding + innerTextViewTrailingMargin))
+      .constraint(equalTo: innerView.trailingAnchor)
 
     NSLayoutConstraint.activate([
       innerViewTopAnchorConstraint,
@@ -114,25 +76,6 @@ public class PressableRootView: UIView {
       innerTextViewLeadingAnchorConstraint,
       innerTextViewTrailingAnchorConstraint
     ])
-
-    self.innerViewTopAnchorConstraint = innerViewTopAnchorConstraint
-    self.innerViewBottomAnchorConstraint = innerViewBottomAnchorConstraint
-    self.innerViewLeadingAnchorConstraint = innerViewLeadingAnchorConstraint
-    self.innerViewHeightAnchorConstraint = innerViewHeightAnchorConstraint
-    self.innerViewWidthAnchorConstraint = innerViewWidthAnchorConstraint
-    self.innerTextViewTopAnchorConstraint = innerTextViewTopAnchorConstraint
-    self.innerTextViewLeadingAnchorConstraint = innerTextViewLeadingAnchorConstraint
-    self.innerTextViewTrailingAnchorConstraint = innerTextViewTrailingAnchorConstraint
-
-    // For debugging
-    innerViewTopAnchorConstraint.identifier = "innerViewTopAnchorConstraint"
-    innerViewBottomAnchorConstraint.identifier = "innerViewBottomAnchorConstraint"
-    innerViewLeadingAnchorConstraint.identifier = "innerViewLeadingAnchorConstraint"
-    innerViewHeightAnchorConstraint.identifier = "innerViewHeightAnchorConstraint"
-    innerViewWidthAnchorConstraint.identifier = "innerViewWidthAnchorConstraint"
-    innerTextViewTopAnchorConstraint.identifier = "innerTextViewTopAnchorConstraint"
-    innerTextViewLeadingAnchorConstraint.identifier = "innerTextViewLeadingAnchorConstraint"
-    innerTextViewTrailingAnchorConstraint.identifier = "innerTextViewTrailingAnchorConstraint"
   }
 
   private func update() {

--- a/examples/generated/test/swift/layouts/FitContentParentSecondaryChildren.swift
+++ b/examples/generated/test/swift/layouts/FitContentParentSecondaryChildren.swift
@@ -45,13 +45,13 @@ public class FitContentParentSecondaryChildren: UIView {
 
     let view1ViewHeightAnchorParentConstraint = view1View
       .heightAnchor
-      .constraint(lessThanOrEqualTo: heightAnchor, constant: -(24 + 24))
+      .constraint(lessThanOrEqualTo: heightAnchor, constant: -48)
     let view3ViewHeightAnchorParentConstraint = view3View
       .heightAnchor
-      .constraint(lessThanOrEqualTo: heightAnchor, constant: -(24 + 24))
+      .constraint(lessThanOrEqualTo: heightAnchor, constant: -48)
     let view2ViewHeightAnchorParentConstraint = view2View
       .heightAnchor
-      .constraint(lessThanOrEqualTo: heightAnchor, constant: -(24 + 24))
+      .constraint(lessThanOrEqualTo: heightAnchor, constant: -48)
     let view1ViewLeadingAnchorConstraint = view1View.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24)
     let view1ViewTopAnchorConstraint = view1View.topAnchor.constraint(equalTo: topAnchor, constant: 24)
     let view3ViewLeadingAnchorConstraint = view3View.leadingAnchor.constraint(equalTo: view1View.trailingAnchor)

--- a/examples/generated/test/swift/layouts/FitContentParentSecondaryChildren.swift
+++ b/examples/generated/test/swift/layouts/FitContentParentSecondaryChildren.swift
@@ -26,39 +26,6 @@ public class FitContentParentSecondaryChildren: UIView {
   private var view3View = UIView(frame: .zero)
   private var view2View = UIView(frame: .zero)
 
-  private var topPadding: CGFloat = 24
-  private var trailingPadding: CGFloat = 24
-  private var bottomPadding: CGFloat = 24
-  private var leadingPadding: CGFloat = 24
-  private var view1ViewTopMargin: CGFloat = 0
-  private var view1ViewTrailingMargin: CGFloat = 0
-  private var view1ViewBottomMargin: CGFloat = 0
-  private var view1ViewLeadingMargin: CGFloat = 0
-  private var view3ViewTopMargin: CGFloat = 0
-  private var view3ViewTrailingMargin: CGFloat = 0
-  private var view3ViewBottomMargin: CGFloat = 0
-  private var view3ViewLeadingMargin: CGFloat = 0
-  private var view2ViewTopMargin: CGFloat = 0
-  private var view2ViewTrailingMargin: CGFloat = 0
-  private var view2ViewBottomMargin: CGFloat = 0
-  private var view2ViewLeadingMargin: CGFloat = 0
-
-  private var view1ViewHeightAnchorParentConstraint: NSLayoutConstraint?
-  private var view3ViewHeightAnchorParentConstraint: NSLayoutConstraint?
-  private var view2ViewHeightAnchorParentConstraint: NSLayoutConstraint?
-  private var view1ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var view1ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var view3ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var view3ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var view2ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var view2ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var view1ViewHeightAnchorConstraint: NSLayoutConstraint?
-  private var view1ViewWidthAnchorConstraint: NSLayoutConstraint?
-  private var view3ViewHeightAnchorConstraint: NSLayoutConstraint?
-  private var view3ViewWidthAnchorConstraint: NSLayoutConstraint?
-  private var view2ViewHeightAnchorConstraint: NSLayoutConstraint?
-  private var view2ViewWidthAnchorConstraint: NSLayoutConstraint?
-
   private func setUpViews() {
     addSubview(view1View)
     addSubview(view3View)
@@ -78,37 +45,19 @@ public class FitContentParentSecondaryChildren: UIView {
 
     let view1ViewHeightAnchorParentConstraint = view1View
       .heightAnchor
-      .constraint(
-        lessThanOrEqualTo: heightAnchor,
-        constant: -(topPadding + view1ViewTopMargin + bottomPadding + view1ViewBottomMargin))
+      .constraint(lessThanOrEqualTo: heightAnchor, constant: -(24 + 24))
     let view3ViewHeightAnchorParentConstraint = view3View
       .heightAnchor
-      .constraint(
-        lessThanOrEqualTo: heightAnchor,
-        constant: -(topPadding + view3ViewTopMargin + bottomPadding + view3ViewBottomMargin))
+      .constraint(lessThanOrEqualTo: heightAnchor, constant: -(24 + 24))
     let view2ViewHeightAnchorParentConstraint = view2View
       .heightAnchor
-      .constraint(
-        lessThanOrEqualTo: heightAnchor,
-        constant: -(topPadding + view2ViewTopMargin + bottomPadding + view2ViewBottomMargin))
-    let view1ViewLeadingAnchorConstraint = view1View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + view1ViewLeadingMargin)
-    let view1ViewTopAnchorConstraint = view1View
-      .topAnchor
-      .constraint(equalTo: topAnchor, constant: topPadding + view1ViewTopMargin)
-    let view3ViewLeadingAnchorConstraint = view3View
-      .leadingAnchor
-      .constraint(equalTo: view1View.trailingAnchor, constant: view1ViewTrailingMargin + view3ViewLeadingMargin)
-    let view3ViewTopAnchorConstraint = view3View
-      .topAnchor
-      .constraint(equalTo: topAnchor, constant: topPadding + view3ViewTopMargin)
-    let view2ViewLeadingAnchorConstraint = view2View
-      .leadingAnchor
-      .constraint(equalTo: view3View.trailingAnchor, constant: view3ViewTrailingMargin + view2ViewLeadingMargin)
-    let view2ViewTopAnchorConstraint = view2View
-      .topAnchor
-      .constraint(equalTo: topAnchor, constant: topPadding + view2ViewTopMargin)
+      .constraint(lessThanOrEqualTo: heightAnchor, constant: -(24 + 24))
+    let view1ViewLeadingAnchorConstraint = view1View.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24)
+    let view1ViewTopAnchorConstraint = view1View.topAnchor.constraint(equalTo: topAnchor, constant: 24)
+    let view3ViewLeadingAnchorConstraint = view3View.leadingAnchor.constraint(equalTo: view1View.trailingAnchor)
+    let view3ViewTopAnchorConstraint = view3View.topAnchor.constraint(equalTo: topAnchor, constant: 24)
+    let view2ViewLeadingAnchorConstraint = view2View.leadingAnchor.constraint(equalTo: view3View.trailingAnchor)
+    let view2ViewTopAnchorConstraint = view2View.topAnchor.constraint(equalTo: topAnchor, constant: 24)
     let view1ViewHeightAnchorConstraint = view1View.heightAnchor.constraint(equalToConstant: 60)
     let view1ViewWidthAnchorConstraint = view1View.widthAnchor.constraint(equalToConstant: 60)
     let view3ViewHeightAnchorConstraint = view3View.heightAnchor.constraint(equalToConstant: 120)
@@ -137,39 +86,6 @@ public class FitContentParentSecondaryChildren: UIView {
       view2ViewHeightAnchorConstraint,
       view2ViewWidthAnchorConstraint
     ])
-
-    self.view1ViewHeightAnchorParentConstraint = view1ViewHeightAnchorParentConstraint
-    self.view3ViewHeightAnchorParentConstraint = view3ViewHeightAnchorParentConstraint
-    self.view2ViewHeightAnchorParentConstraint = view2ViewHeightAnchorParentConstraint
-    self.view1ViewLeadingAnchorConstraint = view1ViewLeadingAnchorConstraint
-    self.view1ViewTopAnchorConstraint = view1ViewTopAnchorConstraint
-    self.view3ViewLeadingAnchorConstraint = view3ViewLeadingAnchorConstraint
-    self.view3ViewTopAnchorConstraint = view3ViewTopAnchorConstraint
-    self.view2ViewLeadingAnchorConstraint = view2ViewLeadingAnchorConstraint
-    self.view2ViewTopAnchorConstraint = view2ViewTopAnchorConstraint
-    self.view1ViewHeightAnchorConstraint = view1ViewHeightAnchorConstraint
-    self.view1ViewWidthAnchorConstraint = view1ViewWidthAnchorConstraint
-    self.view3ViewHeightAnchorConstraint = view3ViewHeightAnchorConstraint
-    self.view3ViewWidthAnchorConstraint = view3ViewWidthAnchorConstraint
-    self.view2ViewHeightAnchorConstraint = view2ViewHeightAnchorConstraint
-    self.view2ViewWidthAnchorConstraint = view2ViewWidthAnchorConstraint
-
-    // For debugging
-    view1ViewHeightAnchorParentConstraint.identifier = "view1ViewHeightAnchorParentConstraint"
-    view3ViewHeightAnchorParentConstraint.identifier = "view3ViewHeightAnchorParentConstraint"
-    view2ViewHeightAnchorParentConstraint.identifier = "view2ViewHeightAnchorParentConstraint"
-    view1ViewLeadingAnchorConstraint.identifier = "view1ViewLeadingAnchorConstraint"
-    view1ViewTopAnchorConstraint.identifier = "view1ViewTopAnchorConstraint"
-    view3ViewLeadingAnchorConstraint.identifier = "view3ViewLeadingAnchorConstraint"
-    view3ViewTopAnchorConstraint.identifier = "view3ViewTopAnchorConstraint"
-    view2ViewLeadingAnchorConstraint.identifier = "view2ViewLeadingAnchorConstraint"
-    view2ViewTopAnchorConstraint.identifier = "view2ViewTopAnchorConstraint"
-    view1ViewHeightAnchorConstraint.identifier = "view1ViewHeightAnchorConstraint"
-    view1ViewWidthAnchorConstraint.identifier = "view1ViewWidthAnchorConstraint"
-    view3ViewHeightAnchorConstraint.identifier = "view3ViewHeightAnchorConstraint"
-    view3ViewWidthAnchorConstraint.identifier = "view3ViewWidthAnchorConstraint"
-    view2ViewHeightAnchorConstraint.identifier = "view2ViewHeightAnchorConstraint"
-    view2ViewWidthAnchorConstraint.identifier = "view2ViewWidthAnchorConstraint"
   }
 
   private func update() {}

--- a/examples/generated/test/swift/layouts/FixedParentFillAndFitChildren.swift
+++ b/examples/generated/test/swift/layouts/FixedParentFillAndFitChildren.swift
@@ -28,58 +28,6 @@ public class FixedParentFillAndFitChildren: UIView {
   private var view2View = UIView(frame: .zero)
   private var view3View = UIView(frame: .zero)
 
-  private var topPadding: CGFloat = 24
-  private var trailingPadding: CGFloat = 24
-  private var bottomPadding: CGFloat = 24
-  private var leadingPadding: CGFloat = 24
-  private var view1ViewTopMargin: CGFloat = 0
-  private var view1ViewTrailingMargin: CGFloat = 0
-  private var view1ViewBottomMargin: CGFloat = 0
-  private var view1ViewLeadingMargin: CGFloat = 0
-  private var view1ViewTopPadding: CGFloat = 24
-  private var view1ViewTrailingPadding: CGFloat = 24
-  private var view1ViewBottomPadding: CGFloat = 24
-  private var view1ViewLeadingPadding: CGFloat = 24
-  private var view2ViewTopMargin: CGFloat = 0
-  private var view2ViewTrailingMargin: CGFloat = 0
-  private var view2ViewBottomMargin: CGFloat = 0
-  private var view2ViewLeadingMargin: CGFloat = 0
-  private var view3ViewTopMargin: CGFloat = 0
-  private var view3ViewTrailingMargin: CGFloat = 0
-  private var view3ViewBottomMargin: CGFloat = 0
-  private var view3ViewLeadingMargin: CGFloat = 0
-  private var view4ViewTopMargin: CGFloat = 0
-  private var view4ViewTrailingMargin: CGFloat = 0
-  private var view4ViewBottomMargin: CGFloat = 0
-  private var view4ViewLeadingMargin: CGFloat = 0
-  private var view5ViewTopMargin: CGFloat = 0
-  private var view5ViewTrailingMargin: CGFloat = 0
-  private var view5ViewBottomMargin: CGFloat = 0
-  private var view5ViewLeadingMargin: CGFloat = 12
-
-  private var heightAnchorConstraint: NSLayoutConstraint?
-  private var view2ViewView3ViewHeightAnchorSiblingConstraint: NSLayoutConstraint?
-  private var view1ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var view1ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var view1ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var view2ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var view2ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var view2ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var view3ViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var view3ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var view3ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var view3ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var view4ViewHeightAnchorParentConstraint: NSLayoutConstraint?
-  private var view5ViewHeightAnchorParentConstraint: NSLayoutConstraint?
-  private var view4ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var view4ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var view5ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var view5ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var view4ViewHeightAnchorConstraint: NSLayoutConstraint?
-  private var view4ViewWidthAnchorConstraint: NSLayoutConstraint?
-  private var view5ViewHeightAnchorConstraint: NSLayoutConstraint?
-  private var view5ViewWidthAnchorConstraint: NSLayoutConstraint?
-
   private func setUpViews() {
     addSubview(view1View)
     addSubview(view2View)
@@ -105,59 +53,29 @@ public class FixedParentFillAndFitChildren: UIView {
     let heightAnchorConstraint = heightAnchor.constraint(equalToConstant: 600)
     let view2ViewView3ViewHeightAnchorSiblingConstraint = view2View
       .heightAnchor
-      .constraint(equalTo: view3View.heightAnchor, constant: 0)
-    let view1ViewTopAnchorConstraint = view1View
-      .topAnchor
-      .constraint(equalTo: topAnchor, constant: topPadding + view1ViewTopMargin)
-    let view1ViewLeadingAnchorConstraint = view1View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + view1ViewLeadingMargin)
-    let view1ViewTrailingAnchorConstraint = view1View
-      .trailingAnchor
-      .constraint(equalTo: trailingAnchor, constant: -(trailingPadding + view1ViewTrailingMargin))
-    let view2ViewTopAnchorConstraint = view2View
-      .topAnchor
-      .constraint(equalTo: view1View.bottomAnchor, constant: view1ViewBottomMargin + view2ViewTopMargin)
-    let view2ViewLeadingAnchorConstraint = view2View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + view2ViewLeadingMargin)
-    let view2ViewTrailingAnchorConstraint = view2View
-      .trailingAnchor
-      .constraint(equalTo: trailingAnchor, constant: -(trailingPadding + view2ViewTrailingMargin))
-    let view3ViewBottomAnchorConstraint = view3View
-      .bottomAnchor
-      .constraint(equalTo: bottomAnchor, constant: -(bottomPadding + view3ViewBottomMargin))
-    let view3ViewTopAnchorConstraint = view3View
-      .topAnchor
-      .constraint(equalTo: view2View.bottomAnchor, constant: view2ViewBottomMargin + view3ViewTopMargin)
-    let view3ViewLeadingAnchorConstraint = view3View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + view3ViewLeadingMargin)
-    let view3ViewTrailingAnchorConstraint = view3View
-      .trailingAnchor
-      .constraint(equalTo: trailingAnchor, constant: -(trailingPadding + view3ViewTrailingMargin))
+      .constraint(equalTo: view3View.heightAnchor)
+    let view1ViewTopAnchorConstraint = view1View.topAnchor.constraint(equalTo: topAnchor, constant: 24)
+    let view1ViewLeadingAnchorConstraint = view1View.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24)
+    let view1ViewTrailingAnchorConstraint = view1View.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -24)
+    let view2ViewTopAnchorConstraint = view2View.topAnchor.constraint(equalTo: view1View.bottomAnchor)
+    let view2ViewLeadingAnchorConstraint = view2View.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24)
+    let view2ViewTrailingAnchorConstraint = view2View.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -24)
+    let view3ViewBottomAnchorConstraint = view3View.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -24)
+    let view3ViewTopAnchorConstraint = view3View.topAnchor.constraint(equalTo: view2View.bottomAnchor)
+    let view3ViewLeadingAnchorConstraint = view3View.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24)
+    let view3ViewTrailingAnchorConstraint = view3View.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -24)
     let view4ViewHeightAnchorParentConstraint = view4View
       .heightAnchor
-      .constraint(
-        lessThanOrEqualTo: view1View.heightAnchor,
-        constant: -(view1ViewTopPadding + view4ViewTopMargin + view1ViewBottomPadding + view4ViewBottomMargin))
+      .constraint(lessThanOrEqualTo: view1View.heightAnchor, constant: -(24 + 24))
     let view5ViewHeightAnchorParentConstraint = view5View
       .heightAnchor
-      .constraint(
-        lessThanOrEqualTo: view1View.heightAnchor,
-        constant: -(view1ViewTopPadding + view5ViewTopMargin + view1ViewBottomPadding + view5ViewBottomMargin))
+      .constraint(lessThanOrEqualTo: view1View.heightAnchor, constant: -(24 + 24))
     let view4ViewLeadingAnchorConstraint = view4View
       .leadingAnchor
-      .constraint(equalTo: view1View.leadingAnchor, constant: view1ViewLeadingPadding + view4ViewLeadingMargin)
-    let view4ViewTopAnchorConstraint = view4View
-      .topAnchor
-      .constraint(equalTo: view1View.topAnchor, constant: view1ViewTopPadding + view4ViewTopMargin)
-    let view5ViewLeadingAnchorConstraint = view5View
-      .leadingAnchor
-      .constraint(equalTo: view4View.trailingAnchor, constant: view4ViewTrailingMargin + view5ViewLeadingMargin)
-    let view5ViewTopAnchorConstraint = view5View
-      .topAnchor
-      .constraint(equalTo: view1View.topAnchor, constant: view1ViewTopPadding + view5ViewTopMargin)
+      .constraint(equalTo: view1View.leadingAnchor, constant: 24)
+    let view4ViewTopAnchorConstraint = view4View.topAnchor.constraint(equalTo: view1View.topAnchor, constant: 24)
+    let view5ViewLeadingAnchorConstraint = view5View.leadingAnchor.constraint(equalTo: view4View.trailingAnchor)
+    let view5ViewTopAnchorConstraint = view5View.topAnchor.constraint(equalTo: view1View.topAnchor, constant: 24)
     let view4ViewHeightAnchorConstraint = view4View.heightAnchor.constraint(equalToConstant: 100)
     let view4ViewWidthAnchorConstraint = view4View.widthAnchor.constraint(equalToConstant: 60)
     let view5ViewHeightAnchorConstraint = view5View.heightAnchor.constraint(equalToConstant: 60)
@@ -190,53 +108,6 @@ public class FixedParentFillAndFitChildren: UIView {
       view5ViewHeightAnchorConstraint,
       view5ViewWidthAnchorConstraint
     ])
-
-    self.heightAnchorConstraint = heightAnchorConstraint
-    self.view2ViewView3ViewHeightAnchorSiblingConstraint = view2ViewView3ViewHeightAnchorSiblingConstraint
-    self.view1ViewTopAnchorConstraint = view1ViewTopAnchorConstraint
-    self.view1ViewLeadingAnchorConstraint = view1ViewLeadingAnchorConstraint
-    self.view1ViewTrailingAnchorConstraint = view1ViewTrailingAnchorConstraint
-    self.view2ViewTopAnchorConstraint = view2ViewTopAnchorConstraint
-    self.view2ViewLeadingAnchorConstraint = view2ViewLeadingAnchorConstraint
-    self.view2ViewTrailingAnchorConstraint = view2ViewTrailingAnchorConstraint
-    self.view3ViewBottomAnchorConstraint = view3ViewBottomAnchorConstraint
-    self.view3ViewTopAnchorConstraint = view3ViewTopAnchorConstraint
-    self.view3ViewLeadingAnchorConstraint = view3ViewLeadingAnchorConstraint
-    self.view3ViewTrailingAnchorConstraint = view3ViewTrailingAnchorConstraint
-    self.view4ViewHeightAnchorParentConstraint = view4ViewHeightAnchorParentConstraint
-    self.view5ViewHeightAnchorParentConstraint = view5ViewHeightAnchorParentConstraint
-    self.view4ViewLeadingAnchorConstraint = view4ViewLeadingAnchorConstraint
-    self.view4ViewTopAnchorConstraint = view4ViewTopAnchorConstraint
-    self.view5ViewLeadingAnchorConstraint = view5ViewLeadingAnchorConstraint
-    self.view5ViewTopAnchorConstraint = view5ViewTopAnchorConstraint
-    self.view4ViewHeightAnchorConstraint = view4ViewHeightAnchorConstraint
-    self.view4ViewWidthAnchorConstraint = view4ViewWidthAnchorConstraint
-    self.view5ViewHeightAnchorConstraint = view5ViewHeightAnchorConstraint
-    self.view5ViewWidthAnchorConstraint = view5ViewWidthAnchorConstraint
-
-    // For debugging
-    heightAnchorConstraint.identifier = "heightAnchorConstraint"
-    view2ViewView3ViewHeightAnchorSiblingConstraint.identifier = "view2ViewView3ViewHeightAnchorSiblingConstraint"
-    view1ViewTopAnchorConstraint.identifier = "view1ViewTopAnchorConstraint"
-    view1ViewLeadingAnchorConstraint.identifier = "view1ViewLeadingAnchorConstraint"
-    view1ViewTrailingAnchorConstraint.identifier = "view1ViewTrailingAnchorConstraint"
-    view2ViewTopAnchorConstraint.identifier = "view2ViewTopAnchorConstraint"
-    view2ViewLeadingAnchorConstraint.identifier = "view2ViewLeadingAnchorConstraint"
-    view2ViewTrailingAnchorConstraint.identifier = "view2ViewTrailingAnchorConstraint"
-    view3ViewBottomAnchorConstraint.identifier = "view3ViewBottomAnchorConstraint"
-    view3ViewTopAnchorConstraint.identifier = "view3ViewTopAnchorConstraint"
-    view3ViewLeadingAnchorConstraint.identifier = "view3ViewLeadingAnchorConstraint"
-    view3ViewTrailingAnchorConstraint.identifier = "view3ViewTrailingAnchorConstraint"
-    view4ViewHeightAnchorParentConstraint.identifier = "view4ViewHeightAnchorParentConstraint"
-    view5ViewHeightAnchorParentConstraint.identifier = "view5ViewHeightAnchorParentConstraint"
-    view4ViewLeadingAnchorConstraint.identifier = "view4ViewLeadingAnchorConstraint"
-    view4ViewTopAnchorConstraint.identifier = "view4ViewTopAnchorConstraint"
-    view5ViewLeadingAnchorConstraint.identifier = "view5ViewLeadingAnchorConstraint"
-    view5ViewTopAnchorConstraint.identifier = "view5ViewTopAnchorConstraint"
-    view4ViewHeightAnchorConstraint.identifier = "view4ViewHeightAnchorConstraint"
-    view4ViewWidthAnchorConstraint.identifier = "view4ViewWidthAnchorConstraint"
-    view5ViewHeightAnchorConstraint.identifier = "view5ViewHeightAnchorConstraint"
-    view5ViewWidthAnchorConstraint.identifier = "view5ViewWidthAnchorConstraint"
   }
 
   private func update() {}

--- a/examples/generated/test/swift/layouts/FixedParentFillAndFitChildren.swift
+++ b/examples/generated/test/swift/layouts/FixedParentFillAndFitChildren.swift
@@ -66,15 +66,17 @@ public class FixedParentFillAndFitChildren: UIView {
     let view3ViewTrailingAnchorConstraint = view3View.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -24)
     let view4ViewHeightAnchorParentConstraint = view4View
       .heightAnchor
-      .constraint(lessThanOrEqualTo: view1View.heightAnchor, constant: -(24 + 24))
+      .constraint(lessThanOrEqualTo: view1View.heightAnchor, constant: -48)
     let view5ViewHeightAnchorParentConstraint = view5View
       .heightAnchor
-      .constraint(lessThanOrEqualTo: view1View.heightAnchor, constant: -(24 + 24))
+      .constraint(lessThanOrEqualTo: view1View.heightAnchor, constant: -48)
     let view4ViewLeadingAnchorConstraint = view4View
       .leadingAnchor
       .constraint(equalTo: view1View.leadingAnchor, constant: 24)
     let view4ViewTopAnchorConstraint = view4View.topAnchor.constraint(equalTo: view1View.topAnchor, constant: 24)
-    let view5ViewLeadingAnchorConstraint = view5View.leadingAnchor.constraint(equalTo: view4View.trailingAnchor)
+    let view5ViewLeadingAnchorConstraint = view5View
+      .leadingAnchor
+      .constraint(equalTo: view4View.trailingAnchor, constant: 12)
     let view5ViewTopAnchorConstraint = view5View.topAnchor.constraint(equalTo: view1View.topAnchor, constant: 24)
     let view4ViewHeightAnchorConstraint = view4View.heightAnchor.constraint(equalToConstant: 100)
     let view4ViewWidthAnchorConstraint = view4View.widthAnchor.constraint(equalToConstant: 60)

--- a/examples/generated/test/swift/layouts/FixedParentFitChild.swift
+++ b/examples/generated/test/swift/layouts/FixedParentFitChild.swift
@@ -49,15 +49,17 @@ public class FixedParentFitChild: UIView {
     let view1ViewTrailingAnchorConstraint = view1View.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -24)
     let view4ViewHeightAnchorParentConstraint = view4View
       .heightAnchor
-      .constraint(lessThanOrEqualTo: view1View.heightAnchor, constant: -(24 + 24))
+      .constraint(lessThanOrEqualTo: view1View.heightAnchor, constant: -48)
     let view5ViewHeightAnchorParentConstraint = view5View
       .heightAnchor
-      .constraint(lessThanOrEqualTo: view1View.heightAnchor, constant: -(24 + 24))
+      .constraint(lessThanOrEqualTo: view1View.heightAnchor, constant: -48)
     let view4ViewLeadingAnchorConstraint = view4View
       .leadingAnchor
       .constraint(equalTo: view1View.leadingAnchor, constant: 24)
     let view4ViewTopAnchorConstraint = view4View.topAnchor.constraint(equalTo: view1View.topAnchor, constant: 24)
-    let view5ViewLeadingAnchorConstraint = view5View.leadingAnchor.constraint(equalTo: view4View.trailingAnchor)
+    let view5ViewLeadingAnchorConstraint = view5View
+      .leadingAnchor
+      .constraint(equalTo: view4View.trailingAnchor, constant: 12)
     let view5ViewTopAnchorConstraint = view5View.topAnchor.constraint(equalTo: view1View.topAnchor, constant: 24)
     let view4ViewHeightAnchorConstraint = view4View.heightAnchor.constraint(equalToConstant: 100)
     let view4ViewWidthAnchorConstraint = view4View.widthAnchor.constraint(equalToConstant: 60)

--- a/examples/generated/test/swift/layouts/FixedParentFitChild.swift
+++ b/examples/generated/test/swift/layouts/FixedParentFitChild.swift
@@ -26,42 +26,6 @@ public class FixedParentFitChild: UIView {
   private var view4View = UIView(frame: .zero)
   private var view5View = UIView(frame: .zero)
 
-  private var topPadding: CGFloat = 24
-  private var trailingPadding: CGFloat = 24
-  private var bottomPadding: CGFloat = 24
-  private var leadingPadding: CGFloat = 24
-  private var view1ViewTopMargin: CGFloat = 0
-  private var view1ViewTrailingMargin: CGFloat = 0
-  private var view1ViewBottomMargin: CGFloat = 0
-  private var view1ViewLeadingMargin: CGFloat = 0
-  private var view1ViewTopPadding: CGFloat = 24
-  private var view1ViewTrailingPadding: CGFloat = 24
-  private var view1ViewBottomPadding: CGFloat = 24
-  private var view1ViewLeadingPadding: CGFloat = 24
-  private var view4ViewTopMargin: CGFloat = 0
-  private var view4ViewTrailingMargin: CGFloat = 0
-  private var view4ViewBottomMargin: CGFloat = 0
-  private var view4ViewLeadingMargin: CGFloat = 0
-  private var view5ViewTopMargin: CGFloat = 0
-  private var view5ViewTrailingMargin: CGFloat = 0
-  private var view5ViewBottomMargin: CGFloat = 0
-  private var view5ViewLeadingMargin: CGFloat = 12
-
-  private var heightAnchorConstraint: NSLayoutConstraint?
-  private var view1ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var view1ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var view1ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var view4ViewHeightAnchorParentConstraint: NSLayoutConstraint?
-  private var view5ViewHeightAnchorParentConstraint: NSLayoutConstraint?
-  private var view4ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var view4ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var view5ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var view5ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var view4ViewHeightAnchorConstraint: NSLayoutConstraint?
-  private var view4ViewWidthAnchorConstraint: NSLayoutConstraint?
-  private var view5ViewHeightAnchorConstraint: NSLayoutConstraint?
-  private var view5ViewWidthAnchorConstraint: NSLayoutConstraint?
-
   private func setUpViews() {
     addSubview(view1View)
     view1View.addSubview(view4View)
@@ -80,37 +44,21 @@ public class FixedParentFitChild: UIView {
     view5View.translatesAutoresizingMaskIntoConstraints = false
 
     let heightAnchorConstraint = heightAnchor.constraint(equalToConstant: 600)
-    let view1ViewTopAnchorConstraint = view1View
-      .topAnchor
-      .constraint(equalTo: topAnchor, constant: topPadding + view1ViewTopMargin)
-    let view1ViewLeadingAnchorConstraint = view1View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + view1ViewLeadingMargin)
-    let view1ViewTrailingAnchorConstraint = view1View
-      .trailingAnchor
-      .constraint(equalTo: trailingAnchor, constant: -(trailingPadding + view1ViewTrailingMargin))
+    let view1ViewTopAnchorConstraint = view1View.topAnchor.constraint(equalTo: topAnchor, constant: 24)
+    let view1ViewLeadingAnchorConstraint = view1View.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24)
+    let view1ViewTrailingAnchorConstraint = view1View.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -24)
     let view4ViewHeightAnchorParentConstraint = view4View
       .heightAnchor
-      .constraint(
-        lessThanOrEqualTo: view1View.heightAnchor,
-        constant: -(view1ViewTopPadding + view4ViewTopMargin + view1ViewBottomPadding + view4ViewBottomMargin))
+      .constraint(lessThanOrEqualTo: view1View.heightAnchor, constant: -(24 + 24))
     let view5ViewHeightAnchorParentConstraint = view5View
       .heightAnchor
-      .constraint(
-        lessThanOrEqualTo: view1View.heightAnchor,
-        constant: -(view1ViewTopPadding + view5ViewTopMargin + view1ViewBottomPadding + view5ViewBottomMargin))
+      .constraint(lessThanOrEqualTo: view1View.heightAnchor, constant: -(24 + 24))
     let view4ViewLeadingAnchorConstraint = view4View
       .leadingAnchor
-      .constraint(equalTo: view1View.leadingAnchor, constant: view1ViewLeadingPadding + view4ViewLeadingMargin)
-    let view4ViewTopAnchorConstraint = view4View
-      .topAnchor
-      .constraint(equalTo: view1View.topAnchor, constant: view1ViewTopPadding + view4ViewTopMargin)
-    let view5ViewLeadingAnchorConstraint = view5View
-      .leadingAnchor
-      .constraint(equalTo: view4View.trailingAnchor, constant: view4ViewTrailingMargin + view5ViewLeadingMargin)
-    let view5ViewTopAnchorConstraint = view5View
-      .topAnchor
-      .constraint(equalTo: view1View.topAnchor, constant: view1ViewTopPadding + view5ViewTopMargin)
+      .constraint(equalTo: view1View.leadingAnchor, constant: 24)
+    let view4ViewTopAnchorConstraint = view4View.topAnchor.constraint(equalTo: view1View.topAnchor, constant: 24)
+    let view5ViewLeadingAnchorConstraint = view5View.leadingAnchor.constraint(equalTo: view4View.trailingAnchor)
+    let view5ViewTopAnchorConstraint = view5View.topAnchor.constraint(equalTo: view1View.topAnchor, constant: 24)
     let view4ViewHeightAnchorConstraint = view4View.heightAnchor.constraint(equalToConstant: 100)
     let view4ViewWidthAnchorConstraint = view4View.widthAnchor.constraint(equalToConstant: 60)
     let view5ViewHeightAnchorConstraint = view5View.heightAnchor.constraint(equalToConstant: 60)
@@ -135,37 +83,6 @@ public class FixedParentFitChild: UIView {
       view5ViewHeightAnchorConstraint,
       view5ViewWidthAnchorConstraint
     ])
-
-    self.heightAnchorConstraint = heightAnchorConstraint
-    self.view1ViewTopAnchorConstraint = view1ViewTopAnchorConstraint
-    self.view1ViewLeadingAnchorConstraint = view1ViewLeadingAnchorConstraint
-    self.view1ViewTrailingAnchorConstraint = view1ViewTrailingAnchorConstraint
-    self.view4ViewHeightAnchorParentConstraint = view4ViewHeightAnchorParentConstraint
-    self.view5ViewHeightAnchorParentConstraint = view5ViewHeightAnchorParentConstraint
-    self.view4ViewLeadingAnchorConstraint = view4ViewLeadingAnchorConstraint
-    self.view4ViewTopAnchorConstraint = view4ViewTopAnchorConstraint
-    self.view5ViewLeadingAnchorConstraint = view5ViewLeadingAnchorConstraint
-    self.view5ViewTopAnchorConstraint = view5ViewTopAnchorConstraint
-    self.view4ViewHeightAnchorConstraint = view4ViewHeightAnchorConstraint
-    self.view4ViewWidthAnchorConstraint = view4ViewWidthAnchorConstraint
-    self.view5ViewHeightAnchorConstraint = view5ViewHeightAnchorConstraint
-    self.view5ViewWidthAnchorConstraint = view5ViewWidthAnchorConstraint
-
-    // For debugging
-    heightAnchorConstraint.identifier = "heightAnchorConstraint"
-    view1ViewTopAnchorConstraint.identifier = "view1ViewTopAnchorConstraint"
-    view1ViewLeadingAnchorConstraint.identifier = "view1ViewLeadingAnchorConstraint"
-    view1ViewTrailingAnchorConstraint.identifier = "view1ViewTrailingAnchorConstraint"
-    view4ViewHeightAnchorParentConstraint.identifier = "view4ViewHeightAnchorParentConstraint"
-    view5ViewHeightAnchorParentConstraint.identifier = "view5ViewHeightAnchorParentConstraint"
-    view4ViewLeadingAnchorConstraint.identifier = "view4ViewLeadingAnchorConstraint"
-    view4ViewTopAnchorConstraint.identifier = "view4ViewTopAnchorConstraint"
-    view5ViewLeadingAnchorConstraint.identifier = "view5ViewLeadingAnchorConstraint"
-    view5ViewTopAnchorConstraint.identifier = "view5ViewTopAnchorConstraint"
-    view4ViewHeightAnchorConstraint.identifier = "view4ViewHeightAnchorConstraint"
-    view4ViewWidthAnchorConstraint.identifier = "view4ViewWidthAnchorConstraint"
-    view5ViewHeightAnchorConstraint.identifier = "view5ViewHeightAnchorConstraint"
-    view5ViewWidthAnchorConstraint.identifier = "view5ViewWidthAnchorConstraint"
   }
 
   private func update() {}

--- a/examples/generated/test/swift/layouts/PrimaryAxis.swift
+++ b/examples/generated/test/swift/layouts/PrimaryAxis.swift
@@ -30,56 +30,6 @@ public class PrimaryAxis: UIView {
 
   private var textViewTextStyle = TextStyles.body1
 
-  private var topPadding: CGFloat = 24
-  private var trailingPadding: CGFloat = 24
-  private var bottomPadding: CGFloat = 24
-  private var leadingPadding: CGFloat = 24
-  private var fixedViewTopMargin: CGFloat = 0
-  private var fixedViewTrailingMargin: CGFloat = 0
-  private var fixedViewBottomMargin: CGFloat = 24
-  private var fixedViewLeadingMargin: CGFloat = 0
-  private var fitViewTopMargin: CGFloat = 0
-  private var fitViewTrailingMargin: CGFloat = 0
-  private var fitViewBottomMargin: CGFloat = 24
-  private var fitViewLeadingMargin: CGFloat = 0
-  private var fitViewTopPadding: CGFloat = 0
-  private var fitViewTrailingPadding: CGFloat = 0
-  private var fitViewBottomPadding: CGFloat = 0
-  private var fitViewLeadingPadding: CGFloat = 0
-  private var fill1ViewTopMargin: CGFloat = 0
-  private var fill1ViewTrailingMargin: CGFloat = 0
-  private var fill1ViewBottomMargin: CGFloat = 0
-  private var fill1ViewLeadingMargin: CGFloat = 0
-  private var fill2ViewTopMargin: CGFloat = 0
-  private var fill2ViewTrailingMargin: CGFloat = 0
-  private var fill2ViewBottomMargin: CGFloat = 0
-  private var fill2ViewLeadingMargin: CGFloat = 0
-  private var textViewTopMargin: CGFloat = 0
-  private var textViewTrailingMargin: CGFloat = 0
-  private var textViewBottomMargin: CGFloat = 0
-  private var textViewLeadingMargin: CGFloat = 0
-
-  private var heightAnchorConstraint: NSLayoutConstraint?
-  private var fill1ViewFill2ViewHeightAnchorSiblingConstraint: NSLayoutConstraint?
-  private var fixedViewTopAnchorConstraint: NSLayoutConstraint?
-  private var fixedViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var fitViewTopAnchorConstraint: NSLayoutConstraint?
-  private var fitViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var fill1ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var fill1ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var fill2ViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var fill2ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var fill2ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var fixedViewHeightAnchorConstraint: NSLayoutConstraint?
-  private var fixedViewWidthAnchorConstraint: NSLayoutConstraint?
-  private var fitViewWidthAnchorConstraint: NSLayoutConstraint?
-  private var textViewTopAnchorConstraint: NSLayoutConstraint?
-  private var textViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var textViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var textViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var fill1ViewWidthAnchorConstraint: NSLayoutConstraint?
-  private var fill2ViewWidthAnchorConstraint: NSLayoutConstraint?
-
   private func setUpViews() {
     textView.numberOfLines = 0
 
@@ -107,49 +57,23 @@ public class PrimaryAxis: UIView {
     let heightAnchorConstraint = heightAnchor.constraint(equalToConstant: 500)
     let fill1ViewFill2ViewHeightAnchorSiblingConstraint = fill1View
       .heightAnchor
-      .constraint(equalTo: fill2View.heightAnchor, constant: 0)
-    let fixedViewTopAnchorConstraint = fixedView
-      .topAnchor
-      .constraint(equalTo: topAnchor, constant: topPadding + fixedViewTopMargin)
-    let fixedViewLeadingAnchorConstraint = fixedView
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + fixedViewLeadingMargin)
-    let fitViewTopAnchorConstraint = fitView
-      .topAnchor
-      .constraint(equalTo: fixedView.bottomAnchor, constant: fixedViewBottomMargin + fitViewTopMargin)
-    let fitViewLeadingAnchorConstraint = fitView
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + fitViewLeadingMargin)
-    let fill1ViewTopAnchorConstraint = fill1View
-      .topAnchor
-      .constraint(equalTo: fitView.bottomAnchor, constant: fitViewBottomMargin + fill1ViewTopMargin)
-    let fill1ViewLeadingAnchorConstraint = fill1View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + fill1ViewLeadingMargin)
-    let fill2ViewBottomAnchorConstraint = fill2View
-      .bottomAnchor
-      .constraint(equalTo: bottomAnchor, constant: -(bottomPadding + fill2ViewBottomMargin))
-    let fill2ViewTopAnchorConstraint = fill2View
-      .topAnchor
-      .constraint(equalTo: fill1View.bottomAnchor, constant: fill1ViewBottomMargin + fill2ViewTopMargin)
-    let fill2ViewLeadingAnchorConstraint = fill2View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + fill2ViewLeadingMargin)
+      .constraint(equalTo: fill2View.heightAnchor)
+    let fixedViewTopAnchorConstraint = fixedView.topAnchor.constraint(equalTo: topAnchor, constant: 24)
+    let fixedViewLeadingAnchorConstraint = fixedView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24)
+    let fitViewTopAnchorConstraint = fitView.topAnchor.constraint(equalTo: fixedView.bottomAnchor, constant: 24)
+    let fitViewLeadingAnchorConstraint = fitView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24)
+    let fill1ViewTopAnchorConstraint = fill1View.topAnchor.constraint(equalTo: fitView.bottomAnchor, constant: 24)
+    let fill1ViewLeadingAnchorConstraint = fill1View.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24)
+    let fill2ViewBottomAnchorConstraint = fill2View.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -24)
+    let fill2ViewTopAnchorConstraint = fill2View.topAnchor.constraint(equalTo: fill1View.bottomAnchor)
+    let fill2ViewLeadingAnchorConstraint = fill2View.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24)
     let fixedViewHeightAnchorConstraint = fixedView.heightAnchor.constraint(equalToConstant: 100)
     let fixedViewWidthAnchorConstraint = fixedView.widthAnchor.constraint(equalToConstant: 100)
     let fitViewWidthAnchorConstraint = fitView.widthAnchor.constraint(equalToConstant: 100)
-    let textViewTopAnchorConstraint = textView
-      .topAnchor
-      .constraint(equalTo: fitView.topAnchor, constant: fitViewTopPadding + textViewTopMargin)
-    let textViewBottomAnchorConstraint = textView
-      .bottomAnchor
-      .constraint(equalTo: fitView.bottomAnchor, constant: -(fitViewBottomPadding + textViewBottomMargin))
-    let textViewLeadingAnchorConstraint = textView
-      .leadingAnchor
-      .constraint(equalTo: fitView.leadingAnchor, constant: fitViewLeadingPadding + textViewLeadingMargin)
-    let textViewTrailingAnchorConstraint = textView
-      .trailingAnchor
-      .constraint(equalTo: fitView.trailingAnchor, constant: -(fitViewTrailingPadding + textViewTrailingMargin))
+    let textViewTopAnchorConstraint = textView.topAnchor.constraint(equalTo: fitView.topAnchor)
+    let textViewBottomAnchorConstraint = textView.bottomAnchor.constraint(equalTo: fitView.bottomAnchor, constant: -24)
+    let textViewLeadingAnchorConstraint = textView.leadingAnchor.constraint(equalTo: fitView.leadingAnchor)
+    let textViewTrailingAnchorConstraint = textView.trailingAnchor.constraint(equalTo: fitView.trailingAnchor)
     let fill1ViewWidthAnchorConstraint = fill1View.widthAnchor.constraint(equalToConstant: 100)
     let fill2ViewWidthAnchorConstraint = fill2View.widthAnchor.constraint(equalToConstant: 100)
 
@@ -175,49 +99,6 @@ public class PrimaryAxis: UIView {
       fill1ViewWidthAnchorConstraint,
       fill2ViewWidthAnchorConstraint
     ])
-
-    self.heightAnchorConstraint = heightAnchorConstraint
-    self.fill1ViewFill2ViewHeightAnchorSiblingConstraint = fill1ViewFill2ViewHeightAnchorSiblingConstraint
-    self.fixedViewTopAnchorConstraint = fixedViewTopAnchorConstraint
-    self.fixedViewLeadingAnchorConstraint = fixedViewLeadingAnchorConstraint
-    self.fitViewTopAnchorConstraint = fitViewTopAnchorConstraint
-    self.fitViewLeadingAnchorConstraint = fitViewLeadingAnchorConstraint
-    self.fill1ViewTopAnchorConstraint = fill1ViewTopAnchorConstraint
-    self.fill1ViewLeadingAnchorConstraint = fill1ViewLeadingAnchorConstraint
-    self.fill2ViewBottomAnchorConstraint = fill2ViewBottomAnchorConstraint
-    self.fill2ViewTopAnchorConstraint = fill2ViewTopAnchorConstraint
-    self.fill2ViewLeadingAnchorConstraint = fill2ViewLeadingAnchorConstraint
-    self.fixedViewHeightAnchorConstraint = fixedViewHeightAnchorConstraint
-    self.fixedViewWidthAnchorConstraint = fixedViewWidthAnchorConstraint
-    self.fitViewWidthAnchorConstraint = fitViewWidthAnchorConstraint
-    self.textViewTopAnchorConstraint = textViewTopAnchorConstraint
-    self.textViewBottomAnchorConstraint = textViewBottomAnchorConstraint
-    self.textViewLeadingAnchorConstraint = textViewLeadingAnchorConstraint
-    self.textViewTrailingAnchorConstraint = textViewTrailingAnchorConstraint
-    self.fill1ViewWidthAnchorConstraint = fill1ViewWidthAnchorConstraint
-    self.fill2ViewWidthAnchorConstraint = fill2ViewWidthAnchorConstraint
-
-    // For debugging
-    heightAnchorConstraint.identifier = "heightAnchorConstraint"
-    fill1ViewFill2ViewHeightAnchorSiblingConstraint.identifier = "fill1ViewFill2ViewHeightAnchorSiblingConstraint"
-    fixedViewTopAnchorConstraint.identifier = "fixedViewTopAnchorConstraint"
-    fixedViewLeadingAnchorConstraint.identifier = "fixedViewLeadingAnchorConstraint"
-    fitViewTopAnchorConstraint.identifier = "fitViewTopAnchorConstraint"
-    fitViewLeadingAnchorConstraint.identifier = "fitViewLeadingAnchorConstraint"
-    fill1ViewTopAnchorConstraint.identifier = "fill1ViewTopAnchorConstraint"
-    fill1ViewLeadingAnchorConstraint.identifier = "fill1ViewLeadingAnchorConstraint"
-    fill2ViewBottomAnchorConstraint.identifier = "fill2ViewBottomAnchorConstraint"
-    fill2ViewTopAnchorConstraint.identifier = "fill2ViewTopAnchorConstraint"
-    fill2ViewLeadingAnchorConstraint.identifier = "fill2ViewLeadingAnchorConstraint"
-    fixedViewHeightAnchorConstraint.identifier = "fixedViewHeightAnchorConstraint"
-    fixedViewWidthAnchorConstraint.identifier = "fixedViewWidthAnchorConstraint"
-    fitViewWidthAnchorConstraint.identifier = "fitViewWidthAnchorConstraint"
-    textViewTopAnchorConstraint.identifier = "textViewTopAnchorConstraint"
-    textViewBottomAnchorConstraint.identifier = "textViewBottomAnchorConstraint"
-    textViewLeadingAnchorConstraint.identifier = "textViewLeadingAnchorConstraint"
-    textViewTrailingAnchorConstraint.identifier = "textViewTrailingAnchorConstraint"
-    fill1ViewWidthAnchorConstraint.identifier = "fill1ViewWidthAnchorConstraint"
-    fill2ViewWidthAnchorConstraint.identifier = "fill2ViewWidthAnchorConstraint"
   }
 
   private func update() {}

--- a/examples/generated/test/swift/layouts/PrimaryAxis.swift
+++ b/examples/generated/test/swift/layouts/PrimaryAxis.swift
@@ -71,7 +71,7 @@ public class PrimaryAxis: UIView {
     let fixedViewWidthAnchorConstraint = fixedView.widthAnchor.constraint(equalToConstant: 100)
     let fitViewWidthAnchorConstraint = fitView.widthAnchor.constraint(equalToConstant: 100)
     let textViewTopAnchorConstraint = textView.topAnchor.constraint(equalTo: fitView.topAnchor)
-    let textViewBottomAnchorConstraint = textView.bottomAnchor.constraint(equalTo: fitView.bottomAnchor, constant: -24)
+    let textViewBottomAnchorConstraint = textView.bottomAnchor.constraint(equalTo: fitView.bottomAnchor)
     let textViewLeadingAnchorConstraint = textView.leadingAnchor.constraint(equalTo: fitView.leadingAnchor)
     let textViewTrailingAnchorConstraint = textView.trailingAnchor.constraint(equalTo: fitView.trailingAnchor)
     let fill1ViewWidthAnchorConstraint = fill1View.widthAnchor.constraint(equalToConstant: 100)

--- a/examples/generated/test/swift/layouts/SecondaryAxis.swift
+++ b/examples/generated/test/swift/layouts/SecondaryAxis.swift
@@ -29,49 +29,6 @@ public class SecondaryAxis: UIView {
 
   private var textViewTextStyle = TextStyles.body1
 
-  private var topPadding: CGFloat = 24
-  private var trailingPadding: CGFloat = 24
-  private var bottomPadding: CGFloat = 24
-  private var leadingPadding: CGFloat = 24
-  private var fixedViewTopMargin: CGFloat = 0
-  private var fixedViewTrailingMargin: CGFloat = 0
-  private var fixedViewBottomMargin: CGFloat = 24
-  private var fixedViewLeadingMargin: CGFloat = 0
-  private var fitViewTopMargin: CGFloat = 0
-  private var fitViewTrailingMargin: CGFloat = 0
-  private var fitViewBottomMargin: CGFloat = 24
-  private var fitViewLeadingMargin: CGFloat = 0
-  private var fitViewTopPadding: CGFloat = 12
-  private var fitViewTrailingPadding: CGFloat = 12
-  private var fitViewBottomPadding: CGFloat = 12
-  private var fitViewLeadingPadding: CGFloat = 12
-  private var fillViewTopMargin: CGFloat = 0
-  private var fillViewTrailingMargin: CGFloat = 0
-  private var fillViewBottomMargin: CGFloat = 0
-  private var fillViewLeadingMargin: CGFloat = 0
-  private var textViewTopMargin: CGFloat = 0
-  private var textViewTrailingMargin: CGFloat = 0
-  private var textViewBottomMargin: CGFloat = 0
-  private var textViewLeadingMargin: CGFloat = 0
-
-  private var fixedViewTopAnchorConstraint: NSLayoutConstraint?
-  private var fixedViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var fitViewTopAnchorConstraint: NSLayoutConstraint?
-  private var fitViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var fitViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var fillViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var fillViewTopAnchorConstraint: NSLayoutConstraint?
-  private var fillViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var fillViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var fixedViewHeightAnchorConstraint: NSLayoutConstraint?
-  private var fixedViewWidthAnchorConstraint: NSLayoutConstraint?
-  private var fitViewHeightAnchorConstraint: NSLayoutConstraint?
-  private var textViewWidthAnchorParentConstraint: NSLayoutConstraint?
-  private var textViewTopAnchorConstraint: NSLayoutConstraint?
-  private var textViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var textViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var fillViewHeightAnchorConstraint: NSLayoutConstraint?
-
   private func setUpViews() {
     textView.numberOfLines = 0
 
@@ -93,50 +50,30 @@ public class SecondaryAxis: UIView {
     fillView.translatesAutoresizingMaskIntoConstraints = false
     textView.translatesAutoresizingMaskIntoConstraints = false
 
-    let fixedViewTopAnchorConstraint = fixedView
-      .topAnchor
-      .constraint(equalTo: topAnchor, constant: topPadding + fixedViewTopMargin)
-    let fixedViewLeadingAnchorConstraint = fixedView
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + fixedViewLeadingMargin)
-    let fitViewTopAnchorConstraint = fitView
-      .topAnchor
-      .constraint(equalTo: fixedView.bottomAnchor, constant: fixedViewBottomMargin + fitViewTopMargin)
-    let fitViewLeadingAnchorConstraint = fitView
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + fitViewLeadingMargin)
+    let fixedViewTopAnchorConstraint = fixedView.topAnchor.constraint(equalTo: topAnchor, constant: 24)
+    let fixedViewLeadingAnchorConstraint = fixedView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24)
+    let fitViewTopAnchorConstraint = fitView.topAnchor.constraint(equalTo: fixedView.bottomAnchor, constant: 24)
+    let fitViewLeadingAnchorConstraint = fitView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24)
     let fitViewTrailingAnchorConstraint = fitView
       .trailingAnchor
-      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -(trailingPadding + fitViewTrailingMargin))
-    let fillViewBottomAnchorConstraint = fillView
-      .bottomAnchor
-      .constraint(equalTo: bottomAnchor, constant: -(bottomPadding + fillViewBottomMargin))
-    let fillViewTopAnchorConstraint = fillView
-      .topAnchor
-      .constraint(equalTo: fitView.bottomAnchor, constant: fitViewBottomMargin + fillViewTopMargin)
-    let fillViewLeadingAnchorConstraint = fillView
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + fillViewLeadingMargin)
-    let fillViewTrailingAnchorConstraint = fillView
-      .trailingAnchor
-      .constraint(equalTo: trailingAnchor, constant: -(trailingPadding + fillViewTrailingMargin))
+      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -24)
+    let fillViewBottomAnchorConstraint = fillView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -24)
+    let fillViewTopAnchorConstraint = fillView.topAnchor.constraint(equalTo: fitView.bottomAnchor, constant: 24)
+    let fillViewLeadingAnchorConstraint = fillView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24)
+    let fillViewTrailingAnchorConstraint = fillView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -24)
     let fixedViewHeightAnchorConstraint = fixedView.heightAnchor.constraint(equalToConstant: 100)
     let fixedViewWidthAnchorConstraint = fixedView.widthAnchor.constraint(equalToConstant: 100)
     let fitViewHeightAnchorConstraint = fitView.heightAnchor.constraint(equalToConstant: 100)
     let textViewWidthAnchorParentConstraint = textView
       .widthAnchor
-      .constraint(
-        lessThanOrEqualTo: fitView.widthAnchor,
-        constant: -(fitViewLeadingPadding + textViewLeadingMargin + fitViewTrailingPadding + textViewTrailingMargin))
-    let textViewTopAnchorConstraint = textView
-      .topAnchor
-      .constraint(equalTo: fitView.topAnchor, constant: fitViewTopPadding + textViewTopMargin)
+      .constraint(lessThanOrEqualTo: fitView.widthAnchor, constant: -(12 + 12))
+    let textViewTopAnchorConstraint = textView.topAnchor.constraint(equalTo: fitView.topAnchor, constant: 12)
     let textViewLeadingAnchorConstraint = textView
       .leadingAnchor
-      .constraint(equalTo: fitView.leadingAnchor, constant: fitViewLeadingPadding + textViewLeadingMargin)
+      .constraint(equalTo: fitView.leadingAnchor, constant: 12)
     let textViewTrailingAnchorConstraint = textView
       .trailingAnchor
-      .constraint(equalTo: fitView.trailingAnchor, constant: -(fitViewTrailingPadding + textViewTrailingMargin))
+      .constraint(equalTo: fitView.trailingAnchor, constant: -12)
     let fillViewHeightAnchorConstraint = fillView.heightAnchor.constraint(equalToConstant: 100)
 
     textViewWidthAnchorParentConstraint.priority = UILayoutPriority.defaultLow
@@ -160,43 +97,6 @@ public class SecondaryAxis: UIView {
       textViewTrailingAnchorConstraint,
       fillViewHeightAnchorConstraint
     ])
-
-    self.fixedViewTopAnchorConstraint = fixedViewTopAnchorConstraint
-    self.fixedViewLeadingAnchorConstraint = fixedViewLeadingAnchorConstraint
-    self.fitViewTopAnchorConstraint = fitViewTopAnchorConstraint
-    self.fitViewLeadingAnchorConstraint = fitViewLeadingAnchorConstraint
-    self.fitViewTrailingAnchorConstraint = fitViewTrailingAnchorConstraint
-    self.fillViewBottomAnchorConstraint = fillViewBottomAnchorConstraint
-    self.fillViewTopAnchorConstraint = fillViewTopAnchorConstraint
-    self.fillViewLeadingAnchorConstraint = fillViewLeadingAnchorConstraint
-    self.fillViewTrailingAnchorConstraint = fillViewTrailingAnchorConstraint
-    self.fixedViewHeightAnchorConstraint = fixedViewHeightAnchorConstraint
-    self.fixedViewWidthAnchorConstraint = fixedViewWidthAnchorConstraint
-    self.fitViewHeightAnchorConstraint = fitViewHeightAnchorConstraint
-    self.textViewWidthAnchorParentConstraint = textViewWidthAnchorParentConstraint
-    self.textViewTopAnchorConstraint = textViewTopAnchorConstraint
-    self.textViewLeadingAnchorConstraint = textViewLeadingAnchorConstraint
-    self.textViewTrailingAnchorConstraint = textViewTrailingAnchorConstraint
-    self.fillViewHeightAnchorConstraint = fillViewHeightAnchorConstraint
-
-    // For debugging
-    fixedViewTopAnchorConstraint.identifier = "fixedViewTopAnchorConstraint"
-    fixedViewLeadingAnchorConstraint.identifier = "fixedViewLeadingAnchorConstraint"
-    fitViewTopAnchorConstraint.identifier = "fitViewTopAnchorConstraint"
-    fitViewLeadingAnchorConstraint.identifier = "fitViewLeadingAnchorConstraint"
-    fitViewTrailingAnchorConstraint.identifier = "fitViewTrailingAnchorConstraint"
-    fillViewBottomAnchorConstraint.identifier = "fillViewBottomAnchorConstraint"
-    fillViewTopAnchorConstraint.identifier = "fillViewTopAnchorConstraint"
-    fillViewLeadingAnchorConstraint.identifier = "fillViewLeadingAnchorConstraint"
-    fillViewTrailingAnchorConstraint.identifier = "fillViewTrailingAnchorConstraint"
-    fixedViewHeightAnchorConstraint.identifier = "fixedViewHeightAnchorConstraint"
-    fixedViewWidthAnchorConstraint.identifier = "fixedViewWidthAnchorConstraint"
-    fitViewHeightAnchorConstraint.identifier = "fitViewHeightAnchorConstraint"
-    textViewWidthAnchorParentConstraint.identifier = "textViewWidthAnchorParentConstraint"
-    textViewTopAnchorConstraint.identifier = "textViewTopAnchorConstraint"
-    textViewLeadingAnchorConstraint.identifier = "textViewLeadingAnchorConstraint"
-    textViewTrailingAnchorConstraint.identifier = "textViewTrailingAnchorConstraint"
-    fillViewHeightAnchorConstraint.identifier = "fillViewHeightAnchorConstraint"
   }
 
   private func update() {}

--- a/examples/generated/test/swift/layouts/SecondaryAxis.swift
+++ b/examples/generated/test/swift/layouts/SecondaryAxis.swift
@@ -66,7 +66,7 @@ public class SecondaryAxis: UIView {
     let fitViewHeightAnchorConstraint = fitView.heightAnchor.constraint(equalToConstant: 100)
     let textViewWidthAnchorParentConstraint = textView
       .widthAnchor
-      .constraint(lessThanOrEqualTo: fitView.widthAnchor, constant: -(12 + 12))
+      .constraint(lessThanOrEqualTo: fitView.widthAnchor, constant: -24)
     let textViewTopAnchorConstraint = textView.topAnchor.constraint(equalTo: fitView.topAnchor, constant: 12)
     let textViewLeadingAnchorConstraint = textView
       .leadingAnchor

--- a/examples/generated/test/swift/logic/Assign.swift
+++ b/examples/generated/test/swift/logic/Assign.swift
@@ -36,20 +36,6 @@ public class Assign: UIView {
 
   private var textViewTextStyle = TextStyles.body1
 
-  private var topPadding: CGFloat = 0
-  private var trailingPadding: CGFloat = 0
-  private var bottomPadding: CGFloat = 0
-  private var leadingPadding: CGFloat = 0
-  private var textViewTopMargin: CGFloat = 0
-  private var textViewTrailingMargin: CGFloat = 0
-  private var textViewBottomMargin: CGFloat = 0
-  private var textViewLeadingMargin: CGFloat = 0
-
-  private var textViewTopAnchorConstraint: NSLayoutConstraint?
-  private var textViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var textViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var textViewTrailingAnchorConstraint: NSLayoutConstraint?
-
   private func setUpViews() {
     textView.numberOfLines = 0
 
@@ -60,18 +46,10 @@ public class Assign: UIView {
     translatesAutoresizingMaskIntoConstraints = false
     textView.translatesAutoresizingMaskIntoConstraints = false
 
-    let textViewTopAnchorConstraint = textView
-      .topAnchor
-      .constraint(equalTo: topAnchor, constant: topPadding + textViewTopMargin)
-    let textViewBottomAnchorConstraint = textView
-      .bottomAnchor
-      .constraint(equalTo: bottomAnchor, constant: -(bottomPadding + textViewBottomMargin))
-    let textViewLeadingAnchorConstraint = textView
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + textViewLeadingMargin)
-    let textViewTrailingAnchorConstraint = textView
-      .trailingAnchor
-      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -(trailingPadding + textViewTrailingMargin))
+    let textViewTopAnchorConstraint = textView.topAnchor.constraint(equalTo: topAnchor)
+    let textViewBottomAnchorConstraint = textView.bottomAnchor.constraint(equalTo: bottomAnchor)
+    let textViewLeadingAnchorConstraint = textView.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let textViewTrailingAnchorConstraint = textView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor)
 
     NSLayoutConstraint.activate([
       textViewTopAnchorConstraint,
@@ -79,17 +57,6 @@ public class Assign: UIView {
       textViewLeadingAnchorConstraint,
       textViewTrailingAnchorConstraint
     ])
-
-    self.textViewTopAnchorConstraint = textViewTopAnchorConstraint
-    self.textViewBottomAnchorConstraint = textViewBottomAnchorConstraint
-    self.textViewLeadingAnchorConstraint = textViewLeadingAnchorConstraint
-    self.textViewTrailingAnchorConstraint = textViewTrailingAnchorConstraint
-
-    // For debugging
-    textViewTopAnchorConstraint.identifier = "textViewTopAnchorConstraint"
-    textViewBottomAnchorConstraint.identifier = "textViewBottomAnchorConstraint"
-    textViewLeadingAnchorConstraint.identifier = "textViewLeadingAnchorConstraint"
-    textViewTrailingAnchorConstraint.identifier = "textViewTrailingAnchorConstraint"
   }
 
   private func update() {

--- a/examples/generated/test/swift/style/BorderWidthColor.swift
+++ b/examples/generated/test/swift/style/BorderWidthColor.swift
@@ -24,21 +24,6 @@ public class BorderWidthColor: UIView {
 
   private var view1View = UIView(frame: .zero)
 
-  private var topPadding: CGFloat = 0
-  private var trailingPadding: CGFloat = 0
-  private var bottomPadding: CGFloat = 0
-  private var leadingPadding: CGFloat = 0
-  private var view1ViewTopMargin: CGFloat = 0
-  private var view1ViewTrailingMargin: CGFloat = 0
-  private var view1ViewBottomMargin: CGFloat = 0
-  private var view1ViewLeadingMargin: CGFloat = 0
-
-  private var view1ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var view1ViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var view1ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var view1ViewHeightAnchorConstraint: NSLayoutConstraint?
-  private var view1ViewWidthAnchorConstraint: NSLayoutConstraint?
-
   private func setUpViews() {
     addSubview(view1View)
 
@@ -51,15 +36,9 @@ public class BorderWidthColor: UIView {
     translatesAutoresizingMaskIntoConstraints = false
     view1View.translatesAutoresizingMaskIntoConstraints = false
 
-    let view1ViewTopAnchorConstraint = view1View
-      .topAnchor
-      .constraint(equalTo: topAnchor, constant: topPadding + view1ViewTopMargin)
-    let view1ViewBottomAnchorConstraint = view1View
-      .bottomAnchor
-      .constraint(equalTo: bottomAnchor, constant: -(bottomPadding + view1ViewBottomMargin))
-    let view1ViewLeadingAnchorConstraint = view1View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + view1ViewLeadingMargin)
+    let view1ViewTopAnchorConstraint = view1View.topAnchor.constraint(equalTo: topAnchor)
+    let view1ViewBottomAnchorConstraint = view1View.bottomAnchor.constraint(equalTo: bottomAnchor)
+    let view1ViewLeadingAnchorConstraint = view1View.leadingAnchor.constraint(equalTo: leadingAnchor)
     let view1ViewHeightAnchorConstraint = view1View.heightAnchor.constraint(equalToConstant: 100)
     let view1ViewWidthAnchorConstraint = view1View.widthAnchor.constraint(equalToConstant: 100)
 
@@ -70,19 +49,6 @@ public class BorderWidthColor: UIView {
       view1ViewHeightAnchorConstraint,
       view1ViewWidthAnchorConstraint
     ])
-
-    self.view1ViewTopAnchorConstraint = view1ViewTopAnchorConstraint
-    self.view1ViewBottomAnchorConstraint = view1ViewBottomAnchorConstraint
-    self.view1ViewLeadingAnchorConstraint = view1ViewLeadingAnchorConstraint
-    self.view1ViewHeightAnchorConstraint = view1ViewHeightAnchorConstraint
-    self.view1ViewWidthAnchorConstraint = view1ViewWidthAnchorConstraint
-
-    // For debugging
-    view1ViewTopAnchorConstraint.identifier = "view1ViewTopAnchorConstraint"
-    view1ViewBottomAnchorConstraint.identifier = "view1ViewBottomAnchorConstraint"
-    view1ViewLeadingAnchorConstraint.identifier = "view1ViewLeadingAnchorConstraint"
-    view1ViewHeightAnchorConstraint.identifier = "view1ViewHeightAnchorConstraint"
-    view1ViewWidthAnchorConstraint.identifier = "view1ViewWidthAnchorConstraint"
   }
 
   private func update() {}

--- a/examples/generated/test/swift/style/BoxModelConditional.swift
+++ b/examples/generated/test/swift/style/BoxModelConditional.swift
@@ -1,0 +1,84 @@
+import UIKit
+import Foundation
+
+// MARK: - BoxModelConditional
+
+public class BoxModelConditional: UIView {
+
+  // MARK: Lifecycle
+
+  public init(margin: CGFloat, size: CGFloat) {
+    self.margin = margin
+    self.size = size
+
+    super.init(frame: .zero)
+
+    setUpViews()
+    setUpConstraints()
+
+    update()
+  }
+
+  public convenience init() {
+    self.init(margin: 0, size: 0)
+  }
+
+  public required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: Public
+
+  public var margin: CGFloat { didSet { update() } }
+  public var size: CGFloat { didSet { update() } }
+
+  // MARK: Private
+
+  private var innerView = UIView(frame: .zero)
+
+  private var innerViewTopAnchorConstraint: NSLayoutConstraint?
+  private var innerViewBottomAnchorConstraint: NSLayoutConstraint?
+  private var innerViewLeadingAnchorConstraint: NSLayoutConstraint?
+  private var innerViewHeightAnchorConstraint: NSLayoutConstraint?
+  private var innerViewWidthAnchorConstraint: NSLayoutConstraint?
+
+  private func setUpViews() {
+    addSubview(innerView)
+
+    innerView.backgroundColor = #colorLiteral(red: 0.847058823529, green: 0.847058823529, blue: 0.847058823529, alpha: 1)
+  }
+
+  private func setUpConstraints() {
+    translatesAutoresizingMaskIntoConstraints = false
+    innerView.translatesAutoresizingMaskIntoConstraints = false
+
+    let innerViewTopAnchorConstraint = innerView.topAnchor.constraint(equalTo: topAnchor, constant: 4)
+    let innerViewBottomAnchorConstraint = innerView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -4)
+    let innerViewLeadingAnchorConstraint = innerView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 4)
+    let innerViewHeightAnchorConstraint = innerView.heightAnchor.constraint(equalToConstant: 60)
+    let innerViewWidthAnchorConstraint = innerView.widthAnchor.constraint(equalToConstant: 60)
+
+    NSLayoutConstraint.activate([
+      innerViewTopAnchorConstraint,
+      innerViewBottomAnchorConstraint,
+      innerViewLeadingAnchorConstraint,
+      innerViewHeightAnchorConstraint,
+      innerViewWidthAnchorConstraint
+    ])
+
+    self.innerViewTopAnchorConstraint = innerViewTopAnchorConstraint
+    self.innerViewBottomAnchorConstraint = innerViewBottomAnchorConstraint
+    self.innerViewLeadingAnchorConstraint = innerViewLeadingAnchorConstraint
+    self.innerViewHeightAnchorConstraint = innerViewHeightAnchorConstraint
+    self.innerViewWidthAnchorConstraint = innerViewWidthAnchorConstraint
+  }
+
+  private func update() {
+    // TODO: Margin & padding: innerView.marginTop = // TODO: Margin & padding: margin
+    // TODO: Margin & padding: innerView.marginRight = // TODO: Margin & padding: margin
+    // TODO: Margin & padding: innerView.marginBottom = // TODO: Margin & padding: margin
+    // TODO: Margin & padding: innerView.marginLeft = // TODO: Margin & padding: margin
+    innerViewHeightAnchorConstraint?.constant = size
+    innerViewWidthAnchorConstraint?.constant = size
+  }
+}

--- a/examples/generated/test/swift/style/TextAlignment.swift
+++ b/examples/generated/test/swift/style/TextAlignment.swift
@@ -55,194 +55,6 @@ public class TextAlignment: UIView {
   private var text9ViewTextStyle = TextStyles.body1
   private var text10ViewTextStyle = TextStyles.body1.with(alignment: .center)
 
-  private var topPadding: CGFloat = 10
-  private var trailingPadding: CGFloat = 10
-  private var bottomPadding: CGFloat = 10
-  private var leadingPadding: CGFloat = 10
-  private var view1ViewTopMargin: CGFloat = 0
-  private var view1ViewTrailingMargin: CGFloat = 0
-  private var view1ViewBottomMargin: CGFloat = 0
-  private var view1ViewLeadingMargin: CGFloat = 0
-  private var view1ViewTopPadding: CGFloat = 0
-  private var view1ViewTrailingPadding: CGFloat = 0
-  private var view1ViewBottomPadding: CGFloat = 0
-  private var view1ViewLeadingPadding: CGFloat = 0
-  private var view3ViewTopMargin: CGFloat = 0
-  private var view3ViewTrailingMargin: CGFloat = 0
-  private var view3ViewBottomMargin: CGFloat = 0
-  private var view3ViewLeadingMargin: CGFloat = 0
-  private var view3ViewTopPadding: CGFloat = 0
-  private var view3ViewTrailingPadding: CGFloat = 12
-  private var view3ViewBottomPadding: CGFloat = 0
-  private var view3ViewLeadingPadding: CGFloat = 12
-  private var view4ViewTopMargin: CGFloat = 0
-  private var view4ViewTrailingMargin: CGFloat = 0
-  private var view4ViewBottomMargin: CGFloat = 0
-  private var view4ViewLeadingMargin: CGFloat = 0
-  private var view4ViewTopPadding: CGFloat = 0
-  private var view4ViewTrailingPadding: CGFloat = 12
-  private var view4ViewBottomPadding: CGFloat = 0
-  private var view4ViewLeadingPadding: CGFloat = 12
-  private var view5ViewTopMargin: CGFloat = 0
-  private var view5ViewTrailingMargin: CGFloat = 0
-  private var view5ViewBottomMargin: CGFloat = 0
-  private var view5ViewLeadingMargin: CGFloat = 0
-  private var view5ViewTopPadding: CGFloat = 0
-  private var view5ViewTrailingPadding: CGFloat = 12
-  private var view5ViewBottomPadding: CGFloat = 0
-  private var view5ViewLeadingPadding: CGFloat = 12
-  private var view6ViewTopMargin: CGFloat = 0
-  private var view6ViewTrailingMargin: CGFloat = 0
-  private var view6ViewBottomMargin: CGFloat = 0
-  private var view6ViewLeadingMargin: CGFloat = 0
-  private var view6ViewTopPadding: CGFloat = 0
-  private var view6ViewTrailingPadding: CGFloat = 12
-  private var view6ViewBottomPadding: CGFloat = 0
-  private var view6ViewLeadingPadding: CGFloat = 12
-  private var rightAlignmentContainerViewTopMargin: CGFloat = 0
-  private var rightAlignmentContainerViewTrailingMargin: CGFloat = 0
-  private var rightAlignmentContainerViewBottomMargin: CGFloat = 0
-  private var rightAlignmentContainerViewLeadingMargin: CGFloat = 0
-  private var rightAlignmentContainerViewTopPadding: CGFloat = 0
-  private var rightAlignmentContainerViewTrailingPadding: CGFloat = 0
-  private var rightAlignmentContainerViewBottomPadding: CGFloat = 0
-  private var rightAlignmentContainerViewLeadingPadding: CGFloat = 0
-  private var imageViewTopMargin: CGFloat = 0
-  private var imageViewTrailingMargin: CGFloat = 0
-  private var imageViewBottomMargin: CGFloat = 0
-  private var imageViewLeadingMargin: CGFloat = 0
-  private var view2ViewTopMargin: CGFloat = 0
-  private var view2ViewTrailingMargin: CGFloat = 0
-  private var view2ViewBottomMargin: CGFloat = 0
-  private var view2ViewLeadingMargin: CGFloat = 0
-  private var textViewTopMargin: CGFloat = 16
-  private var textViewTrailingMargin: CGFloat = 0
-  private var textViewBottomMargin: CGFloat = 0
-  private var textViewLeadingMargin: CGFloat = 0
-  private var text1ViewTopMargin: CGFloat = 16
-  private var text1ViewTrailingMargin: CGFloat = 0
-  private var text1ViewBottomMargin: CGFloat = 0
-  private var text1ViewLeadingMargin: CGFloat = 0
-  private var text2ViewTopMargin: CGFloat = 12
-  private var text2ViewTrailingMargin: CGFloat = 0
-  private var text2ViewBottomMargin: CGFloat = 0
-  private var text2ViewLeadingMargin: CGFloat = 0
-  private var text3ViewTopMargin: CGFloat = 0
-  private var text3ViewTrailingMargin: CGFloat = 0
-  private var text3ViewBottomMargin: CGFloat = 0
-  private var text3ViewLeadingMargin: CGFloat = 0
-  private var text4ViewTopMargin: CGFloat = 0
-  private var text4ViewTrailingMargin: CGFloat = 0
-  private var text4ViewBottomMargin: CGFloat = 0
-  private var text4ViewLeadingMargin: CGFloat = 0
-  private var text5ViewTopMargin: CGFloat = 0
-  private var text5ViewTrailingMargin: CGFloat = 0
-  private var text5ViewBottomMargin: CGFloat = 0
-  private var text5ViewLeadingMargin: CGFloat = 0
-  private var text6ViewTopMargin: CGFloat = 0
-  private var text6ViewTrailingMargin: CGFloat = 0
-  private var text6ViewBottomMargin: CGFloat = 0
-  private var text6ViewLeadingMargin: CGFloat = 0
-  private var text7ViewTopMargin: CGFloat = 0
-  private var text7ViewTrailingMargin: CGFloat = 0
-  private var text7ViewBottomMargin: CGFloat = 0
-  private var text7ViewLeadingMargin: CGFloat = 0
-  private var text8ViewTopMargin: CGFloat = 0
-  private var text8ViewTrailingMargin: CGFloat = 0
-  private var text8ViewBottomMargin: CGFloat = 0
-  private var text8ViewLeadingMargin: CGFloat = 0
-  private var text9ViewTopMargin: CGFloat = 0
-  private var text9ViewTrailingMargin: CGFloat = 0
-  private var text9ViewBottomMargin: CGFloat = 0
-  private var text9ViewLeadingMargin: CGFloat = 0
-  private var text10ViewTopMargin: CGFloat = 0
-  private var text10ViewTrailingMargin: CGFloat = 0
-  private var text10ViewBottomMargin: CGFloat = 0
-  private var text10ViewLeadingMargin: CGFloat = 0
-  private var image1ViewTopMargin: CGFloat = 0
-  private var image1ViewTrailingMargin: CGFloat = 0
-  private var image1ViewBottomMargin: CGFloat = 0
-  private var image1ViewLeadingMargin: CGFloat = 0
-
-  private var view1ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var view1ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var view1ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var view3ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var view3ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var view3ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var view4ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var view4ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var view5ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var view5ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var view5ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var view6ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var view6ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var rightAlignmentContainerViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var rightAlignmentContainerViewTopAnchorConstraint: NSLayoutConstraint?
-  private var rightAlignmentContainerViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var rightAlignmentContainerViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var imageViewTopAnchorConstraint: NSLayoutConstraint?
-  private var imageViewCenterXAnchorConstraint: NSLayoutConstraint?
-  private var view2ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var view2ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var view2ViewCenterXAnchorConstraint: NSLayoutConstraint?
-  private var view2ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var textViewTopAnchorConstraint: NSLayoutConstraint?
-  private var textViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var textViewCenterXAnchorConstraint: NSLayoutConstraint?
-  private var textViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var text1ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var text1ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var text1ViewCenterXAnchorConstraint: NSLayoutConstraint?
-  private var text1ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var text2ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var text2ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var text2ViewCenterXAnchorConstraint: NSLayoutConstraint?
-  private var text2ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var text3ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var text3ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var text3ViewCenterXAnchorConstraint: NSLayoutConstraint?
-  private var text3ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var text4ViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var text4ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var text4ViewCenterXAnchorConstraint: NSLayoutConstraint?
-  private var text5ViewWidthAnchorParentConstraint: NSLayoutConstraint?
-  private var text5ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var text5ViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var text5ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var text5ViewCenterXAnchorConstraint: NSLayoutConstraint?
-  private var text5ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var view4ViewWidthAnchorConstraint: NSLayoutConstraint?
-  private var text6ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var text6ViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var text6ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var text6ViewCenterXAnchorConstraint: NSLayoutConstraint?
-  private var text6ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var text7ViewWidthAnchorParentConstraint: NSLayoutConstraint?
-  private var text7ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var text7ViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var text7ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var text7ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var view6ViewWidthAnchorConstraint: NSLayoutConstraint?
-  private var text8ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var text8ViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var text8ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var text8ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var text9ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var text9ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var text9ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var text10ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var text10ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var text10ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var image1ViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var image1ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var image1ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var imageViewHeightAnchorConstraint: NSLayoutConstraint?
-  private var imageViewWidthAnchorConstraint: NSLayoutConstraint?
-  private var text4ViewWidthAnchorConstraint: NSLayoutConstraint?
-  private var image1ViewHeightAnchorConstraint: NSLayoutConstraint?
-  private var image1ViewWidthAnchorConstraint: NSLayoutConstraint?
-
   private func setUpViews() {
     textView.numberOfLines = 0
     text1View.numberOfLines = 0
@@ -326,251 +138,131 @@ public class TextAlignment: UIView {
     text10View.translatesAutoresizingMaskIntoConstraints = false
     image1View.translatesAutoresizingMaskIntoConstraints = false
 
-    let view1ViewTopAnchorConstraint = view1View
-      .topAnchor
-      .constraint(equalTo: topAnchor, constant: topPadding + view1ViewTopMargin)
-    let view1ViewLeadingAnchorConstraint = view1View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + view1ViewLeadingMargin)
-    let view1ViewTrailingAnchorConstraint = view1View
-      .trailingAnchor
-      .constraint(equalTo: trailingAnchor, constant: -(trailingPadding + view1ViewTrailingMargin))
-    let view3ViewTopAnchorConstraint = view3View
-      .topAnchor
-      .constraint(equalTo: view1View.bottomAnchor, constant: view1ViewBottomMargin + view3ViewTopMargin)
-    let view3ViewLeadingAnchorConstraint = view3View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + view3ViewLeadingMargin)
+    let view1ViewTopAnchorConstraint = view1View.topAnchor.constraint(equalTo: topAnchor, constant: 10)
+    let view1ViewLeadingAnchorConstraint = view1View.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10)
+    let view1ViewTrailingAnchorConstraint = view1View.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -10)
+    let view3ViewTopAnchorConstraint = view3View.topAnchor.constraint(equalTo: view1View.bottomAnchor)
+    let view3ViewLeadingAnchorConstraint = view3View.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10)
     let view3ViewTrailingAnchorConstraint = view3View
       .trailingAnchor
-      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -(trailingPadding + view3ViewTrailingMargin))
-    let view4ViewTopAnchorConstraint = view4View
-      .topAnchor
-      .constraint(equalTo: view3View.bottomAnchor, constant: view3ViewBottomMargin + view4ViewTopMargin)
-    let view4ViewLeadingAnchorConstraint = view4View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + view4ViewLeadingMargin)
-    let view5ViewTopAnchorConstraint = view5View
-      .topAnchor
-      .constraint(equalTo: view4View.bottomAnchor, constant: view4ViewBottomMargin + view5ViewTopMargin)
-    let view5ViewLeadingAnchorConstraint = view5View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + view5ViewLeadingMargin)
+      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -10)
+    let view4ViewTopAnchorConstraint = view4View.topAnchor.constraint(equalTo: view3View.bottomAnchor)
+    let view4ViewLeadingAnchorConstraint = view4View.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10)
+    let view5ViewTopAnchorConstraint = view5View.topAnchor.constraint(equalTo: view4View.bottomAnchor)
+    let view5ViewLeadingAnchorConstraint = view5View.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10)
     let view5ViewTrailingAnchorConstraint = view5View
       .trailingAnchor
-      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -(trailingPadding + view5ViewTrailingMargin))
-    let view6ViewTopAnchorConstraint = view6View
-      .topAnchor
-      .constraint(equalTo: view5View.bottomAnchor, constant: view5ViewBottomMargin + view6ViewTopMargin)
-    let view6ViewLeadingAnchorConstraint = view6View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + view6ViewLeadingMargin)
+      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -10)
+    let view6ViewTopAnchorConstraint = view6View.topAnchor.constraint(equalTo: view5View.bottomAnchor)
+    let view6ViewLeadingAnchorConstraint = view6View.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10)
     let rightAlignmentContainerViewBottomAnchorConstraint = rightAlignmentContainerView
       .bottomAnchor
-      .constraint(equalTo: bottomAnchor, constant: -(bottomPadding + rightAlignmentContainerViewBottomMargin))
+      .constraint(equalTo: bottomAnchor, constant: -10)
     let rightAlignmentContainerViewTopAnchorConstraint = rightAlignmentContainerView
       .topAnchor
-      .constraint(
-        equalTo: view6View.bottomAnchor,
-        constant: view6ViewBottomMargin + rightAlignmentContainerViewTopMargin)
+      .constraint(equalTo: view6View.bottomAnchor)
     let rightAlignmentContainerViewLeadingAnchorConstraint = rightAlignmentContainerView
       .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + rightAlignmentContainerViewLeadingMargin)
+      .constraint(equalTo: leadingAnchor, constant: 10)
     let rightAlignmentContainerViewTrailingAnchorConstraint = rightAlignmentContainerView
       .trailingAnchor
-      .constraint(equalTo: trailingAnchor, constant: -(trailingPadding + rightAlignmentContainerViewTrailingMargin))
-    let imageViewTopAnchorConstraint = imageView
-      .topAnchor
-      .constraint(equalTo: view1View.topAnchor, constant: view1ViewTopPadding + imageViewTopMargin)
-    let imageViewCenterXAnchorConstraint = imageView
-      .centerXAnchor
-      .constraint(equalTo: view1View.centerXAnchor, constant: 0)
-    let view2ViewTopAnchorConstraint = view2View
-      .topAnchor
-      .constraint(equalTo: imageView.bottomAnchor, constant: imageViewBottomMargin + view2ViewTopMargin)
+      .constraint(equalTo: trailingAnchor, constant: -10)
+    let imageViewTopAnchorConstraint = imageView.topAnchor.constraint(equalTo: view1View.topAnchor)
+    let imageViewCenterXAnchorConstraint = imageView.centerXAnchor.constraint(equalTo: view1View.centerXAnchor)
+    let view2ViewTopAnchorConstraint = view2View.topAnchor.constraint(equalTo: imageView.bottomAnchor)
     let view2ViewLeadingAnchorConstraint = view2View
       .leadingAnchor
-      .constraint(
-        greaterThanOrEqualTo: view1View.leadingAnchor,
-        constant: view1ViewLeadingPadding + view2ViewLeadingMargin)
-    let view2ViewCenterXAnchorConstraint = view2View
-      .centerXAnchor
-      .constraint(equalTo: view1View.centerXAnchor, constant: 0)
+      .constraint(greaterThanOrEqualTo: view1View.leadingAnchor)
+    let view2ViewCenterXAnchorConstraint = view2View.centerXAnchor.constraint(equalTo: view1View.centerXAnchor)
     let view2ViewTrailingAnchorConstraint = view2View
       .trailingAnchor
-      .constraint(
-        lessThanOrEqualTo: view1View.trailingAnchor,
-        constant: -(view1ViewTrailingPadding + view2ViewTrailingMargin))
-    let textViewTopAnchorConstraint = textView
-      .topAnchor
-      .constraint(equalTo: view2View.bottomAnchor, constant: view2ViewBottomMargin + textViewTopMargin)
-    let textViewLeadingAnchorConstraint = textView
-      .leadingAnchor
-      .constraint(equalTo: view1View.leadingAnchor, constant: view1ViewLeadingPadding + textViewLeadingMargin)
-    let textViewCenterXAnchorConstraint = textView
-      .centerXAnchor
-      .constraint(equalTo: view1View.centerXAnchor, constant: 0)
-    let textViewTrailingAnchorConstraint = textView
-      .trailingAnchor
-      .constraint(equalTo: view1View.trailingAnchor, constant: -(view1ViewTrailingPadding + textViewTrailingMargin))
-    let text1ViewTopAnchorConstraint = text1View
-      .topAnchor
-      .constraint(equalTo: textView.bottomAnchor, constant: textViewBottomMargin + text1ViewTopMargin)
+      .constraint(lessThanOrEqualTo: view1View.trailingAnchor)
+    let textViewTopAnchorConstraint = textView.topAnchor.constraint(equalTo: view2View.bottomAnchor)
+    let textViewLeadingAnchorConstraint = textView.leadingAnchor.constraint(equalTo: view1View.leadingAnchor)
+    let textViewCenterXAnchorConstraint = textView.centerXAnchor.constraint(equalTo: view1View.centerXAnchor)
+    let textViewTrailingAnchorConstraint = textView.trailingAnchor.constraint(equalTo: view1View.trailingAnchor)
+    let text1ViewTopAnchorConstraint = text1View.topAnchor.constraint(equalTo: textView.bottomAnchor, constant: 16)
     let text1ViewLeadingAnchorConstraint = text1View
       .leadingAnchor
-      .constraint(
-        greaterThanOrEqualTo: view1View.leadingAnchor,
-        constant: view1ViewLeadingPadding + text1ViewLeadingMargin)
-    let text1ViewCenterXAnchorConstraint = text1View
-      .centerXAnchor
-      .constraint(equalTo: view1View.centerXAnchor, constant: 0)
+      .constraint(greaterThanOrEqualTo: view1View.leadingAnchor)
+    let text1ViewCenterXAnchorConstraint = text1View.centerXAnchor.constraint(equalTo: view1View.centerXAnchor)
     let text1ViewTrailingAnchorConstraint = text1View
       .trailingAnchor
-      .constraint(
-        lessThanOrEqualTo: view1View.trailingAnchor,
-        constant: -(view1ViewTrailingPadding + text1ViewTrailingMargin))
-    let text2ViewTopAnchorConstraint = text2View
-      .topAnchor
-      .constraint(equalTo: text1View.bottomAnchor, constant: text1ViewBottomMargin + text2ViewTopMargin)
-    let text2ViewLeadingAnchorConstraint = text2View
-      .leadingAnchor
-      .constraint(equalTo: view1View.leadingAnchor, constant: view1ViewLeadingPadding + text2ViewLeadingMargin)
-    let text2ViewCenterXAnchorConstraint = text2View
-      .centerXAnchor
-      .constraint(equalTo: view1View.centerXAnchor, constant: 0)
-    let text2ViewTrailingAnchorConstraint = text2View
-      .trailingAnchor
-      .constraint(equalTo: view1View.trailingAnchor, constant: -(view1ViewTrailingPadding + text2ViewTrailingMargin))
-    let text3ViewTopAnchorConstraint = text3View
-      .topAnchor
-      .constraint(equalTo: text2View.bottomAnchor, constant: text2ViewBottomMargin + text3ViewTopMargin)
-    let text3ViewLeadingAnchorConstraint = text3View
-      .leadingAnchor
-      .constraint(equalTo: view1View.leadingAnchor, constant: view1ViewLeadingPadding + text3ViewLeadingMargin)
-    let text3ViewCenterXAnchorConstraint = text3View
-      .centerXAnchor
-      .constraint(equalTo: view1View.centerXAnchor, constant: 0)
-    let text3ViewTrailingAnchorConstraint = text3View
-      .trailingAnchor
-      .constraint(equalTo: view1View.trailingAnchor, constant: -(view1ViewTrailingPadding + text3ViewTrailingMargin))
-    let text4ViewBottomAnchorConstraint = text4View
-      .bottomAnchor
-      .constraint(equalTo: view1View.bottomAnchor, constant: -(view1ViewBottomPadding + text4ViewBottomMargin))
-    let text4ViewTopAnchorConstraint = text4View
-      .topAnchor
-      .constraint(equalTo: text3View.bottomAnchor, constant: text3ViewBottomMargin + text4ViewTopMargin)
-    let text4ViewCenterXAnchorConstraint = text4View
-      .centerXAnchor
-      .constraint(equalTo: view1View.centerXAnchor, constant: 0)
+      .constraint(lessThanOrEqualTo: view1View.trailingAnchor)
+    let text2ViewTopAnchorConstraint = text2View.topAnchor.constraint(equalTo: text1View.bottomAnchor, constant: 16)
+    let text2ViewLeadingAnchorConstraint = text2View.leadingAnchor.constraint(equalTo: view1View.leadingAnchor)
+    let text2ViewCenterXAnchorConstraint = text2View.centerXAnchor.constraint(equalTo: view1View.centerXAnchor)
+    let text2ViewTrailingAnchorConstraint = text2View.trailingAnchor.constraint(equalTo: view1View.trailingAnchor)
+    let text3ViewTopAnchorConstraint = text3View.topAnchor.constraint(equalTo: text2View.bottomAnchor, constant: 12)
+    let text3ViewLeadingAnchorConstraint = text3View.leadingAnchor.constraint(equalTo: view1View.leadingAnchor)
+    let text3ViewCenterXAnchorConstraint = text3View.centerXAnchor.constraint(equalTo: view1View.centerXAnchor)
+    let text3ViewTrailingAnchorConstraint = text3View.trailingAnchor.constraint(equalTo: view1View.trailingAnchor)
+    let text4ViewBottomAnchorConstraint = text4View.bottomAnchor.constraint(equalTo: view1View.bottomAnchor)
+    let text4ViewTopAnchorConstraint = text4View.topAnchor.constraint(equalTo: text3View.bottomAnchor)
+    let text4ViewCenterXAnchorConstraint = text4View.centerXAnchor.constraint(equalTo: view1View.centerXAnchor)
     let text5ViewWidthAnchorParentConstraint = text5View
       .widthAnchor
-      .constraint(
-        lessThanOrEqualTo: view3View.widthAnchor,
-        constant:
-        -(view3ViewLeadingPadding + text5ViewLeadingMargin + view3ViewTrailingPadding + text5ViewTrailingMargin))
-    let text5ViewTopAnchorConstraint = text5View
-      .topAnchor
-      .constraint(equalTo: view3View.topAnchor, constant: view3ViewTopPadding + text5ViewTopMargin)
-    let text5ViewBottomAnchorConstraint = text5View
-      .bottomAnchor
-      .constraint(equalTo: view3View.bottomAnchor, constant: -(view3ViewBottomPadding + text5ViewBottomMargin))
+      .constraint(lessThanOrEqualTo: view3View.widthAnchor, constant: -(12 + 12))
+    let text5ViewTopAnchorConstraint = text5View.topAnchor.constraint(equalTo: view3View.topAnchor)
+    let text5ViewBottomAnchorConstraint = text5View.bottomAnchor.constraint(equalTo: view3View.bottomAnchor)
     let text5ViewLeadingAnchorConstraint = text5View
       .leadingAnchor
-      .constraint(equalTo: view3View.leadingAnchor, constant: view3ViewLeadingPadding + text5ViewLeadingMargin)
-    let text5ViewCenterXAnchorConstraint = text5View
-      .centerXAnchor
-      .constraint(equalTo: view3View.centerXAnchor, constant: 0)
+      .constraint(equalTo: view3View.leadingAnchor, constant: 12)
+    let text5ViewCenterXAnchorConstraint = text5View.centerXAnchor.constraint(equalTo: view3View.centerXAnchor)
     let text5ViewTrailingAnchorConstraint = text5View
       .trailingAnchor
-      .constraint(equalTo: view3View.trailingAnchor, constant: -(view3ViewTrailingPadding + text5ViewTrailingMargin))
+      .constraint(equalTo: view3View.trailingAnchor, constant: -12)
     let view4ViewWidthAnchorConstraint = view4View.widthAnchor.constraint(equalToConstant: 400)
-    let text6ViewTopAnchorConstraint = text6View
-      .topAnchor
-      .constraint(equalTo: view4View.topAnchor, constant: view4ViewTopPadding + text6ViewTopMargin)
-    let text6ViewBottomAnchorConstraint = text6View
-      .bottomAnchor
-      .constraint(equalTo: view4View.bottomAnchor, constant: -(view4ViewBottomPadding + text6ViewBottomMargin))
+    let text6ViewTopAnchorConstraint = text6View.topAnchor.constraint(equalTo: view4View.topAnchor)
+    let text6ViewBottomAnchorConstraint = text6View.bottomAnchor.constraint(equalTo: view4View.bottomAnchor)
     let text6ViewLeadingAnchorConstraint = text6View
       .leadingAnchor
-      .constraint(equalTo: view4View.leadingAnchor, constant: view4ViewLeadingPadding + text6ViewLeadingMargin)
-    let text6ViewCenterXAnchorConstraint = text6View
-      .centerXAnchor
-      .constraint(equalTo: view4View.centerXAnchor, constant: 0)
+      .constraint(equalTo: view4View.leadingAnchor, constant: 12)
+    let text6ViewCenterXAnchorConstraint = text6View.centerXAnchor.constraint(equalTo: view4View.centerXAnchor)
     let text6ViewTrailingAnchorConstraint = text6View
       .trailingAnchor
-      .constraint(equalTo: view4View.trailingAnchor, constant: -(view4ViewTrailingPadding + text6ViewTrailingMargin))
+      .constraint(equalTo: view4View.trailingAnchor, constant: -12)
     let text7ViewWidthAnchorParentConstraint = text7View
       .widthAnchor
-      .constraint(
-        lessThanOrEqualTo: view5View.widthAnchor,
-        constant:
-        -(view5ViewLeadingPadding + text7ViewLeadingMargin + view5ViewTrailingPadding + text7ViewTrailingMargin))
-    let text7ViewTopAnchorConstraint = text7View
-      .topAnchor
-      .constraint(equalTo: view5View.topAnchor, constant: view5ViewTopPadding + text7ViewTopMargin)
-    let text7ViewBottomAnchorConstraint = text7View
-      .bottomAnchor
-      .constraint(equalTo: view5View.bottomAnchor, constant: -(view5ViewBottomPadding + text7ViewBottomMargin))
+      .constraint(lessThanOrEqualTo: view5View.widthAnchor, constant: -(12 + 12))
+    let text7ViewTopAnchorConstraint = text7View.topAnchor.constraint(equalTo: view5View.topAnchor)
+    let text7ViewBottomAnchorConstraint = text7View.bottomAnchor.constraint(equalTo: view5View.bottomAnchor)
     let text7ViewLeadingAnchorConstraint = text7View
       .leadingAnchor
-      .constraint(equalTo: view5View.leadingAnchor, constant: view5ViewLeadingPadding + text7ViewLeadingMargin)
+      .constraint(equalTo: view5View.leadingAnchor, constant: 12)
     let text7ViewTrailingAnchorConstraint = text7View
       .trailingAnchor
-      .constraint(equalTo: view5View.trailingAnchor, constant: -(view5ViewTrailingPadding + text7ViewTrailingMargin))
+      .constraint(equalTo: view5View.trailingAnchor, constant: -12)
     let view6ViewWidthAnchorConstraint = view6View.widthAnchor.constraint(equalToConstant: 400)
-    let text8ViewTopAnchorConstraint = text8View
-      .topAnchor
-      .constraint(equalTo: view6View.topAnchor, constant: view6ViewTopPadding + text8ViewTopMargin)
-    let text8ViewBottomAnchorConstraint = text8View
-      .bottomAnchor
-      .constraint(equalTo: view6View.bottomAnchor, constant: -(view6ViewBottomPadding + text8ViewBottomMargin))
+    let text8ViewTopAnchorConstraint = text8View.topAnchor.constraint(equalTo: view6View.topAnchor)
+    let text8ViewBottomAnchorConstraint = text8View.bottomAnchor.constraint(equalTo: view6View.bottomAnchor)
     let text8ViewLeadingAnchorConstraint = text8View
       .leadingAnchor
-      .constraint(equalTo: view6View.leadingAnchor, constant: view6ViewLeadingPadding + text8ViewLeadingMargin)
+      .constraint(equalTo: view6View.leadingAnchor, constant: 12)
     let text8ViewTrailingAnchorConstraint = text8View
       .trailingAnchor
-      .constraint(equalTo: view6View.trailingAnchor, constant: -(view6ViewTrailingPadding + text8ViewTrailingMargin))
-    let text9ViewTopAnchorConstraint = text9View
-      .topAnchor
-      .constraint(
-        equalTo: rightAlignmentContainerView.topAnchor,
-        constant: rightAlignmentContainerViewTopPadding + text9ViewTopMargin)
+      .constraint(equalTo: view6View.trailingAnchor, constant: -12)
+    let text9ViewTopAnchorConstraint = text9View.topAnchor.constraint(equalTo: rightAlignmentContainerView.topAnchor)
     let text9ViewLeadingAnchorConstraint = text9View
       .leadingAnchor
-      .constraint(
-        greaterThanOrEqualTo: rightAlignmentContainerView.leadingAnchor,
-        constant: rightAlignmentContainerViewLeadingPadding + text9ViewLeadingMargin)
+      .constraint(greaterThanOrEqualTo: rightAlignmentContainerView.leadingAnchor)
     let text9ViewTrailingAnchorConstraint = text9View
       .trailingAnchor
-      .constraint(
-        equalTo: rightAlignmentContainerView.trailingAnchor,
-        constant: -(rightAlignmentContainerViewTrailingPadding + text9ViewTrailingMargin))
-    let text10ViewTopAnchorConstraint = text10View
-      .topAnchor
-      .constraint(equalTo: text9View.bottomAnchor, constant: text9ViewBottomMargin + text10ViewTopMargin)
+      .constraint(equalTo: rightAlignmentContainerView.trailingAnchor)
+    let text10ViewTopAnchorConstraint = text10View.topAnchor.constraint(equalTo: text9View.bottomAnchor)
     let text10ViewLeadingAnchorConstraint = text10View
       .leadingAnchor
-      .constraint(
-        equalTo: rightAlignmentContainerView.leadingAnchor,
-        constant: rightAlignmentContainerViewLeadingPadding + text10ViewLeadingMargin)
+      .constraint(equalTo: rightAlignmentContainerView.leadingAnchor)
     let text10ViewTrailingAnchorConstraint = text10View
       .trailingAnchor
-      .constraint(
-        equalTo: rightAlignmentContainerView.trailingAnchor,
-        constant: -(rightAlignmentContainerViewTrailingPadding + text10ViewTrailingMargin))
+      .constraint(equalTo: rightAlignmentContainerView.trailingAnchor)
     let image1ViewBottomAnchorConstraint = image1View
       .bottomAnchor
-      .constraint(
-        equalTo: rightAlignmentContainerView.bottomAnchor,
-        constant: -(rightAlignmentContainerViewBottomPadding + image1ViewBottomMargin))
-    let image1ViewTopAnchorConstraint = image1View
-      .topAnchor
-      .constraint(equalTo: text10View.bottomAnchor, constant: text10ViewBottomMargin + image1ViewTopMargin)
+      .constraint(equalTo: rightAlignmentContainerView.bottomAnchor)
+    let image1ViewTopAnchorConstraint = image1View.topAnchor.constraint(equalTo: text10View.bottomAnchor)
     let image1ViewTrailingAnchorConstraint = image1View
       .trailingAnchor
-      .constraint(
-        equalTo: rightAlignmentContainerView.trailingAnchor,
-        constant: -(rightAlignmentContainerViewTrailingPadding + image1ViewTrailingMargin))
+      .constraint(equalTo: rightAlignmentContainerView.trailingAnchor)
     let imageViewHeightAnchorConstraint = imageView.heightAnchor.constraint(equalToConstant: 100)
     let imageViewWidthAnchorConstraint = imageView.widthAnchor.constraint(equalToConstant: 100)
     let text4ViewWidthAnchorConstraint = text4View.widthAnchor.constraint(equalToConstant: 80)
@@ -660,166 +352,6 @@ public class TextAlignment: UIView {
       image1ViewHeightAnchorConstraint,
       image1ViewWidthAnchorConstraint
     ])
-
-    self.view1ViewTopAnchorConstraint = view1ViewTopAnchorConstraint
-    self.view1ViewLeadingAnchorConstraint = view1ViewLeadingAnchorConstraint
-    self.view1ViewTrailingAnchorConstraint = view1ViewTrailingAnchorConstraint
-    self.view3ViewTopAnchorConstraint = view3ViewTopAnchorConstraint
-    self.view3ViewLeadingAnchorConstraint = view3ViewLeadingAnchorConstraint
-    self.view3ViewTrailingAnchorConstraint = view3ViewTrailingAnchorConstraint
-    self.view4ViewTopAnchorConstraint = view4ViewTopAnchorConstraint
-    self.view4ViewLeadingAnchorConstraint = view4ViewLeadingAnchorConstraint
-    self.view5ViewTopAnchorConstraint = view5ViewTopAnchorConstraint
-    self.view5ViewLeadingAnchorConstraint = view5ViewLeadingAnchorConstraint
-    self.view5ViewTrailingAnchorConstraint = view5ViewTrailingAnchorConstraint
-    self.view6ViewTopAnchorConstraint = view6ViewTopAnchorConstraint
-    self.view6ViewLeadingAnchorConstraint = view6ViewLeadingAnchorConstraint
-    self.rightAlignmentContainerViewBottomAnchorConstraint = rightAlignmentContainerViewBottomAnchorConstraint
-    self.rightAlignmentContainerViewTopAnchorConstraint = rightAlignmentContainerViewTopAnchorConstraint
-    self.rightAlignmentContainerViewLeadingAnchorConstraint = rightAlignmentContainerViewLeadingAnchorConstraint
-    self.rightAlignmentContainerViewTrailingAnchorConstraint = rightAlignmentContainerViewTrailingAnchorConstraint
-    self.imageViewTopAnchorConstraint = imageViewTopAnchorConstraint
-    self.imageViewCenterXAnchorConstraint = imageViewCenterXAnchorConstraint
-    self.view2ViewTopAnchorConstraint = view2ViewTopAnchorConstraint
-    self.view2ViewLeadingAnchorConstraint = view2ViewLeadingAnchorConstraint
-    self.view2ViewCenterXAnchorConstraint = view2ViewCenterXAnchorConstraint
-    self.view2ViewTrailingAnchorConstraint = view2ViewTrailingAnchorConstraint
-    self.textViewTopAnchorConstraint = textViewTopAnchorConstraint
-    self.textViewLeadingAnchorConstraint = textViewLeadingAnchorConstraint
-    self.textViewCenterXAnchorConstraint = textViewCenterXAnchorConstraint
-    self.textViewTrailingAnchorConstraint = textViewTrailingAnchorConstraint
-    self.text1ViewTopAnchorConstraint = text1ViewTopAnchorConstraint
-    self.text1ViewLeadingAnchorConstraint = text1ViewLeadingAnchorConstraint
-    self.text1ViewCenterXAnchorConstraint = text1ViewCenterXAnchorConstraint
-    self.text1ViewTrailingAnchorConstraint = text1ViewTrailingAnchorConstraint
-    self.text2ViewTopAnchorConstraint = text2ViewTopAnchorConstraint
-    self.text2ViewLeadingAnchorConstraint = text2ViewLeadingAnchorConstraint
-    self.text2ViewCenterXAnchorConstraint = text2ViewCenterXAnchorConstraint
-    self.text2ViewTrailingAnchorConstraint = text2ViewTrailingAnchorConstraint
-    self.text3ViewTopAnchorConstraint = text3ViewTopAnchorConstraint
-    self.text3ViewLeadingAnchorConstraint = text3ViewLeadingAnchorConstraint
-    self.text3ViewCenterXAnchorConstraint = text3ViewCenterXAnchorConstraint
-    self.text3ViewTrailingAnchorConstraint = text3ViewTrailingAnchorConstraint
-    self.text4ViewBottomAnchorConstraint = text4ViewBottomAnchorConstraint
-    self.text4ViewTopAnchorConstraint = text4ViewTopAnchorConstraint
-    self.text4ViewCenterXAnchorConstraint = text4ViewCenterXAnchorConstraint
-    self.text5ViewWidthAnchorParentConstraint = text5ViewWidthAnchorParentConstraint
-    self.text5ViewTopAnchorConstraint = text5ViewTopAnchorConstraint
-    self.text5ViewBottomAnchorConstraint = text5ViewBottomAnchorConstraint
-    self.text5ViewLeadingAnchorConstraint = text5ViewLeadingAnchorConstraint
-    self.text5ViewCenterXAnchorConstraint = text5ViewCenterXAnchorConstraint
-    self.text5ViewTrailingAnchorConstraint = text5ViewTrailingAnchorConstraint
-    self.view4ViewWidthAnchorConstraint = view4ViewWidthAnchorConstraint
-    self.text6ViewTopAnchorConstraint = text6ViewTopAnchorConstraint
-    self.text6ViewBottomAnchorConstraint = text6ViewBottomAnchorConstraint
-    self.text6ViewLeadingAnchorConstraint = text6ViewLeadingAnchorConstraint
-    self.text6ViewCenterXAnchorConstraint = text6ViewCenterXAnchorConstraint
-    self.text6ViewTrailingAnchorConstraint = text6ViewTrailingAnchorConstraint
-    self.text7ViewWidthAnchorParentConstraint = text7ViewWidthAnchorParentConstraint
-    self.text7ViewTopAnchorConstraint = text7ViewTopAnchorConstraint
-    self.text7ViewBottomAnchorConstraint = text7ViewBottomAnchorConstraint
-    self.text7ViewLeadingAnchorConstraint = text7ViewLeadingAnchorConstraint
-    self.text7ViewTrailingAnchorConstraint = text7ViewTrailingAnchorConstraint
-    self.view6ViewWidthAnchorConstraint = view6ViewWidthAnchorConstraint
-    self.text8ViewTopAnchorConstraint = text8ViewTopAnchorConstraint
-    self.text8ViewBottomAnchorConstraint = text8ViewBottomAnchorConstraint
-    self.text8ViewLeadingAnchorConstraint = text8ViewLeadingAnchorConstraint
-    self.text8ViewTrailingAnchorConstraint = text8ViewTrailingAnchorConstraint
-    self.text9ViewTopAnchorConstraint = text9ViewTopAnchorConstraint
-    self.text9ViewLeadingAnchorConstraint = text9ViewLeadingAnchorConstraint
-    self.text9ViewTrailingAnchorConstraint = text9ViewTrailingAnchorConstraint
-    self.text10ViewTopAnchorConstraint = text10ViewTopAnchorConstraint
-    self.text10ViewLeadingAnchorConstraint = text10ViewLeadingAnchorConstraint
-    self.text10ViewTrailingAnchorConstraint = text10ViewTrailingAnchorConstraint
-    self.image1ViewBottomAnchorConstraint = image1ViewBottomAnchorConstraint
-    self.image1ViewTopAnchorConstraint = image1ViewTopAnchorConstraint
-    self.image1ViewTrailingAnchorConstraint = image1ViewTrailingAnchorConstraint
-    self.imageViewHeightAnchorConstraint = imageViewHeightAnchorConstraint
-    self.imageViewWidthAnchorConstraint = imageViewWidthAnchorConstraint
-    self.text4ViewWidthAnchorConstraint = text4ViewWidthAnchorConstraint
-    self.image1ViewHeightAnchorConstraint = image1ViewHeightAnchorConstraint
-    self.image1ViewWidthAnchorConstraint = image1ViewWidthAnchorConstraint
-
-    // For debugging
-    view1ViewTopAnchorConstraint.identifier = "view1ViewTopAnchorConstraint"
-    view1ViewLeadingAnchorConstraint.identifier = "view1ViewLeadingAnchorConstraint"
-    view1ViewTrailingAnchorConstraint.identifier = "view1ViewTrailingAnchorConstraint"
-    view3ViewTopAnchorConstraint.identifier = "view3ViewTopAnchorConstraint"
-    view3ViewLeadingAnchorConstraint.identifier = "view3ViewLeadingAnchorConstraint"
-    view3ViewTrailingAnchorConstraint.identifier = "view3ViewTrailingAnchorConstraint"
-    view4ViewTopAnchorConstraint.identifier = "view4ViewTopAnchorConstraint"
-    view4ViewLeadingAnchorConstraint.identifier = "view4ViewLeadingAnchorConstraint"
-    view5ViewTopAnchorConstraint.identifier = "view5ViewTopAnchorConstraint"
-    view5ViewLeadingAnchorConstraint.identifier = "view5ViewLeadingAnchorConstraint"
-    view5ViewTrailingAnchorConstraint.identifier = "view5ViewTrailingAnchorConstraint"
-    view6ViewTopAnchorConstraint.identifier = "view6ViewTopAnchorConstraint"
-    view6ViewLeadingAnchorConstraint.identifier = "view6ViewLeadingAnchorConstraint"
-    rightAlignmentContainerViewBottomAnchorConstraint.identifier = "rightAlignmentContainerViewBottomAnchorConstraint"
-    rightAlignmentContainerViewTopAnchorConstraint.identifier = "rightAlignmentContainerViewTopAnchorConstraint"
-    rightAlignmentContainerViewLeadingAnchorConstraint.identifier = "rightAlignmentContainerViewLeadingAnchorConstraint"
-    rightAlignmentContainerViewTrailingAnchorConstraint.identifier =
-      "rightAlignmentContainerViewTrailingAnchorConstraint"
-    imageViewTopAnchorConstraint.identifier = "imageViewTopAnchorConstraint"
-    imageViewCenterXAnchorConstraint.identifier = "imageViewCenterXAnchorConstraint"
-    view2ViewTopAnchorConstraint.identifier = "view2ViewTopAnchorConstraint"
-    view2ViewLeadingAnchorConstraint.identifier = "view2ViewLeadingAnchorConstraint"
-    view2ViewCenterXAnchorConstraint.identifier = "view2ViewCenterXAnchorConstraint"
-    view2ViewTrailingAnchorConstraint.identifier = "view2ViewTrailingAnchorConstraint"
-    textViewTopAnchorConstraint.identifier = "textViewTopAnchorConstraint"
-    textViewLeadingAnchorConstraint.identifier = "textViewLeadingAnchorConstraint"
-    textViewCenterXAnchorConstraint.identifier = "textViewCenterXAnchorConstraint"
-    textViewTrailingAnchorConstraint.identifier = "textViewTrailingAnchorConstraint"
-    text1ViewTopAnchorConstraint.identifier = "text1ViewTopAnchorConstraint"
-    text1ViewLeadingAnchorConstraint.identifier = "text1ViewLeadingAnchorConstraint"
-    text1ViewCenterXAnchorConstraint.identifier = "text1ViewCenterXAnchorConstraint"
-    text1ViewTrailingAnchorConstraint.identifier = "text1ViewTrailingAnchorConstraint"
-    text2ViewTopAnchorConstraint.identifier = "text2ViewTopAnchorConstraint"
-    text2ViewLeadingAnchorConstraint.identifier = "text2ViewLeadingAnchorConstraint"
-    text2ViewCenterXAnchorConstraint.identifier = "text2ViewCenterXAnchorConstraint"
-    text2ViewTrailingAnchorConstraint.identifier = "text2ViewTrailingAnchorConstraint"
-    text3ViewTopAnchorConstraint.identifier = "text3ViewTopAnchorConstraint"
-    text3ViewLeadingAnchorConstraint.identifier = "text3ViewLeadingAnchorConstraint"
-    text3ViewCenterXAnchorConstraint.identifier = "text3ViewCenterXAnchorConstraint"
-    text3ViewTrailingAnchorConstraint.identifier = "text3ViewTrailingAnchorConstraint"
-    text4ViewBottomAnchorConstraint.identifier = "text4ViewBottomAnchorConstraint"
-    text4ViewTopAnchorConstraint.identifier = "text4ViewTopAnchorConstraint"
-    text4ViewCenterXAnchorConstraint.identifier = "text4ViewCenterXAnchorConstraint"
-    text5ViewWidthAnchorParentConstraint.identifier = "text5ViewWidthAnchorParentConstraint"
-    text5ViewTopAnchorConstraint.identifier = "text5ViewTopAnchorConstraint"
-    text5ViewBottomAnchorConstraint.identifier = "text5ViewBottomAnchorConstraint"
-    text5ViewLeadingAnchorConstraint.identifier = "text5ViewLeadingAnchorConstraint"
-    text5ViewCenterXAnchorConstraint.identifier = "text5ViewCenterXAnchorConstraint"
-    text5ViewTrailingAnchorConstraint.identifier = "text5ViewTrailingAnchorConstraint"
-    view4ViewWidthAnchorConstraint.identifier = "view4ViewWidthAnchorConstraint"
-    text6ViewTopAnchorConstraint.identifier = "text6ViewTopAnchorConstraint"
-    text6ViewBottomAnchorConstraint.identifier = "text6ViewBottomAnchorConstraint"
-    text6ViewLeadingAnchorConstraint.identifier = "text6ViewLeadingAnchorConstraint"
-    text6ViewCenterXAnchorConstraint.identifier = "text6ViewCenterXAnchorConstraint"
-    text6ViewTrailingAnchorConstraint.identifier = "text6ViewTrailingAnchorConstraint"
-    text7ViewWidthAnchorParentConstraint.identifier = "text7ViewWidthAnchorParentConstraint"
-    text7ViewTopAnchorConstraint.identifier = "text7ViewTopAnchorConstraint"
-    text7ViewBottomAnchorConstraint.identifier = "text7ViewBottomAnchorConstraint"
-    text7ViewLeadingAnchorConstraint.identifier = "text7ViewLeadingAnchorConstraint"
-    text7ViewTrailingAnchorConstraint.identifier = "text7ViewTrailingAnchorConstraint"
-    view6ViewWidthAnchorConstraint.identifier = "view6ViewWidthAnchorConstraint"
-    text8ViewTopAnchorConstraint.identifier = "text8ViewTopAnchorConstraint"
-    text8ViewBottomAnchorConstraint.identifier = "text8ViewBottomAnchorConstraint"
-    text8ViewLeadingAnchorConstraint.identifier = "text8ViewLeadingAnchorConstraint"
-    text8ViewTrailingAnchorConstraint.identifier = "text8ViewTrailingAnchorConstraint"
-    text9ViewTopAnchorConstraint.identifier = "text9ViewTopAnchorConstraint"
-    text9ViewLeadingAnchorConstraint.identifier = "text9ViewLeadingAnchorConstraint"
-    text9ViewTrailingAnchorConstraint.identifier = "text9ViewTrailingAnchorConstraint"
-    text10ViewTopAnchorConstraint.identifier = "text10ViewTopAnchorConstraint"
-    text10ViewLeadingAnchorConstraint.identifier = "text10ViewLeadingAnchorConstraint"
-    text10ViewTrailingAnchorConstraint.identifier = "text10ViewTrailingAnchorConstraint"
-    image1ViewBottomAnchorConstraint.identifier = "image1ViewBottomAnchorConstraint"
-    image1ViewTopAnchorConstraint.identifier = "image1ViewTopAnchorConstraint"
-    image1ViewTrailingAnchorConstraint.identifier = "image1ViewTrailingAnchorConstraint"
-    imageViewHeightAnchorConstraint.identifier = "imageViewHeightAnchorConstraint"
-    imageViewWidthAnchorConstraint.identifier = "imageViewWidthAnchorConstraint"
-    text4ViewWidthAnchorConstraint.identifier = "text4ViewWidthAnchorConstraint"
-    image1ViewHeightAnchorConstraint.identifier = "image1ViewHeightAnchorConstraint"
-    image1ViewWidthAnchorConstraint.identifier = "image1ViewWidthAnchorConstraint"
   }
 
   private func update() {}

--- a/examples/generated/test/swift/style/TextAlignment.swift
+++ b/examples/generated/test/swift/style/TextAlignment.swift
@@ -177,7 +177,7 @@ public class TextAlignment: UIView {
     let view2ViewTrailingAnchorConstraint = view2View
       .trailingAnchor
       .constraint(lessThanOrEqualTo: view1View.trailingAnchor)
-    let textViewTopAnchorConstraint = textView.topAnchor.constraint(equalTo: view2View.bottomAnchor)
+    let textViewTopAnchorConstraint = textView.topAnchor.constraint(equalTo: view2View.bottomAnchor, constant: 16)
     let textViewLeadingAnchorConstraint = textView.leadingAnchor.constraint(equalTo: view1View.leadingAnchor)
     let textViewCenterXAnchorConstraint = textView.centerXAnchor.constraint(equalTo: view1View.centerXAnchor)
     let textViewTrailingAnchorConstraint = textView.trailingAnchor.constraint(equalTo: view1View.trailingAnchor)
@@ -189,11 +189,11 @@ public class TextAlignment: UIView {
     let text1ViewTrailingAnchorConstraint = text1View
       .trailingAnchor
       .constraint(lessThanOrEqualTo: view1View.trailingAnchor)
-    let text2ViewTopAnchorConstraint = text2View.topAnchor.constraint(equalTo: text1View.bottomAnchor, constant: 16)
+    let text2ViewTopAnchorConstraint = text2View.topAnchor.constraint(equalTo: text1View.bottomAnchor, constant: 12)
     let text2ViewLeadingAnchorConstraint = text2View.leadingAnchor.constraint(equalTo: view1View.leadingAnchor)
     let text2ViewCenterXAnchorConstraint = text2View.centerXAnchor.constraint(equalTo: view1View.centerXAnchor)
     let text2ViewTrailingAnchorConstraint = text2View.trailingAnchor.constraint(equalTo: view1View.trailingAnchor)
-    let text3ViewTopAnchorConstraint = text3View.topAnchor.constraint(equalTo: text2View.bottomAnchor, constant: 12)
+    let text3ViewTopAnchorConstraint = text3View.topAnchor.constraint(equalTo: text2View.bottomAnchor)
     let text3ViewLeadingAnchorConstraint = text3View.leadingAnchor.constraint(equalTo: view1View.leadingAnchor)
     let text3ViewCenterXAnchorConstraint = text3View.centerXAnchor.constraint(equalTo: view1View.centerXAnchor)
     let text3ViewTrailingAnchorConstraint = text3View.trailingAnchor.constraint(equalTo: view1View.trailingAnchor)
@@ -202,7 +202,7 @@ public class TextAlignment: UIView {
     let text4ViewCenterXAnchorConstraint = text4View.centerXAnchor.constraint(equalTo: view1View.centerXAnchor)
     let text5ViewWidthAnchorParentConstraint = text5View
       .widthAnchor
-      .constraint(lessThanOrEqualTo: view3View.widthAnchor, constant: -(12 + 12))
+      .constraint(lessThanOrEqualTo: view3View.widthAnchor, constant: -24)
     let text5ViewTopAnchorConstraint = text5View.topAnchor.constraint(equalTo: view3View.topAnchor)
     let text5ViewBottomAnchorConstraint = text5View.bottomAnchor.constraint(equalTo: view3View.bottomAnchor)
     let text5ViewLeadingAnchorConstraint = text5View
@@ -224,7 +224,7 @@ public class TextAlignment: UIView {
       .constraint(equalTo: view4View.trailingAnchor, constant: -12)
     let text7ViewWidthAnchorParentConstraint = text7View
       .widthAnchor
-      .constraint(lessThanOrEqualTo: view5View.widthAnchor, constant: -(12 + 12))
+      .constraint(lessThanOrEqualTo: view5View.widthAnchor, constant: -24)
     let text7ViewTopAnchorConstraint = text7View.topAnchor.constraint(equalTo: view5View.topAnchor)
     let text7ViewBottomAnchorConstraint = text7View.bottomAnchor.constraint(equalTo: view5View.bottomAnchor)
     let text7ViewLeadingAnchorConstraint = text7View

--- a/examples/generated/test/swift/style/TextStyleConditional.swift
+++ b/examples/generated/test/swift/style/TextStyleConditional.swift
@@ -36,20 +36,6 @@ public class TextStyleConditional: UIView {
 
   private var textViewTextStyle = TextStyles.headline
 
-  private var topPadding: CGFloat = 0
-  private var trailingPadding: CGFloat = 0
-  private var bottomPadding: CGFloat = 0
-  private var leadingPadding: CGFloat = 0
-  private var textViewTopMargin: CGFloat = 0
-  private var textViewTrailingMargin: CGFloat = 0
-  private var textViewBottomMargin: CGFloat = 0
-  private var textViewLeadingMargin: CGFloat = 0
-
-  private var textViewTopAnchorConstraint: NSLayoutConstraint?
-  private var textViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var textViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var textViewTrailingAnchorConstraint: NSLayoutConstraint?
-
   private func setUpViews() {
     textView.numberOfLines = 0
 
@@ -62,18 +48,10 @@ public class TextStyleConditional: UIView {
     translatesAutoresizingMaskIntoConstraints = false
     textView.translatesAutoresizingMaskIntoConstraints = false
 
-    let textViewTopAnchorConstraint = textView
-      .topAnchor
-      .constraint(equalTo: topAnchor, constant: topPadding + textViewTopMargin)
-    let textViewBottomAnchorConstraint = textView
-      .bottomAnchor
-      .constraint(equalTo: bottomAnchor, constant: -(bottomPadding + textViewBottomMargin))
-    let textViewLeadingAnchorConstraint = textView
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + textViewLeadingMargin)
-    let textViewTrailingAnchorConstraint = textView
-      .trailingAnchor
-      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -(trailingPadding + textViewTrailingMargin))
+    let textViewTopAnchorConstraint = textView.topAnchor.constraint(equalTo: topAnchor)
+    let textViewBottomAnchorConstraint = textView.bottomAnchor.constraint(equalTo: bottomAnchor)
+    let textViewLeadingAnchorConstraint = textView.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let textViewTrailingAnchorConstraint = textView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor)
 
     NSLayoutConstraint.activate([
       textViewTopAnchorConstraint,
@@ -81,17 +59,6 @@ public class TextStyleConditional: UIView {
       textViewLeadingAnchorConstraint,
       textViewTrailingAnchorConstraint
     ])
-
-    self.textViewTopAnchorConstraint = textViewTopAnchorConstraint
-    self.textViewBottomAnchorConstraint = textViewBottomAnchorConstraint
-    self.textViewLeadingAnchorConstraint = textViewLeadingAnchorConstraint
-    self.textViewTrailingAnchorConstraint = textViewTrailingAnchorConstraint
-
-    // For debugging
-    textViewTopAnchorConstraint.identifier = "textViewTopAnchorConstraint"
-    textViewBottomAnchorConstraint.identifier = "textViewBottomAnchorConstraint"
-    textViewLeadingAnchorConstraint.identifier = "textViewLeadingAnchorConstraint"
-    textViewTrailingAnchorConstraint.identifier = "textViewTrailingAnchorConstraint"
   }
 
   private func update() {

--- a/examples/generated/test/swift/style/TextStylesTest.swift
+++ b/examples/generated/test/swift/style/TextStylesTest.swift
@@ -44,83 +44,6 @@ public class TextStylesTest: UIView {
   private var text8ViewTextStyle = TextStyles.body1
   private var text9ViewTextStyle = TextStyles.caption
 
-  private var topPadding: CGFloat = 0
-  private var trailingPadding: CGFloat = 0
-  private var bottomPadding: CGFloat = 0
-  private var leadingPadding: CGFloat = 0
-  private var textViewTopMargin: CGFloat = 0
-  private var textViewTrailingMargin: CGFloat = 0
-  private var textViewBottomMargin: CGFloat = 0
-  private var textViewLeadingMargin: CGFloat = 0
-  private var text1ViewTopMargin: CGFloat = 0
-  private var text1ViewTrailingMargin: CGFloat = 0
-  private var text1ViewBottomMargin: CGFloat = 0
-  private var text1ViewLeadingMargin: CGFloat = 0
-  private var text2ViewTopMargin: CGFloat = 0
-  private var text2ViewTrailingMargin: CGFloat = 0
-  private var text2ViewBottomMargin: CGFloat = 0
-  private var text2ViewLeadingMargin: CGFloat = 0
-  private var text3ViewTopMargin: CGFloat = 0
-  private var text3ViewTrailingMargin: CGFloat = 0
-  private var text3ViewBottomMargin: CGFloat = 0
-  private var text3ViewLeadingMargin: CGFloat = 0
-  private var text4ViewTopMargin: CGFloat = 0
-  private var text4ViewTrailingMargin: CGFloat = 0
-  private var text4ViewBottomMargin: CGFloat = 0
-  private var text4ViewLeadingMargin: CGFloat = 0
-  private var text5ViewTopMargin: CGFloat = 0
-  private var text5ViewTrailingMargin: CGFloat = 0
-  private var text5ViewBottomMargin: CGFloat = 0
-  private var text5ViewLeadingMargin: CGFloat = 0
-  private var text6ViewTopMargin: CGFloat = 0
-  private var text6ViewTrailingMargin: CGFloat = 0
-  private var text6ViewBottomMargin: CGFloat = 0
-  private var text6ViewLeadingMargin: CGFloat = 0
-  private var text7ViewTopMargin: CGFloat = 0
-  private var text7ViewTrailingMargin: CGFloat = 0
-  private var text7ViewBottomMargin: CGFloat = 0
-  private var text7ViewLeadingMargin: CGFloat = 0
-  private var text8ViewTopMargin: CGFloat = 0
-  private var text8ViewTrailingMargin: CGFloat = 0
-  private var text8ViewBottomMargin: CGFloat = 0
-  private var text8ViewLeadingMargin: CGFloat = 0
-  private var text9ViewTopMargin: CGFloat = 0
-  private var text9ViewTrailingMargin: CGFloat = 0
-  private var text9ViewBottomMargin: CGFloat = 0
-  private var text9ViewLeadingMargin: CGFloat = 0
-
-  private var textViewTopAnchorConstraint: NSLayoutConstraint?
-  private var textViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var textViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var text1ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var text1ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var text1ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var text2ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var text2ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var text2ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var text3ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var text3ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var text3ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var text4ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var text4ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var text4ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var text5ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var text5ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var text5ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var text6ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var text6ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var text6ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var text7ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var text7ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var text7ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var text8ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var text8ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var text8ViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var text9ViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var text9ViewTopAnchorConstraint: NSLayoutConstraint?
-  private var text9ViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var text9ViewTrailingAnchorConstraint: NSLayoutConstraint?
-
   private func setUpViews() {
     textView.numberOfLines = 0
     text1View.numberOfLines = 0
@@ -189,99 +112,37 @@ public class TextStylesTest: UIView {
     text8View.translatesAutoresizingMaskIntoConstraints = false
     text9View.translatesAutoresizingMaskIntoConstraints = false
 
-    let textViewTopAnchorConstraint = textView
-      .topAnchor
-      .constraint(equalTo: topAnchor, constant: topPadding + textViewTopMargin)
-    let textViewLeadingAnchorConstraint = textView
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + textViewLeadingMargin)
-    let textViewTrailingAnchorConstraint = textView
-      .trailingAnchor
-      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -(trailingPadding + textViewTrailingMargin))
-    let text1ViewTopAnchorConstraint = text1View
-      .topAnchor
-      .constraint(equalTo: textView.bottomAnchor, constant: textViewBottomMargin + text1ViewTopMargin)
-    let text1ViewLeadingAnchorConstraint = text1View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + text1ViewLeadingMargin)
-    let text1ViewTrailingAnchorConstraint = text1View
-      .trailingAnchor
-      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -(trailingPadding + text1ViewTrailingMargin))
-    let text2ViewTopAnchorConstraint = text2View
-      .topAnchor
-      .constraint(equalTo: text1View.bottomAnchor, constant: text1ViewBottomMargin + text2ViewTopMargin)
-    let text2ViewLeadingAnchorConstraint = text2View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + text2ViewLeadingMargin)
-    let text2ViewTrailingAnchorConstraint = text2View
-      .trailingAnchor
-      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -(trailingPadding + text2ViewTrailingMargin))
-    let text3ViewTopAnchorConstraint = text3View
-      .topAnchor
-      .constraint(equalTo: text2View.bottomAnchor, constant: text2ViewBottomMargin + text3ViewTopMargin)
-    let text3ViewLeadingAnchorConstraint = text3View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + text3ViewLeadingMargin)
-    let text3ViewTrailingAnchorConstraint = text3View
-      .trailingAnchor
-      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -(trailingPadding + text3ViewTrailingMargin))
-    let text4ViewTopAnchorConstraint = text4View
-      .topAnchor
-      .constraint(equalTo: text3View.bottomAnchor, constant: text3ViewBottomMargin + text4ViewTopMargin)
-    let text4ViewLeadingAnchorConstraint = text4View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + text4ViewLeadingMargin)
-    let text4ViewTrailingAnchorConstraint = text4View
-      .trailingAnchor
-      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -(trailingPadding + text4ViewTrailingMargin))
-    let text5ViewTopAnchorConstraint = text5View
-      .topAnchor
-      .constraint(equalTo: text4View.bottomAnchor, constant: text4ViewBottomMargin + text5ViewTopMargin)
-    let text5ViewLeadingAnchorConstraint = text5View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + text5ViewLeadingMargin)
-    let text5ViewTrailingAnchorConstraint = text5View
-      .trailingAnchor
-      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -(trailingPadding + text5ViewTrailingMargin))
-    let text6ViewTopAnchorConstraint = text6View
-      .topAnchor
-      .constraint(equalTo: text5View.bottomAnchor, constant: text5ViewBottomMargin + text6ViewTopMargin)
-    let text6ViewLeadingAnchorConstraint = text6View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + text6ViewLeadingMargin)
-    let text6ViewTrailingAnchorConstraint = text6View
-      .trailingAnchor
-      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -(trailingPadding + text6ViewTrailingMargin))
-    let text7ViewTopAnchorConstraint = text7View
-      .topAnchor
-      .constraint(equalTo: text6View.bottomAnchor, constant: text6ViewBottomMargin + text7ViewTopMargin)
-    let text7ViewLeadingAnchorConstraint = text7View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + text7ViewLeadingMargin)
-    let text7ViewTrailingAnchorConstraint = text7View
-      .trailingAnchor
-      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -(trailingPadding + text7ViewTrailingMargin))
-    let text8ViewTopAnchorConstraint = text8View
-      .topAnchor
-      .constraint(equalTo: text7View.bottomAnchor, constant: text7ViewBottomMargin + text8ViewTopMargin)
-    let text8ViewLeadingAnchorConstraint = text8View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + text8ViewLeadingMargin)
-    let text8ViewTrailingAnchorConstraint = text8View
-      .trailingAnchor
-      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -(trailingPadding + text8ViewTrailingMargin))
-    let text9ViewBottomAnchorConstraint = text9View
-      .bottomAnchor
-      .constraint(equalTo: bottomAnchor, constant: -(bottomPadding + text9ViewBottomMargin))
-    let text9ViewTopAnchorConstraint = text9View
-      .topAnchor
-      .constraint(equalTo: text8View.bottomAnchor, constant: text8ViewBottomMargin + text9ViewTopMargin)
-    let text9ViewLeadingAnchorConstraint = text9View
-      .leadingAnchor
-      .constraint(equalTo: leadingAnchor, constant: leadingPadding + text9ViewLeadingMargin)
-    let text9ViewTrailingAnchorConstraint = text9View
-      .trailingAnchor
-      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -(trailingPadding + text9ViewTrailingMargin))
+    let textViewTopAnchorConstraint = textView.topAnchor.constraint(equalTo: topAnchor)
+    let textViewLeadingAnchorConstraint = textView.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let textViewTrailingAnchorConstraint = textView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor)
+    let text1ViewTopAnchorConstraint = text1View.topAnchor.constraint(equalTo: textView.bottomAnchor)
+    let text1ViewLeadingAnchorConstraint = text1View.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let text1ViewTrailingAnchorConstraint = text1View.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor)
+    let text2ViewTopAnchorConstraint = text2View.topAnchor.constraint(equalTo: text1View.bottomAnchor)
+    let text2ViewLeadingAnchorConstraint = text2View.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let text2ViewTrailingAnchorConstraint = text2View.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor)
+    let text3ViewTopAnchorConstraint = text3View.topAnchor.constraint(equalTo: text2View.bottomAnchor)
+    let text3ViewLeadingAnchorConstraint = text3View.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let text3ViewTrailingAnchorConstraint = text3View.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor)
+    let text4ViewTopAnchorConstraint = text4View.topAnchor.constraint(equalTo: text3View.bottomAnchor)
+    let text4ViewLeadingAnchorConstraint = text4View.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let text4ViewTrailingAnchorConstraint = text4View.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor)
+    let text5ViewTopAnchorConstraint = text5View.topAnchor.constraint(equalTo: text4View.bottomAnchor)
+    let text5ViewLeadingAnchorConstraint = text5View.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let text5ViewTrailingAnchorConstraint = text5View.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor)
+    let text6ViewTopAnchorConstraint = text6View.topAnchor.constraint(equalTo: text5View.bottomAnchor)
+    let text6ViewLeadingAnchorConstraint = text6View.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let text6ViewTrailingAnchorConstraint = text6View.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor)
+    let text7ViewTopAnchorConstraint = text7View.topAnchor.constraint(equalTo: text6View.bottomAnchor)
+    let text7ViewLeadingAnchorConstraint = text7View.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let text7ViewTrailingAnchorConstraint = text7View.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor)
+    let text8ViewTopAnchorConstraint = text8View.topAnchor.constraint(equalTo: text7View.bottomAnchor)
+    let text8ViewLeadingAnchorConstraint = text8View.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let text8ViewTrailingAnchorConstraint = text8View.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor)
+    let text9ViewBottomAnchorConstraint = text9View.bottomAnchor.constraint(equalTo: bottomAnchor)
+    let text9ViewTopAnchorConstraint = text9View.topAnchor.constraint(equalTo: text8View.bottomAnchor)
+    let text9ViewLeadingAnchorConstraint = text9View.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let text9ViewTrailingAnchorConstraint = text9View.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor)
 
     NSLayoutConstraint.activate([
       textViewTopAnchorConstraint,
@@ -316,71 +177,6 @@ public class TextStylesTest: UIView {
       text9ViewLeadingAnchorConstraint,
       text9ViewTrailingAnchorConstraint
     ])
-
-    self.textViewTopAnchorConstraint = textViewTopAnchorConstraint
-    self.textViewLeadingAnchorConstraint = textViewLeadingAnchorConstraint
-    self.textViewTrailingAnchorConstraint = textViewTrailingAnchorConstraint
-    self.text1ViewTopAnchorConstraint = text1ViewTopAnchorConstraint
-    self.text1ViewLeadingAnchorConstraint = text1ViewLeadingAnchorConstraint
-    self.text1ViewTrailingAnchorConstraint = text1ViewTrailingAnchorConstraint
-    self.text2ViewTopAnchorConstraint = text2ViewTopAnchorConstraint
-    self.text2ViewLeadingAnchorConstraint = text2ViewLeadingAnchorConstraint
-    self.text2ViewTrailingAnchorConstraint = text2ViewTrailingAnchorConstraint
-    self.text3ViewTopAnchorConstraint = text3ViewTopAnchorConstraint
-    self.text3ViewLeadingAnchorConstraint = text3ViewLeadingAnchorConstraint
-    self.text3ViewTrailingAnchorConstraint = text3ViewTrailingAnchorConstraint
-    self.text4ViewTopAnchorConstraint = text4ViewTopAnchorConstraint
-    self.text4ViewLeadingAnchorConstraint = text4ViewLeadingAnchorConstraint
-    self.text4ViewTrailingAnchorConstraint = text4ViewTrailingAnchorConstraint
-    self.text5ViewTopAnchorConstraint = text5ViewTopAnchorConstraint
-    self.text5ViewLeadingAnchorConstraint = text5ViewLeadingAnchorConstraint
-    self.text5ViewTrailingAnchorConstraint = text5ViewTrailingAnchorConstraint
-    self.text6ViewTopAnchorConstraint = text6ViewTopAnchorConstraint
-    self.text6ViewLeadingAnchorConstraint = text6ViewLeadingAnchorConstraint
-    self.text6ViewTrailingAnchorConstraint = text6ViewTrailingAnchorConstraint
-    self.text7ViewTopAnchorConstraint = text7ViewTopAnchorConstraint
-    self.text7ViewLeadingAnchorConstraint = text7ViewLeadingAnchorConstraint
-    self.text7ViewTrailingAnchorConstraint = text7ViewTrailingAnchorConstraint
-    self.text8ViewTopAnchorConstraint = text8ViewTopAnchorConstraint
-    self.text8ViewLeadingAnchorConstraint = text8ViewLeadingAnchorConstraint
-    self.text8ViewTrailingAnchorConstraint = text8ViewTrailingAnchorConstraint
-    self.text9ViewBottomAnchorConstraint = text9ViewBottomAnchorConstraint
-    self.text9ViewTopAnchorConstraint = text9ViewTopAnchorConstraint
-    self.text9ViewLeadingAnchorConstraint = text9ViewLeadingAnchorConstraint
-    self.text9ViewTrailingAnchorConstraint = text9ViewTrailingAnchorConstraint
-
-    // For debugging
-    textViewTopAnchorConstraint.identifier = "textViewTopAnchorConstraint"
-    textViewLeadingAnchorConstraint.identifier = "textViewLeadingAnchorConstraint"
-    textViewTrailingAnchorConstraint.identifier = "textViewTrailingAnchorConstraint"
-    text1ViewTopAnchorConstraint.identifier = "text1ViewTopAnchorConstraint"
-    text1ViewLeadingAnchorConstraint.identifier = "text1ViewLeadingAnchorConstraint"
-    text1ViewTrailingAnchorConstraint.identifier = "text1ViewTrailingAnchorConstraint"
-    text2ViewTopAnchorConstraint.identifier = "text2ViewTopAnchorConstraint"
-    text2ViewLeadingAnchorConstraint.identifier = "text2ViewLeadingAnchorConstraint"
-    text2ViewTrailingAnchorConstraint.identifier = "text2ViewTrailingAnchorConstraint"
-    text3ViewTopAnchorConstraint.identifier = "text3ViewTopAnchorConstraint"
-    text3ViewLeadingAnchorConstraint.identifier = "text3ViewLeadingAnchorConstraint"
-    text3ViewTrailingAnchorConstraint.identifier = "text3ViewTrailingAnchorConstraint"
-    text4ViewTopAnchorConstraint.identifier = "text4ViewTopAnchorConstraint"
-    text4ViewLeadingAnchorConstraint.identifier = "text4ViewLeadingAnchorConstraint"
-    text4ViewTrailingAnchorConstraint.identifier = "text4ViewTrailingAnchorConstraint"
-    text5ViewTopAnchorConstraint.identifier = "text5ViewTopAnchorConstraint"
-    text5ViewLeadingAnchorConstraint.identifier = "text5ViewLeadingAnchorConstraint"
-    text5ViewTrailingAnchorConstraint.identifier = "text5ViewTrailingAnchorConstraint"
-    text6ViewTopAnchorConstraint.identifier = "text6ViewTopAnchorConstraint"
-    text6ViewLeadingAnchorConstraint.identifier = "text6ViewLeadingAnchorConstraint"
-    text6ViewTrailingAnchorConstraint.identifier = "text6ViewTrailingAnchorConstraint"
-    text7ViewTopAnchorConstraint.identifier = "text7ViewTopAnchorConstraint"
-    text7ViewLeadingAnchorConstraint.identifier = "text7ViewLeadingAnchorConstraint"
-    text7ViewTrailingAnchorConstraint.identifier = "text7ViewTrailingAnchorConstraint"
-    text8ViewTopAnchorConstraint.identifier = "text8ViewTopAnchorConstraint"
-    text8ViewLeadingAnchorConstraint.identifier = "text8ViewLeadingAnchorConstraint"
-    text8ViewTrailingAnchorConstraint.identifier = "text8ViewTrailingAnchorConstraint"
-    text9ViewBottomAnchorConstraint.identifier = "text9ViewBottomAnchorConstraint"
-    text9ViewTopAnchorConstraint.identifier = "text9ViewTopAnchorConstraint"
-    text9ViewLeadingAnchorConstraint.identifier = "text9ViewLeadingAnchorConstraint"
-    text9ViewTrailingAnchorConstraint.identifier = "text9ViewTrailingAnchorConstraint"
   }
 
   private func update() {}

--- a/examples/test/style/BoxModelConditional.component
+++ b/examples/test/style/BoxModelConditional.component
@@ -1,0 +1,145 @@
+{
+  "devices" : [
+    {
+      "height" : 100,
+      "heightMode" : "At Least",
+      "name" : "iPhone SE",
+      "width" : 320
+    },
+    {
+      "height" : 100,
+      "heightMode" : "At Least",
+      "name" : "iPhone 7",
+      "width" : 375
+    },
+    {
+      "height" : 100,
+      "heightMode" : "At Least",
+      "name" : "iPhone 7+",
+      "width" : 414
+    }
+  ],
+  "examples" : [
+    {
+      "id" : "Default",
+      "name" : "Default",
+      "params" : {
+        "size" : 60
+      }
+    },
+    {
+      "id" : "name",
+      "name" : "name",
+      "params" : {
+        "margin" : 20,
+        "size" : 120
+      }
+    }
+  ],
+  "logic" : [
+    {
+      "assignee" : [
+        "layers",
+        "Inner",
+        "marginTop"
+      ],
+      "content" : [
+        "parameters",
+        "margin"
+      ],
+      "type" : "AssignExpr"
+    },
+    {
+      "assignee" : [
+        "layers",
+        "Inner",
+        "marginRight"
+      ],
+      "content" : [
+        "parameters",
+        "margin"
+      ],
+      "type" : "AssignExpr"
+    },
+    {
+      "assignee" : [
+        "layers",
+        "Inner",
+        "marginBottom"
+      ],
+      "content" : [
+        "parameters",
+        "margin"
+      ],
+      "type" : "AssignExpr"
+    },
+    {
+      "assignee" : [
+        "layers",
+        "Inner",
+        "marginLeft"
+      ],
+      "content" : [
+        "parameters",
+        "margin"
+      ],
+      "type" : "AssignExpr"
+    },
+    {
+      "assignee" : [
+        "layers",
+        "Inner",
+        "height"
+      ],
+      "content" : [
+        "parameters",
+        "size"
+      ],
+      "type" : "AssignExpr"
+    },
+    {
+      "assignee" : [
+        "layers",
+        "Inner",
+        "width"
+      ],
+      "content" : [
+        "parameters",
+        "size"
+      ],
+      "type" : "AssignExpr"
+    }
+  ],
+  "params" : [
+    {
+      "name" : "margin",
+      "type" : "Number"
+    },
+    {
+      "name" : "size",
+      "type" : "Number"
+    }
+  ],
+  "root" : {
+    "children" : [
+      {
+        "id" : "Inner",
+        "params" : {
+          "backgroundColor" : "#D8D8D8",
+          "height" : 60,
+          "width" : 60
+        },
+        "type" : "Lona:View"
+      }
+    ],
+    "id" : "Outer",
+    "params" : {
+      "alignSelf" : "stretch",
+      "paddingBottom" : 4,
+      "paddingLeft" : 4,
+      "paddingRight" : 4,
+      "paddingTop" : 4
+    },
+    "type" : "Lona:View"
+  }
+}


### PR DESCRIPTION
## What

- Margin & padding values are now inlined when set as constraint constants
- Constraints are only stored as member variables if they can be modified in `update`
- A new test case `BoxModelConditional` highlights how margins & padding can't be modified in `update` yet. This wasn't implemented before either, but now prints a TODO in the generated code.

## Why

Clearer Swift code.

## Testing Plan

- [X] Tested this change locally
- [X] Checked that existing features work

cc @outdooricon 