### PR TITLE
Add Column Flex Direction as default

### DIFF
--- a/compiler/core/src/javaScript/javaScriptStyles.re
+++ b/compiler/core/src/javaScript/javaScriptStyles.re
@@ -66,6 +66,7 @@ let addDefaultStyles =
         empty
         |> add(ParameterKey.Display, LonaValue.string("flex"))
         |> add(ParameterKey.FlexDirection, LonaValue.string("column"))
+        |> add(ParameterKey.AlignItems, LonaValue.string("stretch"))
       )
     | _ => ParameterMap.empty
     },

--- a/compiler/core/src/javaScript/javaScriptStyles.re
+++ b/compiler/core/src/javaScript/javaScriptStyles.re
@@ -60,16 +60,16 @@ let addDefaultStyles =
     layer.parameters
     |> ParameterMap.filter((key, _) => Layer.parameterIsStyle(key));
   ParameterMap.assign(
-    styleParams,
     switch (framework) {
     | JavaScriptOptions.ReactDOM =>
-      ParameterMap.add(
-        ParameterKey.Display,
-        LonaValue.string("flex"),
-        ParameterMap.empty,
+      ParameterMap.(
+        empty
+        |> add(ParameterKey.Display, LonaValue.string("flex"))
+        |> add(ParameterKey.FlexDirection, LonaValue.string("column"))
       )
     | _ => ParameterMap.empty
     },
+    styleParams,
   );
 };
 

--- a/examples/generated/test/react-dom/components/ComponentParameterInstance.js
+++ b/examples/generated/test/react-dom/components/ComponentParameterInstance.js
@@ -29,6 +29,15 @@ export default class ComponentParameterInstance extends React.Component {
 };
 
 let styles = {
-  view: { alignSelf: "stretch", display: "flex", flexDirection: "column" },
-  componentParameterTemplate: { display: "flex", flexDirection: "column" }
+  view: {
+    alignItems: "stretch",
+    alignSelf: "stretch",
+    display: "flex",
+    flexDirection: "column"
+  },
+  componentParameterTemplate: {
+    alignItems: "stretch",
+    display: "flex",
+    flexDirection: "column"
+  }
 }

--- a/examples/generated/test/react-dom/components/ComponentParameterInstance.js
+++ b/examples/generated/test/react-dom/components/ComponentParameterInstance.js
@@ -29,6 +29,6 @@ export default class ComponentParameterInstance extends React.Component {
 };
 
 let styles = {
-  view: { alignSelf: "stretch", display: "flex" },
-  componentParameterTemplate: { display: "flex" }
+  view: { alignSelf: "stretch", display: "flex", flexDirection: "column" },
+  componentParameterTemplate: { display: "flex", flexDirection: "column" }
 }

--- a/examples/generated/test/react-dom/components/NestedButtons.js
+++ b/examples/generated/test/react-dom/components/NestedButtons.js
@@ -35,12 +35,18 @@ let styles = {
   view: {
     alignSelf: "stretch",
     display: "flex",
+    flexDirection: "column",
     paddingTop: "24px",
     paddingRight: "24px",
     paddingBottom: "24px",
     paddingLeft: "24px"
   },
-  button: { display: "flex" },
-  view1: { alignSelf: "stretch", display: "flex", height: "8px" },
-  button2: { display: "flex" }
+  button: { display: "flex", flexDirection: "column" },
+  view1: {
+    alignSelf: "stretch",
+    display: "flex",
+    flexDirection: "column",
+    height: "8px"
+  },
+  button2: { display: "flex", flexDirection: "column" }
 }

--- a/examples/generated/test/react-dom/components/NestedButtons.js
+++ b/examples/generated/test/react-dom/components/NestedButtons.js
@@ -33,6 +33,7 @@ export default class NestedButtons extends React.Component {
 
 let styles = {
   view: {
+    alignItems: "stretch",
     alignSelf: "stretch",
     display: "flex",
     flexDirection: "column",
@@ -41,12 +42,13 @@ let styles = {
     paddingBottom: "24px",
     paddingLeft: "24px"
   },
-  button: { display: "flex", flexDirection: "column" },
+  button: { alignItems: "stretch", display: "flex", flexDirection: "column" },
   view1: {
+    alignItems: "stretch",
     alignSelf: "stretch",
     display: "flex",
     flexDirection: "column",
     height: "8px"
   },
-  button2: { display: "flex", flexDirection: "column" }
+  button2: { alignItems: "stretch", display: "flex", flexDirection: "column" }
 }

--- a/examples/generated/test/react-dom/components/NestedComponent.js
+++ b/examples/generated/test/react-dom/components/NestedComponent.js
@@ -44,6 +44,7 @@ export default class NestedComponent extends React.Component {
 
 let styles = {
   view: {
+    alignItems: "stretch",
     alignSelf: "stretch",
     display: "flex",
     flexDirection: "column",
@@ -54,15 +55,26 @@ let styles = {
   },
   text: {
     ...textStyles.subheading2,
+    alignItems: "stretch",
     display: "flex",
     flexDirection: "column",
     marginBottom: "8px"
   },
   fitContentParentSecondaryChildren: {
+    alignItems: "stretch",
     display: "flex",
     flexDirection: "column"
   },
-  text1: { display: "flex", flexDirection: "column", marginTop: "12px" },
-  localAsset: { display: "flex", flexDirection: "column" },
-  text2: { display: "flex", flexDirection: "column" }
+  text1: {
+    alignItems: "stretch",
+    display: "flex",
+    flexDirection: "column",
+    marginTop: "12px"
+  },
+  localAsset: {
+    alignItems: "stretch",
+    display: "flex",
+    flexDirection: "column"
+  },
+  text2: { alignItems: "stretch", display: "flex", flexDirection: "column" }
 }

--- a/examples/generated/test/react-dom/components/NestedComponent.js
+++ b/examples/generated/test/react-dom/components/NestedComponent.js
@@ -46,14 +46,23 @@ let styles = {
   view: {
     alignSelf: "stretch",
     display: "flex",
+    flexDirection: "column",
     paddingTop: "10px",
     paddingRight: "10px",
     paddingBottom: "10px",
     paddingLeft: "10px"
   },
-  text: { ...textStyles.subheading2, display: "flex", marginBottom: "8px" },
-  fitContentParentSecondaryChildren: { display: "flex" },
-  text1: { display: "flex", marginTop: "12px" },
-  localAsset: { display: "flex" },
-  text2: { display: "flex" }
+  text: {
+    ...textStyles.subheading2,
+    display: "flex",
+    flexDirection: "column",
+    marginBottom: "8px"
+  },
+  fitContentParentSecondaryChildren: {
+    display: "flex",
+    flexDirection: "column"
+  },
+  text1: { display: "flex", flexDirection: "column", marginTop: "12px" },
+  localAsset: { display: "flex", flexDirection: "column" },
+  text2: { display: "flex", flexDirection: "column" }
 }

--- a/examples/generated/test/react-dom/images/LocalAsset.js
+++ b/examples/generated/test/react-dom/images/LocalAsset.js
@@ -24,8 +24,14 @@ export default class LocalAsset extends React.Component {
 };
 
 let styles = {
-  view: { alignSelf: "stretch", display: "flex", flexDirection: "column" },
+  view: {
+    alignItems: "stretch",
+    alignSelf: "stretch",
+    display: "flex",
+    flexDirection: "column"
+  },
   image: {
+    alignItems: "stretch",
     backgroundColor: "#D8D8D8",
     display: "flex",
     flexDirection: "column",

--- a/examples/generated/test/react-dom/images/LocalAsset.js
+++ b/examples/generated/test/react-dom/images/LocalAsset.js
@@ -24,10 +24,11 @@ export default class LocalAsset extends React.Component {
 };
 
 let styles = {
-  view: { alignSelf: "stretch", display: "flex" },
+  view: { alignSelf: "stretch", display: "flex", flexDirection: "column" },
   image: {
     backgroundColor: "#D8D8D8",
     display: "flex",
+    flexDirection: "column",
     width: "100px",
     height: "100px"
   }

--- a/examples/generated/test/react-dom/interactivity/Button.js
+++ b/examples/generated/test/react-dom/interactivity/Button.js
@@ -47,10 +47,11 @@ let styles = {
   view: {
     backgroundColor: colors.blue100,
     display: "flex",
+    flexDirection: "column",
     paddingTop: "12px",
     paddingRight: "16px",
     paddingBottom: "12px",
     paddingLeft: "16px"
   },
-  text: { ...textStyles.button, display: "flex" }
+  text: { ...textStyles.button, display: "flex", flexDirection: "column" }
 }

--- a/examples/generated/test/react-dom/interactivity/Button.js
+++ b/examples/generated/test/react-dom/interactivity/Button.js
@@ -45,6 +45,7 @@ export default class Button extends React.Component {
 
 let styles = {
   view: {
+    alignItems: "stretch",
     backgroundColor: colors.blue100,
     display: "flex",
     flexDirection: "column",
@@ -53,5 +54,10 @@ let styles = {
     paddingBottom: "12px",
     paddingLeft: "16px"
   },
-  text: { ...textStyles.button, display: "flex", flexDirection: "column" }
+  text: {
+    ...textStyles.button,
+    alignItems: "stretch",
+    display: "flex",
+    flexDirection: "column"
+  }
 }

--- a/examples/generated/test/react-dom/interactivity/PressableRootView.js
+++ b/examples/generated/test/react-dom/interactivity/PressableRootView.js
@@ -75,6 +75,7 @@ let styles = {
     alignSelf: "stretch",
     backgroundColor: colors.grey50,
     display: "flex",
+    flexDirection: "column",
     paddingTop: "24px",
     paddingRight: "24px",
     paddingBottom: "24px",
@@ -83,8 +84,13 @@ let styles = {
   inner: {
     backgroundColor: colors.blue500,
     display: "flex",
+    flexDirection: "column",
     width: "100px",
     height: "100px"
   },
-  innerText: { ...textStyles.headline, display: "flex" }
+  innerText: {
+    ...textStyles.headline,
+    display: "flex",
+    flexDirection: "column"
+  }
 }

--- a/examples/generated/test/react-dom/interactivity/PressableRootView.js
+++ b/examples/generated/test/react-dom/interactivity/PressableRootView.js
@@ -72,6 +72,7 @@ export default class PressableRootView extends React.Component {
 
 let styles = {
   outer: {
+    alignItems: "stretch",
     alignSelf: "stretch",
     backgroundColor: colors.grey50,
     display: "flex",
@@ -82,6 +83,7 @@ let styles = {
     paddingLeft: "24px"
   },
   inner: {
+    alignItems: "stretch",
     backgroundColor: colors.blue500,
     display: "flex",
     flexDirection: "column",
@@ -90,6 +92,7 @@ let styles = {
   },
   innerText: {
     ...textStyles.headline,
+    alignItems: "stretch",
     display: "flex",
     flexDirection: "column"
   }

--- a/examples/generated/test/react-dom/layouts/FitContentParentSecondaryChildren.js
+++ b/examples/generated/test/react-dom/layouts/FitContentParentSecondaryChildren.js
@@ -40,18 +40,21 @@ let styles = {
   view1: {
     backgroundColor: colors.blue500,
     display: "flex",
+    flexDirection: "column",
     width: "60px",
     height: "60px"
   },
   view3: {
     backgroundColor: colors.lightblue500,
     display: "flex",
+    flexDirection: "column",
     width: "100px",
     height: "120px"
   },
   view2: {
     backgroundColor: colors.cyan500,
     display: "flex",
+    flexDirection: "column",
     width: "100px",
     height: "180px"
   }

--- a/examples/generated/test/react-dom/layouts/FitContentParentSecondaryChildren.js
+++ b/examples/generated/test/react-dom/layouts/FitContentParentSecondaryChildren.js
@@ -28,6 +28,7 @@ export default class FitContentParentSecondaryChildren extends React.Component {
 
 let styles = {
   container: {
+    alignItems: "stretch",
     alignSelf: "stretch",
     backgroundColor: colors.bluegrey50,
     display: "flex",
@@ -38,6 +39,7 @@ let styles = {
     paddingLeft: "24px"
   },
   view1: {
+    alignItems: "stretch",
     backgroundColor: colors.blue500,
     display: "flex",
     flexDirection: "column",
@@ -45,6 +47,7 @@ let styles = {
     height: "60px"
   },
   view3: {
+    alignItems: "stretch",
     backgroundColor: colors.lightblue500,
     display: "flex",
     flexDirection: "column",
@@ -52,6 +55,7 @@ let styles = {
     height: "120px"
   },
   view2: {
+    alignItems: "stretch",
     backgroundColor: colors.cyan500,
     display: "flex",
     flexDirection: "column",

--- a/examples/generated/test/react-dom/layouts/FixedParentFillAndFitChildren.js
+++ b/examples/generated/test/react-dom/layouts/FixedParentFillAndFitChildren.js
@@ -33,6 +33,7 @@ export default class FixedParentFillAndFitChildren extends React.Component {
 
 let styles = {
   view: {
+    alignItems: "stretch",
     alignSelf: "stretch",
     display: "flex",
     flexDirection: "column",
@@ -43,6 +44,7 @@ let styles = {
     height: "600px"
   },
   view1: {
+    alignItems: "stretch",
     alignSelf: "stretch",
     backgroundColor: colors.red50,
     display: "flex",
@@ -53,6 +55,7 @@ let styles = {
     paddingLeft: "24px"
   },
   view4: {
+    alignItems: "stretch",
     backgroundColor: colors.red200,
     display: "flex",
     flexDirection: "column",
@@ -60,6 +63,7 @@ let styles = {
     height: "100px"
   },
   view5: {
+    alignItems: "stretch",
     backgroundColor: colors.deeporange200,
     display: "flex",
     flexDirection: "column",
@@ -68,6 +72,7 @@ let styles = {
     height: "60px"
   },
   view2: {
+    alignItems: "stretch",
     alignSelf: "stretch",
     backgroundColor: colors.indigo100,
     display: "flex",
@@ -75,6 +80,7 @@ let styles = {
     flexDirection: "column"
   },
   view3: {
+    alignItems: "stretch",
     alignSelf: "stretch",
     backgroundColor: colors.teal100,
     display: "flex",

--- a/examples/generated/test/react-dom/layouts/FixedParentFillAndFitChildren.js
+++ b/examples/generated/test/react-dom/layouts/FixedParentFillAndFitChildren.js
@@ -35,6 +35,7 @@ let styles = {
   view: {
     alignSelf: "stretch",
     display: "flex",
+    flexDirection: "column",
     paddingTop: "24px",
     paddingRight: "24px",
     paddingBottom: "24px",
@@ -54,12 +55,14 @@ let styles = {
   view4: {
     backgroundColor: colors.red200,
     display: "flex",
+    flexDirection: "column",
     width: "60px",
     height: "100px"
   },
   view5: {
     backgroundColor: colors.deeporange200,
     display: "flex",
+    flexDirection: "column",
     marginLeft: "12px",
     width: "60px",
     height: "60px"
@@ -68,12 +71,14 @@ let styles = {
     alignSelf: "stretch",
     backgroundColor: colors.indigo100,
     display: "flex",
-    flex: 1
+    flex: 1,
+    flexDirection: "column"
   },
   view3: {
     alignSelf: "stretch",
     backgroundColor: colors.teal100,
     display: "flex",
-    flex: 1
+    flex: 1,
+    flexDirection: "column"
   }
 }

--- a/examples/generated/test/react-dom/layouts/FixedParentFitChild.js
+++ b/examples/generated/test/react-dom/layouts/FixedParentFitChild.js
@@ -32,6 +32,7 @@ let styles = {
     alignSelf: "stretch",
     backgroundColor: colors.bluegrey100,
     display: "flex",
+    flexDirection: "column",
     paddingTop: "24px",
     paddingRight: "24px",
     paddingBottom: "24px",
@@ -51,12 +52,14 @@ let styles = {
   view4: {
     backgroundColor: colors.red200,
     display: "flex",
+    flexDirection: "column",
     width: "60px",
     height: "100px"
   },
   view5: {
     backgroundColor: colors.deeporange200,
     display: "flex",
+    flexDirection: "column",
     marginLeft: "12px",
     width: "60px",
     height: "60px"

--- a/examples/generated/test/react-dom/layouts/FixedParentFitChild.js
+++ b/examples/generated/test/react-dom/layouts/FixedParentFitChild.js
@@ -29,6 +29,7 @@ export default class FixedParentFitChild extends React.Component {
 
 let styles = {
   view: {
+    alignItems: "stretch",
     alignSelf: "stretch",
     backgroundColor: colors.bluegrey100,
     display: "flex",
@@ -40,6 +41,7 @@ let styles = {
     height: "600px"
   },
   view1: {
+    alignItems: "stretch",
     alignSelf: "stretch",
     backgroundColor: colors.red50,
     display: "flex",
@@ -50,6 +52,7 @@ let styles = {
     paddingLeft: "24px"
   },
   view4: {
+    alignItems: "stretch",
     backgroundColor: colors.red200,
     display: "flex",
     flexDirection: "column",
@@ -57,6 +60,7 @@ let styles = {
     height: "100px"
   },
   view5: {
+    alignItems: "stretch",
     backgroundColor: colors.deeporange200,
     display: "flex",
     flexDirection: "column",

--- a/examples/generated/test/react-dom/layouts/PrimaryAxis.js
+++ b/examples/generated/test/react-dom/layouts/PrimaryAxis.js
@@ -35,6 +35,7 @@ export default class PrimaryAxis extends React.Component {
 
 let styles = {
   view: {
+    alignItems: "stretch",
     alignSelf: "stretch",
     display: "flex",
     flexDirection: "column",
@@ -45,6 +46,7 @@ let styles = {
     height: "500px"
   },
   fixed: {
+    alignItems: "stretch",
     backgroundColor: "#D8D8D8",
     display: "flex",
     flexDirection: "column",
@@ -53,14 +55,16 @@ let styles = {
     height: "100px"
   },
   fit: {
+    alignItems: "stretch",
     backgroundColor: "#D8D8D8",
     display: "flex",
     flexDirection: "column",
     marginBottom: "24px",
     width: "100px"
   },
-  text: { display: "flex", flexDirection: "column" },
+  text: { alignItems: "stretch", display: "flex", flexDirection: "column" },
   fill1: {
+    alignItems: "stretch",
     backgroundColor: colors.cyan500,
     display: "flex",
     flex: 1,
@@ -68,6 +72,7 @@ let styles = {
     width: "100px"
   },
   fill2: {
+    alignItems: "stretch",
     backgroundColor: colors.blue500,
     display: "flex",
     flex: 1,

--- a/examples/generated/test/react-dom/layouts/PrimaryAxis.js
+++ b/examples/generated/test/react-dom/layouts/PrimaryAxis.js
@@ -37,6 +37,7 @@ let styles = {
   view: {
     alignSelf: "stretch",
     display: "flex",
+    flexDirection: "column",
     paddingTop: "24px",
     paddingRight: "24px",
     paddingBottom: "24px",
@@ -46,6 +47,7 @@ let styles = {
   fixed: {
     backgroundColor: "#D8D8D8",
     display: "flex",
+    flexDirection: "column",
     marginBottom: "24px",
     width: "100px",
     height: "100px"
@@ -53,20 +55,23 @@ let styles = {
   fit: {
     backgroundColor: "#D8D8D8",
     display: "flex",
+    flexDirection: "column",
     marginBottom: "24px",
     width: "100px"
   },
-  text: { display: "flex" },
+  text: { display: "flex", flexDirection: "column" },
   fill1: {
     backgroundColor: colors.cyan500,
     display: "flex",
     flex: 1,
+    flexDirection: "column",
     width: "100px"
   },
   fill2: {
     backgroundColor: colors.blue500,
     display: "flex",
     flex: 1,
+    flexDirection: "column",
     width: "100px"
   }
 }

--- a/examples/generated/test/react-dom/layouts/SecondaryAxis.js
+++ b/examples/generated/test/react-dom/layouts/SecondaryAxis.js
@@ -33,6 +33,7 @@ export default class SecondaryAxis extends React.Component {
 
 let styles = {
   container: {
+    alignItems: "stretch",
     alignSelf: "stretch",
     display: "flex",
     flexDirection: "column",
@@ -42,6 +43,7 @@ let styles = {
     paddingLeft: "24px"
   },
   fixed: {
+    alignItems: "stretch",
     backgroundColor: "#D8D8D8",
     display: "flex",
     flexDirection: "column",
@@ -50,6 +52,7 @@ let styles = {
     height: "100px"
   },
   fit: {
+    alignItems: "stretch",
     backgroundColor: "#D8D8D8",
     display: "flex",
     flexDirection: "column",
@@ -60,8 +63,9 @@ let styles = {
     paddingLeft: "12px",
     height: "100px"
   },
-  text: { display: "flex", flexDirection: "column" },
+  text: { alignItems: "stretch", display: "flex", flexDirection: "column" },
   fill: {
+    alignItems: "stretch",
     alignSelf: "stretch",
     backgroundColor: "#D8D8D8",
     display: "flex",

--- a/examples/generated/test/react-dom/layouts/SecondaryAxis.js
+++ b/examples/generated/test/react-dom/layouts/SecondaryAxis.js
@@ -35,6 +35,7 @@ let styles = {
   container: {
     alignSelf: "stretch",
     display: "flex",
+    flexDirection: "column",
     paddingTop: "24px",
     paddingRight: "24px",
     paddingBottom: "24px",
@@ -43,6 +44,7 @@ let styles = {
   fixed: {
     backgroundColor: "#D8D8D8",
     display: "flex",
+    flexDirection: "column",
     marginBottom: "24px",
     width: "100px",
     height: "100px"
@@ -50,6 +52,7 @@ let styles = {
   fit: {
     backgroundColor: "#D8D8D8",
     display: "flex",
+    flexDirection: "column",
     marginBottom: "24px",
     paddingTop: "12px",
     paddingRight: "12px",
@@ -57,11 +60,12 @@ let styles = {
     paddingLeft: "12px",
     height: "100px"
   },
-  text: { display: "flex" },
+  text: { display: "flex", flexDirection: "column" },
   fill: {
     alignSelf: "stretch",
     backgroundColor: "#D8D8D8",
     display: "flex",
+    flexDirection: "column",
     height: "100px"
   }
 }

--- a/examples/generated/test/react-dom/logic/Assign.js
+++ b/examples/generated/test/react-dom/logic/Assign.js
@@ -24,6 +24,11 @@ export default class Assign extends React.Component {
 };
 
 let styles = {
-  view: { alignSelf: "stretch", display: "flex", flexDirection: "column" },
-  text: { display: "flex", flexDirection: "column" }
+  view: {
+    alignItems: "stretch",
+    alignSelf: "stretch",
+    display: "flex",
+    flexDirection: "column"
+  },
+  text: { alignItems: "stretch", display: "flex", flexDirection: "column" }
 }

--- a/examples/generated/test/react-dom/logic/Assign.js
+++ b/examples/generated/test/react-dom/logic/Assign.js
@@ -24,6 +24,6 @@ export default class Assign extends React.Component {
 };
 
 let styles = {
-  view: { alignSelf: "stretch", display: "flex" },
-  text: { display: "flex" }
+  view: { alignSelf: "stretch", display: "flex", flexDirection: "column" },
+  text: { display: "flex", flexDirection: "column" }
 }

--- a/examples/generated/test/react-dom/logic/If.js
+++ b/examples/generated/test/react-dom/logic/If.js
@@ -28,5 +28,10 @@ export default class If extends React.Component {
 };
 
 let styles = {
-  view: { alignSelf: "stretch", display: "flex", flexDirection: "column" }
+  view: {
+    alignItems: "stretch",
+    alignSelf: "stretch",
+    display: "flex",
+    flexDirection: "column"
+  }
 }

--- a/examples/generated/test/react-dom/logic/If.js
+++ b/examples/generated/test/react-dom/logic/If.js
@@ -27,4 +27,6 @@ export default class If extends React.Component {
   }
 };
 
-let styles = { view: { alignSelf: "stretch", display: "flex" } }
+let styles = {
+  view: { alignSelf: "stretch", display: "flex", flexDirection: "column" }
+}

--- a/examples/generated/test/react-dom/style/BorderWidthColor.js
+++ b/examples/generated/test/react-dom/style/BorderWidthColor.js
@@ -20,8 +20,14 @@ export default class BorderWidthColor extends React.Component {
 };
 
 let styles = {
-  view: { alignSelf: "stretch", display: "flex", flexDirection: "column" },
+  view: {
+    alignItems: "stretch",
+    alignSelf: "stretch",
+    display: "flex",
+    flexDirection: "column"
+  },
   view1: {
+    alignItems: "stretch",
     display: "flex",
     flexDirection: "column",
     borderRadius: "10px",

--- a/examples/generated/test/react-dom/style/BorderWidthColor.js
+++ b/examples/generated/test/react-dom/style/BorderWidthColor.js
@@ -20,9 +20,10 @@ export default class BorderWidthColor extends React.Component {
 };
 
 let styles = {
-  view: { alignSelf: "stretch", display: "flex" },
+  view: { alignSelf: "stretch", display: "flex", flexDirection: "column" },
   view1: {
     display: "flex",
+    flexDirection: "column",
     borderRadius: "10px",
     borderWidth: "20px",
     borderColor: colors.blue300,

--- a/examples/generated/test/react-dom/style/BoxModelConditional.js
+++ b/examples/generated/test/react-dom/style/BoxModelConditional.js
@@ -45,6 +45,7 @@ let styles = {
   outer: {
     alignSelf: "stretch",
     display: "flex",
+    flexDirection: "column",
     paddingTop: "4px",
     paddingRight: "4px",
     paddingBottom: "4px",
@@ -53,6 +54,7 @@ let styles = {
   inner: {
     backgroundColor: "#D8D8D8",
     display: "flex",
+    flexDirection: "column",
     width: "60px",
     height: "60px"
   }

--- a/examples/generated/test/react-dom/style/BoxModelConditional.js
+++ b/examples/generated/test/react-dom/style/BoxModelConditional.js
@@ -43,6 +43,7 @@ export default class BoxModelConditional extends React.Component {
 
 let styles = {
   outer: {
+    alignItems: "stretch",
     alignSelf: "stretch",
     display: "flex",
     flexDirection: "column",
@@ -52,6 +53,7 @@ let styles = {
     paddingLeft: "4px"
   },
   inner: {
+    alignItems: "stretch",
     backgroundColor: "#D8D8D8",
     display: "flex",
     flexDirection: "column",

--- a/examples/generated/test/react-dom/style/TextAlignment.js
+++ b/examples/generated/test/react-dom/style/TextAlignment.js
@@ -101,6 +101,7 @@ let styles = {
     alignItems: "flex-start",
     alignSelf: "stretch",
     display: "flex",
+    flexDirection: "column",
     paddingTop: "10px",
     paddingRight: "10px",
     paddingBottom: "10px",
@@ -111,65 +112,112 @@ let styles = {
     alignSelf: "stretch",
     backgroundColor: colors.indigo50,
     display: "flex",
+    flexDirection: "column",
     justifyContent: "center"
   },
-  image: { display: "flex", width: "100px", height: "100px" },
-  view2: { backgroundColor: "#D8D8D8", display: "flex" },
+  image: {
+    display: "flex",
+    flexDirection: "column",
+    width: "100px",
+    height: "100px"
+  },
+  view2: {
+    backgroundColor: "#D8D8D8",
+    display: "flex",
+    flexDirection: "column"
+  },
   text: {
     textAlign: "center",
     ...textStyles.display1,
     alignSelf: "stretch",
     display: "flex",
+    flexDirection: "column",
     marginTop: "16px"
   },
   text1: {
     textAlign: "center",
     ...textStyles.subheading2,
     display: "flex",
+    flexDirection: "column",
     marginTop: "16px"
   },
-  text2: { alignSelf: "stretch", display: "flex", marginTop: "12px" },
-  text3: { textAlign: "right", alignSelf: "stretch", display: "flex" },
-  text4: { textAlign: "center", display: "flex", width: "80px" },
+  text2: {
+    alignSelf: "stretch",
+    display: "flex",
+    flexDirection: "column",
+    marginTop: "12px"
+  },
+  text3: {
+    textAlign: "right",
+    alignSelf: "stretch",
+    display: "flex",
+    flexDirection: "column"
+  },
+  text4: {
+    textAlign: "center",
+    display: "flex",
+    flexDirection: "column",
+    width: "80px"
+  },
   view3: {
     alignItems: "center",
     backgroundColor: "#D8D8D8",
     display: "flex",
+    flexDirection: "column",
     paddingRight: "12px",
     paddingLeft: "12px"
   },
-  text5: { display: "flex" },
+  text5: { display: "flex", flexDirection: "column" },
   view4: {
     alignItems: "center",
     backgroundColor: "#D8D8D8",
     display: "flex",
+    flexDirection: "column",
     paddingRight: "12px",
     paddingLeft: "12px",
     width: "400px"
   },
-  text6: { display: "flex" },
+  text6: { display: "flex", flexDirection: "column" },
   view5: {
     backgroundColor: "#D8D8D8",
     display: "flex",
+    flexDirection: "column",
     paddingRight: "12px",
     paddingLeft: "12px"
   },
-  text7: { textAlign: "center", display: "flex" },
+  text7: { textAlign: "center", display: "flex", flexDirection: "column" },
   view6: {
     backgroundColor: "#D8D8D8",
     display: "flex",
+    flexDirection: "column",
     paddingRight: "12px",
     paddingLeft: "12px",
     width: "400px"
   },
-  text8: { textAlign: "center", alignSelf: "stretch", display: "flex" },
+  text8: {
+    textAlign: "center",
+    alignSelf: "stretch",
+    display: "flex",
+    flexDirection: "column"
+  },
   rightAlignmentContainer: {
     alignItems: "flex-end",
     alignSelf: "stretch",
     backgroundColor: "#D8D8D8",
-    display: "flex"
+    display: "flex",
+    flexDirection: "column"
   },
-  text9: { display: "flex" },
-  text10: { textAlign: "center", alignSelf: "stretch", display: "flex" },
-  image1: { display: "flex", width: "100px", height: "100px" }
+  text9: { display: "flex", flexDirection: "column" },
+  text10: {
+    textAlign: "center",
+    alignSelf: "stretch",
+    display: "flex",
+    flexDirection: "column"
+  },
+  image1: {
+    display: "flex",
+    flexDirection: "column",
+    width: "100px",
+    height: "100px"
+  }
 }

--- a/examples/generated/test/react-dom/style/TextAlignment.js
+++ b/examples/generated/test/react-dom/style/TextAlignment.js
@@ -116,12 +116,14 @@ let styles = {
     justifyContent: "center"
   },
   image: {
+    alignItems: "stretch",
     display: "flex",
     flexDirection: "column",
     width: "100px",
     height: "100px"
   },
   view2: {
+    alignItems: "stretch",
     backgroundColor: "#D8D8D8",
     display: "flex",
     flexDirection: "column"
@@ -129,6 +131,7 @@ let styles = {
   text: {
     textAlign: "center",
     ...textStyles.display1,
+    alignItems: "stretch",
     alignSelf: "stretch",
     display: "flex",
     flexDirection: "column",
@@ -137,11 +140,13 @@ let styles = {
   text1: {
     textAlign: "center",
     ...textStyles.subheading2,
+    alignItems: "stretch",
     display: "flex",
     flexDirection: "column",
     marginTop: "16px"
   },
   text2: {
+    alignItems: "stretch",
     alignSelf: "stretch",
     display: "flex",
     flexDirection: "column",
@@ -149,12 +154,14 @@ let styles = {
   },
   text3: {
     textAlign: "right",
+    alignItems: "stretch",
     alignSelf: "stretch",
     display: "flex",
     flexDirection: "column"
   },
   text4: {
     textAlign: "center",
+    alignItems: "stretch",
     display: "flex",
     flexDirection: "column",
     width: "80px"
@@ -167,7 +174,7 @@ let styles = {
     paddingRight: "12px",
     paddingLeft: "12px"
   },
-  text5: { display: "flex", flexDirection: "column" },
+  text5: { alignItems: "stretch", display: "flex", flexDirection: "column" },
   view4: {
     alignItems: "center",
     backgroundColor: "#D8D8D8",
@@ -177,16 +184,23 @@ let styles = {
     paddingLeft: "12px",
     width: "400px"
   },
-  text6: { display: "flex", flexDirection: "column" },
+  text6: { alignItems: "stretch", display: "flex", flexDirection: "column" },
   view5: {
+    alignItems: "stretch",
     backgroundColor: "#D8D8D8",
     display: "flex",
     flexDirection: "column",
     paddingRight: "12px",
     paddingLeft: "12px"
   },
-  text7: { textAlign: "center", display: "flex", flexDirection: "column" },
+  text7: {
+    textAlign: "center",
+    alignItems: "stretch",
+    display: "flex",
+    flexDirection: "column"
+  },
   view6: {
+    alignItems: "stretch",
     backgroundColor: "#D8D8D8",
     display: "flex",
     flexDirection: "column",
@@ -196,6 +210,7 @@ let styles = {
   },
   text8: {
     textAlign: "center",
+    alignItems: "stretch",
     alignSelf: "stretch",
     display: "flex",
     flexDirection: "column"
@@ -207,14 +222,16 @@ let styles = {
     display: "flex",
     flexDirection: "column"
   },
-  text9: { display: "flex", flexDirection: "column" },
+  text9: { alignItems: "stretch", display: "flex", flexDirection: "column" },
   text10: {
     textAlign: "center",
+    alignItems: "stretch",
     alignSelf: "stretch",
     display: "flex",
     flexDirection: "column"
   },
   image1: {
+    alignItems: "stretch",
     display: "flex",
     flexDirection: "column",
     width: "100px",

--- a/examples/generated/test/react-dom/style/TextStyleConditional.js
+++ b/examples/generated/test/react-dom/style/TextStyleConditional.js
@@ -27,6 +27,6 @@ export default class TextStyleConditional extends React.Component {
 };
 
 let styles = {
-  view: { alignSelf: "stretch", display: "flex" },
-  text: { ...textStyles.headline, display: "flex" }
+  view: { alignSelf: "stretch", display: "flex", flexDirection: "column" },
+  text: { ...textStyles.headline, display: "flex", flexDirection: "column" }
 }

--- a/examples/generated/test/react-dom/style/TextStyleConditional.js
+++ b/examples/generated/test/react-dom/style/TextStyleConditional.js
@@ -27,6 +27,16 @@ export default class TextStyleConditional extends React.Component {
 };
 
 let styles = {
-  view: { alignSelf: "stretch", display: "flex", flexDirection: "column" },
-  text: { ...textStyles.headline, display: "flex", flexDirection: "column" }
+  view: {
+    alignItems: "stretch",
+    alignSelf: "stretch",
+    display: "flex",
+    flexDirection: "column"
+  },
+  text: {
+    ...textStyles.headline,
+    alignItems: "stretch",
+    display: "flex",
+    flexDirection: "column"
+  }
 }

--- a/examples/generated/test/react-dom/style/TextStylesTest.js
+++ b/examples/generated/test/react-dom/style/TextStylesTest.js
@@ -61,23 +61,70 @@ export default class TextStylesTest extends React.Component {
 };
 
 let styles = {
-  view: { alignSelf: "stretch", display: "flex", flexDirection: "column" },
-  text: { ...textStyles.display4, display: "flex", flexDirection: "column" },
-  text1: { ...textStyles.display3, display: "flex", flexDirection: "column" },
-  text2: { ...textStyles.display2, display: "flex", flexDirection: "column" },
-  text3: { ...textStyles.display1, display: "flex", flexDirection: "column" },
-  text4: { ...textStyles.headline, display: "flex", flexDirection: "column" },
+  view: {
+    alignItems: "stretch",
+    alignSelf: "stretch",
+    display: "flex",
+    flexDirection: "column"
+  },
+  text: {
+    ...textStyles.display4,
+    alignItems: "stretch",
+    display: "flex",
+    flexDirection: "column"
+  },
+  text1: {
+    ...textStyles.display3,
+    alignItems: "stretch",
+    display: "flex",
+    flexDirection: "column"
+  },
+  text2: {
+    ...textStyles.display2,
+    alignItems: "stretch",
+    display: "flex",
+    flexDirection: "column"
+  },
+  text3: {
+    ...textStyles.display1,
+    alignItems: "stretch",
+    display: "flex",
+    flexDirection: "column"
+  },
+  text4: {
+    ...textStyles.headline,
+    alignItems: "stretch",
+    display: "flex",
+    flexDirection: "column"
+  },
   text5: {
     ...textStyles.subheading2,
+    alignItems: "stretch",
     display: "flex",
     flexDirection: "column"
   },
   text6: {
     ...textStyles.subheading1,
+    alignItems: "stretch",
     display: "flex",
     flexDirection: "column"
   },
-  text7: { ...textStyles.body2, display: "flex", flexDirection: "column" },
-  text8: { ...textStyles.body1, display: "flex", flexDirection: "column" },
-  text9: { ...textStyles.caption, display: "flex", flexDirection: "column" }
+  text7: {
+    ...textStyles.body2,
+    alignItems: "stretch",
+    display: "flex",
+    flexDirection: "column"
+  },
+  text8: {
+    ...textStyles.body1,
+    alignItems: "stretch",
+    display: "flex",
+    flexDirection: "column"
+  },
+  text9: {
+    ...textStyles.caption,
+    alignItems: "stretch",
+    display: "flex",
+    flexDirection: "column"
+  }
 }

--- a/examples/generated/test/react-dom/style/TextStylesTest.js
+++ b/examples/generated/test/react-dom/style/TextStylesTest.js
@@ -61,15 +61,23 @@ export default class TextStylesTest extends React.Component {
 };
 
 let styles = {
-  view: { alignSelf: "stretch", display: "flex" },
-  text: { ...textStyles.display4, display: "flex" },
-  text1: { ...textStyles.display3, display: "flex" },
-  text2: { ...textStyles.display2, display: "flex" },
-  text3: { ...textStyles.display1, display: "flex" },
-  text4: { ...textStyles.headline, display: "flex" },
-  text5: { ...textStyles.subheading2, display: "flex" },
-  text6: { ...textStyles.subheading1, display: "flex" },
-  text7: { ...textStyles.body2, display: "flex" },
-  text8: { ...textStyles.body1, display: "flex" },
-  text9: { ...textStyles.caption, display: "flex" }
+  view: { alignSelf: "stretch", display: "flex", flexDirection: "column" },
+  text: { ...textStyles.display4, display: "flex", flexDirection: "column" },
+  text1: { ...textStyles.display3, display: "flex", flexDirection: "column" },
+  text2: { ...textStyles.display2, display: "flex", flexDirection: "column" },
+  text3: { ...textStyles.display1, display: "flex", flexDirection: "column" },
+  text4: { ...textStyles.headline, display: "flex", flexDirection: "column" },
+  text5: {
+    ...textStyles.subheading2,
+    display: "flex",
+    flexDirection: "column"
+  },
+  text6: {
+    ...textStyles.subheading1,
+    display: "flex",
+    flexDirection: "column"
+  },
+  text7: { ...textStyles.body2, display: "flex", flexDirection: "column" },
+  text8: { ...textStyles.body1, display: "flex", flexDirection: "column" },
+  text9: { ...textStyles.caption, display: "flex", flexDirection: "column" }
 }


### PR DESCRIPTION
## What

Web's flex direction default is `row`, but the expectation from lona is that `column` is the default. So, I'm adding column flexDirection alongside the flex declaration for react-dom.

## Why

Produce react-dom layouts consistent with LS.

## Major Changes

* Added flex direction default for react-dom
* Fixed the order that defaults are assigned to the ParameterMap, so that that explicit declarations are not overwritten by the defaults.
