### PR TITLE
Improve JS layout generation

### DIFF
--- a/compiler/core/src/core/layer.re
+++ b/compiler/core/src/core/layer.re
@@ -282,7 +282,6 @@ let layoutParameters = [
   Display,
   Flex,
   FlexDirection,
-  TextStyle,
   JustifyContent,
 ];
 

--- a/compiler/core/src/core/layer.re
+++ b/compiler/core/src/core/layer.re
@@ -276,15 +276,6 @@ let logicAssignmentsFromLayerParameters = layer => {
 
 let parameterIsStyle = key => getParameterCategory(key) == Style;
 
-let layoutParameters = [
-  ParameterKey.AlignItems,
-  AlignSelf,
-  Display,
-  Flex,
-  FlexDirection,
-  JustifyContent,
-];
-
 let splitParamsMap = params =>
   params |> ParameterMap.partition((key, _) => parameterIsStyle(key));
 

--- a/compiler/core/src/core/layer.re
+++ b/compiler/core/src/core/layer.re
@@ -52,6 +52,7 @@ let getParameterCategory = (x: ParameterKey.t) =>
   | BorderRadius => Style
   | BorderWidth => Style
   | TextAlign => Style
+  /* | Shadow => Style */
   /* Props */
   | NumberOfLines => Prop
   | Text => Prop
@@ -109,32 +110,32 @@ let flatmapParameters = (f, layer: Types.layer) => {
   List.concat(parameterLists) |> List.map(f(layer));
 };
 
-let getFlexDirection = (layer: Types.layer) =>
-  switch (ParameterMap.find(ParameterKey.FlexDirection, layer.parameters)) {
+let getFlexDirection = (parameters: Types.layerParameters) =>
+  switch (ParameterMap.find(ParameterKey.FlexDirection, parameters)) {
   | value => value.data |> Json.Decode.string
   | exception Not_found => "column"
   };
 
-let getStringParameterOpt = (parameterName, layer: Types.layer) =>
-  switch (ParameterMap.find_opt(parameterName, layer.parameters)) {
+let getStringParameterOpt = (parameterName, parameters: Types.layerParameters) =>
+  switch (ParameterMap.find_opt(parameterName, parameters)) {
   | Some(value) => Some(value.data |> Json.Decode.string)
   | None => None
   };
 
-let getStringParameter = (parameterName, layer: Types.layer) =>
-  switch (getStringParameterOpt(parameterName, layer)) {
+let getStringParameter = (parameterName, parameters: Types.layerParameters) =>
+  switch (getStringParameterOpt(parameterName, parameters)) {
   | Some(value) => value
   | None => ""
   };
 
-let getNumberParameterOpt = (parameterName, layer: Types.layer) =>
-  switch (ParameterMap.find(parameterName, layer.parameters)) {
+let getNumberParameterOpt = (parameterName, parameters: Types.layerParameters) =>
+  switch (ParameterMap.find(parameterName, parameters)) {
   | value => Some(value.data |> Json.Decode.float)
   | exception Not_found => None
   };
 
-let getNumberParameter = (parameterName, layer: Types.layer) =>
-  switch (getNumberParameterOpt(parameterName, layer)) {
+let getNumberParameter = (parameterName, parameters: Types.layerParameters) =>
+  switch (getNumberParameterOpt(parameterName, parameters)) {
   | Some(value) => value
   | None => 0.0
   };
@@ -147,13 +148,13 @@ type dimensionSizingRules = {
 let getSizingRules = (parent: option(Types.layer), layer: Types.layer) => {
   let parentDirection =
     switch (parent) {
-    | Some(parent) => getFlexDirection(parent)
+    | Some(parent) => getFlexDirection(parent.parameters)
     | None => "column"
     };
-  let flex = getNumberParameterOpt(Flex, layer);
-  let width = getNumberParameterOpt(Width, layer);
-  let height = getNumberParameterOpt(Height, layer);
-  let alignSelf = getStringParameterOpt(AlignSelf, layer);
+  let flex = getNumberParameterOpt(Flex, layer.parameters);
+  let width = getNumberParameterOpt(Width, layer.parameters);
+  let height = getNumberParameterOpt(Height, layer.parameters);
+  let alignSelf = getStringParameterOpt(AlignSelf, layer.parameters);
   let widthSizingRule =
     switch (parentDirection, flex, width, alignSelf) {
     | ("row", Some(1.0), _, _) => Types.Fill

--- a/compiler/core/src/core/layer.re
+++ b/compiler/core/src/core/layer.re
@@ -276,6 +276,16 @@ let logicAssignmentsFromLayerParameters = layer => {
 
 let parameterIsStyle = key => getParameterCategory(key) == Style;
 
+let layoutParameters = [
+  ParameterKey.AlignItems,
+  AlignSelf,
+  Display,
+  Flex,
+  FlexDirection,
+  TextStyle,
+  JustifyContent,
+];
+
 let splitParamsMap = params =>
   params |> ParameterMap.partition((key, _) => parameterIsStyle(key));
 

--- a/compiler/core/src/core/layer.re
+++ b/compiler/core/src/core/layer.re
@@ -196,9 +196,15 @@ let getLayout =
   let {width, height} = getSizingRules(parent, parameters);
   let direction = getFlexDirection(parameters) |> Layout.FromString.direction;
   let justifyContent =
-    getJustifyContent(parameters) |> Layout.FromString.childrenAlignment;
+    switch (getStringParameterOpt(ParameterKey.JustifyContent, parameters)) {
+    | Some(value) => value |> Layout.FromString.childrenAlignment
+    | None => Unspecified
+    };
   let alignItems =
-    getAlignItems(parameters) |> Layout.FromString.childrenAlignment;
+    switch (getStringParameterOpt(ParameterKey.AlignItems, parameters)) {
+    | Some(value) => value |> Layout.FromString.childrenAlignment
+    | None => Unspecified
+    };
   let horizontalAlignment =
     switch (direction) {
     | Row => justifyContent

--- a/compiler/core/src/core/layer.re
+++ b/compiler/core/src/core/layer.re
@@ -323,3 +323,32 @@ let getTypeNames = rootLayer => {
        );
   {builtIn: builtInTypeNames, custom: customTypeNames};
 };
+
+/* For the purposes of layouts, we want to swap the custom component layer
+   with the root layer from the custom component's definition. We should
+   use the parameters of the custom component's root layer, since these
+   determine layout. We should still use the type, name, and children of
+   the custom component layer. */
+let getRootLayerForComponentName =
+    (getComponent: string => Js.Json.t, layer: Types.layer, name): Types.layer => {
+  let component = getComponent(name);
+  let rootLayer = component |> Decode.Component.rootLayer(getComponent);
+  {
+    typeName: layer.typeName,
+    styles: layer.styles,
+    name: layer.name,
+    parameters: rootLayer.parameters,
+    children: layer.children,
+  };
+};
+
+/* Any time we access a layer, we want to use its proxy if it has one.
+   This is how we layout custom components.
+   TODO: When we handle "Children" components, we'll need to find/use
+   a different proxy */
+let getProxyLayer = (getComponent: string => Js.Json.t, layer: Types.layer) =>
+  switch (layer.typeName) {
+  | Types.Component(name) =>
+    getRootLayerForComponentName(getComponent, layer, name)
+  | _ => layer
+  };

--- a/compiler/core/src/core/layout.re
+++ b/compiler/core/src/core/layout.re
@@ -1,0 +1,53 @@
+type direction =
+  | Row
+  | Column;
+
+type childrenAlignment =
+  | Start
+  | Center
+  | End;
+
+type sizingRule =
+  | Fill
+  | FitContent
+  | Fixed(float);
+
+type t = {
+  width: sizingRule,
+  height: sizingRule,
+  direction,
+  horizontalAlignment: childrenAlignment,
+  verticalAlignment: childrenAlignment,
+};
+
+module FromString = {
+  let direction = (value: string) =>
+    switch (value) {
+    | "row" => Row
+    | "column" => Column
+    | _ => raise(Not_found)
+    };
+
+  let childrenAlignment = (value: string) =>
+    switch (value) {
+    | "flex-start" => Start
+    | "center" => Center
+    | "flex-end" => End
+    | _ => raise(Not_found)
+    };
+};
+
+module ToString = {
+  let direction = (value: direction) =>
+    switch (value) {
+    | Row => "row"
+    | Column => "column"
+    };
+
+  let childrenAlignment = (value: childrenAlignment) =>
+    switch (value) {
+    | Start => "flex-start"
+    | Center => "center"
+    | End => "flex-end"
+    };
+};

--- a/compiler/core/src/core/layout.re
+++ b/compiler/core/src/core/layout.re
@@ -5,7 +5,8 @@ type direction =
 type childrenAlignment =
   | Start
   | Center
-  | End;
+  | End
+  | Unspecified;
 
 type sizingRule =
   | Fill
@@ -33,7 +34,7 @@ module FromString = {
     | "flex-start" => Start
     | "center" => Center
     | "flex-end" => End
-    | _ => raise(Not_found)
+    | _ => Start
     };
 };
 
@@ -49,5 +50,6 @@ module ToString = {
     | Start => "flex-start"
     | Center => "center"
     | End => "flex-end"
+    | Unspecified => "flex-start"
     };
 };

--- a/compiler/core/src/core/types.re
+++ b/compiler/core/src/core/types.re
@@ -75,11 +75,13 @@ let layerTypeToString = x =>
   | Unknown => "Unknown"
   };
 
+type layerParameters = ParameterMap.t(lonaValue);
+
 type layer = {
   typeName: layerType,
   name: string,
   styles: list(Styles.namedStyles(option(lonaValue))),
-  parameters: ParameterMap.t(lonaValue),
+  parameters: layerParameters,
   children: list(layer),
 };
 

--- a/compiler/core/src/core/types.re
+++ b/compiler/core/src/core/types.re
@@ -84,8 +84,3 @@ type layer = {
   parameters: layerParameters,
   children: list(layer),
 };
-
-type sizingRule =
-  | Fill
-  | FitContent
-  | Fixed(float);

--- a/compiler/core/src/javaScript/javaScriptComponent.re
+++ b/compiler/core/src/javaScript/javaScriptComponent.re
@@ -423,6 +423,7 @@ let generate =
 
   let styleSheetAST =
     JavaScriptStyles.layerToJavaScriptStyleSheetAST(
+      getComponent,
       options.framework,
       config.colorsFile.contents,
       rootLayer,

--- a/compiler/core/src/javaScript/javaScriptComponent.re
+++ b/compiler/core/src/javaScript/javaScriptComponent.re
@@ -231,11 +231,29 @@ let rec layerToJavaScriptAST =
            layerToJavaScriptAST(framework, config, variableMap, getAssetPath),
          )
     };
-  JSXElement({
-    tag: getLayerTagString(framework, layer),
-    attributes: styleAttribute @ attributes,
-    content,
-  });
+
+  /* For JS DOM, wrap custom components in a div that can have the correct
+     default layout attributes. */
+  switch (framework, layer.typeName) {
+  | (JavaScriptOptions.ReactDOM, Types.Component(_)) =>
+    JSXElement({
+      tag: "div",
+      attributes: styleAttribute,
+      content: [
+        JSXElement({
+          tag: getLayerTagString(framework, layer),
+          attributes,
+          content,
+        }),
+      ],
+    })
+  | _ =>
+    JSXElement({
+      tag: getLayerTagString(framework, layer),
+      attributes: styleAttribute @ attributes,
+      content,
+    })
+  };
 };
 
 type componentImports = {

--- a/compiler/core/src/javaScript/javaScriptComponent.re
+++ b/compiler/core/src/javaScript/javaScriptComponent.re
@@ -442,6 +442,7 @@ let generate =
 
   let styleSheetAST =
     JavaScriptStyles.layerToJavaScriptStyleSheetAST(
+      config,
       getComponent,
       options.framework,
       config.colorsFile.contents,

--- a/compiler/core/src/javaScript/javaScriptComponent.re
+++ b/compiler/core/src/javaScript/javaScriptComponent.re
@@ -105,6 +105,7 @@ let createStyleAttributeAST =
           CallExpression({
             callee: Identifier(["Object", "assign"]),
             arguments: [
+              ObjectLiteral([]),
               Identifier([
                 "styles",
                 JavaScriptFormat.styleVariableName(layer.name),

--- a/compiler/core/src/javaScript/javaScriptStyles.re
+++ b/compiler/core/src/javaScript/javaScriptStyles.re
@@ -97,7 +97,7 @@ let getLayoutParameters =
     ParameterMap.(
       switch (framework, frameworkParentDirection, sizingRules.width) {
       | (JavaScriptOptions.ReactDOM, "row", Types.Fill) =>
-        parameters |> add(ParameterKey.Flex, LonaValue.string("1 0 0px"))
+        parameters |> add(ParameterKey.Flex, LonaValue.string("1 1 0%"))
       | (JavaScriptOptions.ReactDOM, "row", Types.FitContent) =>
         parameters |> add(ParameterKey.Flex, LonaValue.string("0 0 auto"))
       | (JavaScriptOptions.ReactDOM, "column", Types.Fill) =>
@@ -124,7 +124,7 @@ let getLayoutParameters =
         parameters
         |> add(ParameterKey.AlignSelf, LonaValue.string("flex-start"))
       | (JavaScriptOptions.ReactDOM, "column", Types.Fill) =>
-        parameters |> add(ParameterKey.Flex, LonaValue.string("1 0 0px"))
+        parameters |> add(ParameterKey.Flex, LonaValue.string("1 1 0%"))
       | (JavaScriptOptions.ReactDOM, "column", Types.FitContent) =>
         parameters |> add(ParameterKey.Flex, LonaValue.string("0 0 auto"))
       | (JavaScriptOptions.ReactDOM, _, Types.Fixed(value)) =>

--- a/compiler/core/src/javaScript/javaScriptStyles.re
+++ b/compiler/core/src/javaScript/javaScriptStyles.re
@@ -89,7 +89,12 @@ let defaultStyles =
         |> add(ParameterKey.Display, LonaValue.string("flex"))
         |> add(ParameterKey.AlignItems, LonaValue.string("flex-start"))
       )
-    | _ => defaults
+    | (JavaScriptOptions.ReactNative, _)
+    | (JavaScriptOptions.ReactSketchapp, _) =>
+      ParameterMap.(
+        defaults
+        |> add(ParameterKey.AlignItems, LonaValue.string("flex-start"))
+      )
     };
 
   /* Add default text style */
@@ -136,19 +141,33 @@ let getLayoutParameters =
 
   let parameters = ParameterMap.empty;
 
+  let flex0Value =
+    switch (framework) {
+    | JavaScriptOptions.ReactDOM => LonaValue.string("0 0 auto")
+    | JavaScriptOptions.ReactNative
+    | JavaScriptOptions.ReactSketchapp => LonaValue.number(0.0)
+    };
+
+  let flex1Value =
+    switch (framework) {
+    | JavaScriptOptions.ReactDOM => LonaValue.string("1 1 0%")
+    | JavaScriptOptions.ReactNative
+    | JavaScriptOptions.ReactSketchapp => LonaValue.number(1.0)
+    };
+
   /* Horizontal axis */
   let parameters =
     ParameterMap.(
-      switch (framework, frameworkParentDirection, sizingRules.width) {
-      | (JavaScriptOptions.ReactDOM, "row", Types.Fill) =>
-        parameters |> add(ParameterKey.Flex, LonaValue.string("1 1 0%"))
-      | (JavaScriptOptions.ReactDOM, "row", Types.FitContent) =>
-        parameters |> add(ParameterKey.Flex, LonaValue.string("0 0 auto"))
-      | (JavaScriptOptions.ReactDOM, "column", Types.Fill) =>
+      switch (frameworkParentDirection, sizingRules.width) {
+      | ("row", Types.Fill) =>
+        parameters |> add(ParameterKey.Flex, flex1Value)
+      | ("row", Types.FitContent) =>
+        parameters |> add(ParameterKey.Flex, flex0Value)
+      | ("column", Types.Fill) =>
         parameters
         |> add(ParameterKey.AlignSelf, LonaValue.string("stretch"))
-      | (JavaScriptOptions.ReactDOM, "column", Types.FitContent) => parameters
-      | (JavaScriptOptions.ReactDOM, _, Types.Fixed(value)) =>
+      | ("column", Types.FitContent) => parameters
+      | (_, Types.Fixed(value)) =>
         parameters |> add(ParameterKey.Width, LonaValue.number(value))
       | _ =>
         Js.log2("Bad parent direction (width)", frameworkParentDirection);
@@ -159,16 +178,16 @@ let getLayoutParameters =
   /* Vertical axis */
   let parameters =
     ParameterMap.(
-      switch (framework, frameworkParentDirection, sizingRules.height) {
-      | (JavaScriptOptions.ReactDOM, "row", Types.Fill) =>
+      switch (frameworkParentDirection, sizingRules.height) {
+      | ("row", Types.Fill) =>
         parameters
         |> add(ParameterKey.AlignSelf, LonaValue.string("stretch"))
-      | (JavaScriptOptions.ReactDOM, "row", Types.FitContent) => parameters
-      | (JavaScriptOptions.ReactDOM, "column", Types.Fill) =>
-        parameters |> add(ParameterKey.Flex, LonaValue.string("1 1 0%"))
-      | (JavaScriptOptions.ReactDOM, "column", Types.FitContent) =>
-        parameters |> add(ParameterKey.Flex, LonaValue.string("0 0 auto"))
-      | (JavaScriptOptions.ReactDOM, _, Types.Fixed(value)) =>
+      | ("row", Types.FitContent) => parameters
+      | ("column", Types.Fill) =>
+        parameters |> add(ParameterKey.Flex, flex1Value)
+      | ("column", Types.FitContent) =>
+        parameters |> add(ParameterKey.Flex, flex0Value)
+      | (_, Types.Fixed(value)) =>
         parameters |> add(ParameterKey.Height, LonaValue.number(value))
       | _ =>
         Js.log2("Bad parent direction (width)", frameworkParentDirection);

--- a/compiler/core/src/javaScript/javaScriptStyles.re
+++ b/compiler/core/src/javaScript/javaScriptStyles.re
@@ -55,10 +55,10 @@ let getStyleProperty =
 };
 
 let addDefaultStyles =
-    (framework: JavaScriptOptions.framework, layer: Types.layer) => {
-  let styleParams =
-    layer.parameters
-    |> ParameterMap.filter((key, _) => Layer.parameterIsStyle(key));
+    (
+      framework: JavaScriptOptions.framework,
+      styleParams: ParameterMap.t(Types.lonaValue),
+    ) =>
   ParameterMap.assign(
     switch (framework) {
     | JavaScriptOptions.ReactDOM =>
@@ -72,7 +72,25 @@ let addDefaultStyles =
     },
     styleParams,
   );
-};
+
+/* let normalizeLayoutStyles =
+     (
+       framework: JavaScriptOptions.framework,
+       styleParams: ParameterMap.t(Types.lonaValue),
+     ) =>
+   ParameterMap.assign(
+     switch (framework) {
+     | JavaScriptOptions.ReactDOM =>
+       ParameterMap.(
+         empty
+         |> add(ParameterKey.Display, LonaValue.string("flex"))
+         |> add(ParameterKey.FlexDirection, LonaValue.string("column"))
+         |> add(ParameterKey.AlignItems, LonaValue.string("stretch"))
+       )
+     | _ => ParameterMap.empty
+     },
+     styleParams,
+   ); */
 
 let getStylePropertyWithUnits =
     (
@@ -102,7 +120,8 @@ let createStyleObjectForLayer =
       key: Identifier([JavaScriptFormat.styleVariableName(layer.name)]),
       value:
         ObjectLiteral(
-          layer
+          layer.parameters
+          |> ParameterMap.filter((key, _) => Layer.parameterIsStyle(key))
           |> addDefaultStyles(framework)
           |> ParameterMap.bindings
           |> List.map(((key, value)) =>

--- a/compiler/core/src/javaScript/javaScriptTextStyle.re
+++ b/compiler/core/src/javaScript/javaScriptTextStyle.re
@@ -32,7 +32,7 @@ let render =
                data: Js.Json.string(value),
              };
              Property({
-               key: Identifier(["family"]),
+               key: Identifier(["fontFamily"]),
                value: Literal(lonaValue),
              });
            }),

--- a/compiler/core/src/swift/swiftComponent.re
+++ b/compiler/core/src/swift/swiftComponent.re
@@ -474,7 +474,7 @@ let generate =
   let textStyleVariableDoc = (layer: Types.layer) => {
     let id =
       Parameter.isSetInitially(layer, TextStyle) ?
-        Layer.getStringParameter(TextStyle, layer) :
+        Layer.getStringParameter(TextStyle, layer.parameters) :
         config.textStylesFile.contents.defaultStyle.id;
     let value =
       Parameter.isSetInitially(layer, TextAlign) ?
@@ -483,7 +483,7 @@ let generate =
           [
             (
               Some("alignment"),
-              ["." ++ Layer.getStringParameter(TextAlign, layer)],
+              ["." ++ Layer.getStringParameter(TextAlign, layer.parameters)],
             ),
           ],
         ) :

--- a/compiler/core/src/swift/swiftComponent.re
+++ b/compiler/core/src/swift/swiftComponent.re
@@ -615,8 +615,7 @@ let generate =
     | SwiftOptions.UIKit => []
     };
 
-  let constraints =
-    SwiftConstraint.calculateConstraints(getComponent, rootLayer);
+  let constraints = Constraint.getConstraints(getComponent, rootLayer);
   let superclass =
     TypeName(
       Naming.layerType(config, pluginContext, swiftOptions, name, Types.View),

--- a/compiler/core/src/swift/swiftConstraint.re
+++ b/compiler/core/src/swift/swiftConstraint.re
@@ -278,27 +278,6 @@ let formatConstraintVariableName =
   };
 };
 
-let calculateConstraints = (getComponent, rootLayer: Types.layer) =>
-  Constraint.getConstraints(
-    /* For the purposes of layouts, we want to swap the custom component layer
-       with the root layer from the custom component's definition. We should
-       use the parameters of the custom component's root layer, since these
-       determine layout. We should still use the type, name, and children of
-       the custom component layer. */
-    (layer: Types.layer, name) => {
-      let component = getComponent(name);
-      let rootLayer = component |> Decode.Component.rootLayer(getComponent);
-      {
-        typeName: layer.typeName,
-        styles: layer.styles,
-        name: layer.name,
-        parameters: rootLayer.parameters,
-        children: layer.children,
-      };
-    },
-    rootLayer,
-  );
-
 let setUpFunction =
     (
       swiftOptions: SwiftOptions.options,
@@ -309,7 +288,7 @@ let setUpFunction =
       root: Types.layer,
     ) => {
   open SwiftAst;
-  let constraints = calculateConstraints(getComponent, root);
+  let constraints = Constraint.getConstraints(getComponent, root);
   let translatesAutoresizingMask = (layer: Types.layer) =>
     BinaryExpression({
       "left":

--- a/compiler/core/src/swift/swiftLogic.re
+++ b/compiler/core/src/swift/swiftLogic.re
@@ -195,7 +195,8 @@ let toSwiftAST =
             let layer = Layer.findByName(layerName, rootLayer);
             switch (layer) {
             | Some(layer) =>
-              let param = Layer.getStringParameterOpt(TextAlign, layer);
+              let param =
+                Layer.getStringParameterOpt(TextAlign, layer.parameters);
               switch (param) {
               | None => right
               | Some(_) =>
@@ -210,7 +211,10 @@ let toSwiftAST =
                           "value":
                             SwiftIdentifier(
                               "."
-                              ++ Layer.getStringParameter(TextAlign, layer),
+                              ++ Layer.getStringParameter(
+                                   TextAlign,
+                                   layer.parameters,
+                                 ),
                             ),
                         }),
                       ],

--- a/compiler/core/src/utils/constraint.re
+++ b/compiler/core/src/utils/constraint.re
@@ -119,18 +119,10 @@ let getRole =
    }; */
 type t = _t;
 
-let getConstraints = (getRootLayerForComponentName, rootLayer: Types.layer) => {
-  /* Any time we access a layer, we want to use its proxy if it has one.
-     This is how we layout custom components.
-     TODO: When we handle "Children" components, we'll need to find a use
-     a different proxy */
-  let getProxyLayer = (layer: Types.layer) =>
-    switch (layer.typeName) {
-    | Types.Component(name) => getRootLayerForComponentName(layer, name)
-    | _ => layer
-    };
+let getConstraints =
+    (getComponent: string => Js.Json.t, rootLayer: Types.layer) => {
   let constrainAxes = (layer: Types.layer) => {
-    let layer = getProxyLayer(layer);
+    let layer = Layer.getProxyLayer(getComponent, layer);
     let direction = Layer.getFlexDirection(layer.parameters);
     let isColumn = direction == "column";
     let primaryBeforeAnchor = isColumn ? Top : Leading;
@@ -150,7 +142,7 @@ let getConstraints = (getRootLayerForComponentName, rootLayer: Types.layer) => {
       isColumn ? sizingRules.width : sizingRules.height;
     let flexChildren =
       layer.children
-      |> List.map(getProxyLayer)
+      |> List.map(Layer.getProxyLayer(getComponent))
       |> List.filter((child: Types.layer) =>
            Layer.getNumberParameter(Flex, child.parameters) === 1.0
          );
@@ -346,7 +338,7 @@ let getConstraints = (getRootLayerForComponentName, rootLayer: Types.layer) => {
       };
     let fitContentSecondaryConstraints =
       layer.children
-      |> List.map(getProxyLayer)
+      |> List.map(Layer.getProxyLayer(getComponent))
       |> List.map(fitContentSecondaryConstraint)
       |> List.concat;
     let heightConstraint =
@@ -379,7 +371,7 @@ let getConstraints = (getRootLayerForComponentName, rootLayer: Types.layer) => {
       @ [fitContentSecondaryConstraints]
       @ (
         layer.children
-        |> List.map(getProxyLayer)
+        |> List.map(Layer.getProxyLayer(getComponent))
         |> List.mapi(addConstraints)
       );
     constraints |> List.concat;

--- a/compiler/core/src/utils/constraint.re
+++ b/compiler/core/src/utils/constraint.re
@@ -136,7 +136,8 @@ let getConstraints =
     let height = Layer.getNumberParameterOpt(Height, layer.parameters);
     let width = Layer.getNumberParameterOpt(Width, layer.parameters);
     let sizingRules =
-      layer |> Layer.getSizingRules(Layer.findParent(rootLayer, layer));
+      layer.parameters
+      |> Layer.getSizingRules(Layer.findParent(rootLayer, layer));
     let primarySizingRule = isColumn ? sizingRules.height : sizingRules.width;
     let secondarySizingRule =
       isColumn ? sizingRules.width : sizingRules.height;
@@ -147,7 +148,8 @@ let getConstraints =
            Layer.getNumberParameter(Flex, child.parameters) === 1.0
          );
     let addConstraints = (index, child: Types.layer) => {
-      let childSizingRules = child |> Layer.getSizingRules(Some(layer));
+      let childSizingRules =
+        child.parameters |> Layer.getSizingRules(Some(layer));
       let childSecondarySizingRule =
         isColumn ? childSizingRules.width : childSizingRules.height;
       let firstViewConstraints =

--- a/compiler/core/src/utils/constraint.re
+++ b/compiler/core/src/utils/constraint.re
@@ -131,7 +131,7 @@ let getConstraints = (getRootLayerForComponentName, rootLayer: Types.layer) => {
     };
   let constrainAxes = (layer: Types.layer) => {
     let layer = getProxyLayer(layer);
-    let direction = Layer.getFlexDirection(layer);
+    let direction = Layer.getFlexDirection(layer.parameters);
     let isColumn = direction == "column";
     let primaryBeforeAnchor = isColumn ? Top : Leading;
     let primaryAfterAnchor = isColumn ? Bottom : Trailing;
@@ -141,8 +141,8 @@ let getConstraints = (getRootLayerForComponentName, rootLayer: Types.layer) => {
     let secondaryCenterAnchor = isColumn ? CenterX : CenterY;
     let primaryDimensionAnchor = isColumn ? Height : Width;
     let secondaryDimensionAnchor = isColumn ? Width : Height;
-    let height = Layer.getNumberParameterOpt(Height, layer);
-    let width = Layer.getNumberParameterOpt(Width, layer);
+    let height = Layer.getNumberParameterOpt(Height, layer.parameters);
+    let width = Layer.getNumberParameterOpt(Width, layer.parameters);
     let sizingRules =
       layer |> Layer.getSizingRules(Layer.findParent(rootLayer, layer));
     let primarySizingRule = isColumn ? sizingRules.height : sizingRules.width;
@@ -152,7 +152,7 @@ let getConstraints = (getRootLayerForComponentName, rootLayer: Types.layer) => {
       layer.children
       |> List.map(getProxyLayer)
       |> List.filter((child: Types.layer) =>
-           Layer.getNumberParameter(Flex, child) === 1.0
+           Layer.getNumberParameter(Flex, child.parameters) === 1.0
          );
     let addConstraints = (index, child: Types.layer) => {
       let childSizingRules = child |> Layer.getSizingRules(Some(layer));
@@ -282,7 +282,7 @@ let getConstraints = (getRootLayerForComponentName, rootLayer: Types.layer) => {
         };
       let secondaryConstraints =
         switch (
-          Layer.getStringParameterOpt(AlignItems, layer),
+          Layer.getStringParameterOpt(AlignItems, layer.parameters),
           childSecondarySizingRule,
         ) {
         /* Fixed children don't need either side of the secondary axis anchored to the parent.

--- a/examples/generated/test/appkit/components/NestedBottomLeftLayout.swift
+++ b/examples/generated/test/appkit/components/NestedBottomLeftLayout.swift
@@ -1,0 +1,71 @@
+import AppKit
+import Foundation
+
+// MARK: - NestedBottomLeftLayout
+
+public class NestedBottomLeftLayout: NSBox {
+
+  // MARK: Lifecycle
+
+  public init() {
+    super.init(frame: .zero)
+
+    setUpViews()
+    setUpConstraints()
+
+    update()
+  }
+
+  public required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: Private
+
+  private var view1View = NSBox()
+  private var localAssetView = LocalAsset()
+
+  private func setUpViews() {
+    boxType = .custom
+    borderType = .noBorder
+    contentViewMargins = .zero
+    view1View.boxType = .custom
+    view1View.borderType = .noBorder
+    view1View.contentViewMargins = .zero
+
+    addSubview(view1View)
+    view1View.addSubview(localAssetView)
+
+    view1View.fillColor = Colors.red100
+  }
+
+  private func setUpConstraints() {
+    translatesAutoresizingMaskIntoConstraints = false
+    view1View.translatesAutoresizingMaskIntoConstraints = false
+    localAssetView.translatesAutoresizingMaskIntoConstraints = false
+
+    let view1ViewTopAnchorConstraint = view1View.topAnchor.constraint(equalTo: topAnchor)
+    let view1ViewBottomAnchorConstraint = view1View.bottomAnchor.constraint(equalTo: bottomAnchor)
+    let view1ViewLeadingAnchorConstraint = view1View.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let view1ViewHeightAnchorConstraint = view1View.heightAnchor.constraint(equalToConstant: 150)
+    let view1ViewWidthAnchorConstraint = view1View.widthAnchor.constraint(equalToConstant: 150)
+    let localAssetViewLeadingAnchorConstraint = localAssetView
+      .leadingAnchor
+      .constraint(equalTo: view1View.leadingAnchor)
+    let localAssetViewTopAnchorConstraint = localAssetView.topAnchor.constraint(equalTo: view1View.topAnchor)
+    let localAssetViewBottomAnchorConstraint = localAssetView.bottomAnchor.constraint(equalTo: view1View.bottomAnchor)
+
+    NSLayoutConstraint.activate([
+      view1ViewTopAnchorConstraint,
+      view1ViewBottomAnchorConstraint,
+      view1ViewLeadingAnchorConstraint,
+      view1ViewHeightAnchorConstraint,
+      view1ViewWidthAnchorConstraint,
+      localAssetViewLeadingAnchorConstraint,
+      localAssetViewTopAnchorConstraint,
+      localAssetViewBottomAnchorConstraint
+    ])
+  }
+
+  private func update() {}
+}

--- a/examples/generated/test/appkit/components/NestedComponent.swift
+++ b/examples/generated/test/appkit/components/NestedComponent.swift
@@ -88,7 +88,7 @@ public class NestedComponent: NSBox {
       .constraint(equalTo: leadingAnchor, constant: 10)
     let localAssetViewTrailingAnchorConstraint = localAssetView
       .trailingAnchor
-      .constraint(equalTo: trailingAnchor, constant: -10)
+      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -10)
     let text2ViewBottomAnchorConstraint = text2View.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -10)
     let text2ViewTopAnchorConstraint = text2View.topAnchor.constraint(equalTo: localAssetView.bottomAnchor)
     let text2ViewLeadingAnchorConstraint = text2View.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10)

--- a/examples/generated/test/appkit/components/NestedLayout.swift
+++ b/examples/generated/test/appkit/components/NestedLayout.swift
@@ -1,0 +1,726 @@
+import AppKit
+import Foundation
+
+// MARK: - NestedLayout
+
+public class NestedLayout: NSBox {
+
+  // MARK: Lifecycle
+
+  public init() {
+    super.init(frame: .zero)
+
+    setUpViews()
+    setUpConstraints()
+
+    update()
+  }
+
+  public required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: Private
+
+  private var topRowView = NSBox()
+  private var column1View = NSBox()
+  private var view1View = NSBox()
+  private var localAssetView = LocalAsset()
+  private var view2View = NSBox()
+  private var localAsset2View = LocalAsset()
+  private var view3View = NSBox()
+  private var localAsset3View = LocalAsset()
+  private var column2View = NSBox()
+  private var view4View = NSBox()
+  private var localAsset4View = LocalAsset()
+  private var view5View = NSBox()
+  private var localAsset5View = LocalAsset()
+  private var view6View = NSBox()
+  private var localAsset6View = LocalAsset()
+  private var column3View = NSBox()
+  private var view7View = NSBox()
+  private var localAsset7View = LocalAsset()
+  private var view8View = NSBox()
+  private var localAsset8View = LocalAsset()
+  private var view9View = NSBox()
+  private var localAsset9View = LocalAsset()
+  private var bottomRowView = NSBox()
+  private var column4View = NSBox()
+  private var view10View = NSBox()
+  private var localAsset10View = LocalAsset()
+  private var view11View = NSBox()
+  private var localAsset11View = LocalAsset()
+  private var view12View = NSBox()
+  private var localAsset12View = LocalAsset()
+  private var column5View = NSBox()
+  private var view13View = NSBox()
+  private var localAsset13View = LocalAsset()
+  private var view14View = NSBox()
+  private var localAsset14View = LocalAsset()
+  private var view15View = NSBox()
+  private var localAsset15View = LocalAsset()
+  private var column6View = NSBox()
+  private var view16View = NSBox()
+  private var localAsset16View = LocalAsset()
+  private var view17View = NSBox()
+  private var localAsset17View = LocalAsset()
+  private var view18View = NSBox()
+  private var localAsset18View = LocalAsset()
+
+  private func setUpViews() {
+    boxType = .custom
+    borderType = .noBorder
+    contentViewMargins = .zero
+    topRowView.boxType = .custom
+    topRowView.borderType = .noBorder
+    topRowView.contentViewMargins = .zero
+    bottomRowView.boxType = .custom
+    bottomRowView.borderType = .noBorder
+    bottomRowView.contentViewMargins = .zero
+    column1View.boxType = .custom
+    column1View.borderType = .noBorder
+    column1View.contentViewMargins = .zero
+    column2View.boxType = .custom
+    column2View.borderType = .noBorder
+    column2View.contentViewMargins = .zero
+    column3View.boxType = .custom
+    column3View.borderType = .noBorder
+    column3View.contentViewMargins = .zero
+    view1View.boxType = .custom
+    view1View.borderType = .noBorder
+    view1View.contentViewMargins = .zero
+    view2View.boxType = .custom
+    view2View.borderType = .noBorder
+    view2View.contentViewMargins = .zero
+    view3View.boxType = .custom
+    view3View.borderType = .noBorder
+    view3View.contentViewMargins = .zero
+    view4View.boxType = .custom
+    view4View.borderType = .noBorder
+    view4View.contentViewMargins = .zero
+    view5View.boxType = .custom
+    view5View.borderType = .noBorder
+    view5View.contentViewMargins = .zero
+    view6View.boxType = .custom
+    view6View.borderType = .noBorder
+    view6View.contentViewMargins = .zero
+    view7View.boxType = .custom
+    view7View.borderType = .noBorder
+    view7View.contentViewMargins = .zero
+    view8View.boxType = .custom
+    view8View.borderType = .noBorder
+    view8View.contentViewMargins = .zero
+    view9View.boxType = .custom
+    view9View.borderType = .noBorder
+    view9View.contentViewMargins = .zero
+    column4View.boxType = .custom
+    column4View.borderType = .noBorder
+    column4View.contentViewMargins = .zero
+    column5View.boxType = .custom
+    column5View.borderType = .noBorder
+    column5View.contentViewMargins = .zero
+    column6View.boxType = .custom
+    column6View.borderType = .noBorder
+    column6View.contentViewMargins = .zero
+    view10View.boxType = .custom
+    view10View.borderType = .noBorder
+    view10View.contentViewMargins = .zero
+    view11View.boxType = .custom
+    view11View.borderType = .noBorder
+    view11View.contentViewMargins = .zero
+    view12View.boxType = .custom
+    view12View.borderType = .noBorder
+    view12View.contentViewMargins = .zero
+    view13View.boxType = .custom
+    view13View.borderType = .noBorder
+    view13View.contentViewMargins = .zero
+    view14View.boxType = .custom
+    view14View.borderType = .noBorder
+    view14View.contentViewMargins = .zero
+    view15View.boxType = .custom
+    view15View.borderType = .noBorder
+    view15View.contentViewMargins = .zero
+    view16View.boxType = .custom
+    view16View.borderType = .noBorder
+    view16View.contentViewMargins = .zero
+    view17View.boxType = .custom
+    view17View.borderType = .noBorder
+    view17View.contentViewMargins = .zero
+    view18View.boxType = .custom
+    view18View.borderType = .noBorder
+    view18View.contentViewMargins = .zero
+
+    addSubview(topRowView)
+    addSubview(bottomRowView)
+    topRowView.addSubview(column1View)
+    topRowView.addSubview(column2View)
+    topRowView.addSubview(column3View)
+    column1View.addSubview(view1View)
+    column1View.addSubview(view2View)
+    column1View.addSubview(view3View)
+    view1View.addSubview(localAssetView)
+    view2View.addSubview(localAsset2View)
+    view3View.addSubview(localAsset3View)
+    column2View.addSubview(view4View)
+    column2View.addSubview(view5View)
+    column2View.addSubview(view6View)
+    view4View.addSubview(localAsset4View)
+    view5View.addSubview(localAsset5View)
+    view6View.addSubview(localAsset6View)
+    column3View.addSubview(view7View)
+    column3View.addSubview(view8View)
+    column3View.addSubview(view9View)
+    view7View.addSubview(localAsset7View)
+    view8View.addSubview(localAsset8View)
+    view9View.addSubview(localAsset9View)
+    bottomRowView.addSubview(column4View)
+    bottomRowView.addSubview(column5View)
+    bottomRowView.addSubview(column6View)
+    column4View.addSubview(view10View)
+    column4View.addSubview(view11View)
+    column4View.addSubview(view12View)
+    view10View.addSubview(localAsset10View)
+    view11View.addSubview(localAsset11View)
+    view12View.addSubview(localAsset12View)
+    column5View.addSubview(view13View)
+    column5View.addSubview(view14View)
+    column5View.addSubview(view15View)
+    view13View.addSubview(localAsset13View)
+    view14View.addSubview(localAsset14View)
+    view15View.addSubview(localAsset15View)
+    column6View.addSubview(view16View)
+    column6View.addSubview(view17View)
+    column6View.addSubview(view18View)
+    view16View.addSubview(localAsset16View)
+    view17View.addSubview(localAsset17View)
+    view18View.addSubview(localAsset18View)
+
+    view1View.fillColor = Colors.grey50
+    view2View.fillColor = #colorLiteral(red: 0, green: 0, blue: 0, alpha: 0)
+    view3View.fillColor = Colors.grey50
+    view5View.fillColor = Colors.grey50
+    view7View.fillColor = Colors.grey50
+    view9View.fillColor = Colors.grey50
+    view10View.fillColor = Colors.grey50
+    view11View.fillColor = #colorLiteral(red: 0, green: 0, blue: 0, alpha: 0)
+    view12View.fillColor = Colors.grey50
+    view14View.fillColor = Colors.grey50
+    view16View.fillColor = Colors.grey50
+    view18View.fillColor = Colors.grey50
+  }
+
+  private func setUpConstraints() {
+    translatesAutoresizingMaskIntoConstraints = false
+    topRowView.translatesAutoresizingMaskIntoConstraints = false
+    bottomRowView.translatesAutoresizingMaskIntoConstraints = false
+    column1View.translatesAutoresizingMaskIntoConstraints = false
+    column2View.translatesAutoresizingMaskIntoConstraints = false
+    column3View.translatesAutoresizingMaskIntoConstraints = false
+    view1View.translatesAutoresizingMaskIntoConstraints = false
+    view2View.translatesAutoresizingMaskIntoConstraints = false
+    view3View.translatesAutoresizingMaskIntoConstraints = false
+    localAssetView.translatesAutoresizingMaskIntoConstraints = false
+    localAsset2View.translatesAutoresizingMaskIntoConstraints = false
+    localAsset3View.translatesAutoresizingMaskIntoConstraints = false
+    view4View.translatesAutoresizingMaskIntoConstraints = false
+    view5View.translatesAutoresizingMaskIntoConstraints = false
+    view6View.translatesAutoresizingMaskIntoConstraints = false
+    localAsset4View.translatesAutoresizingMaskIntoConstraints = false
+    localAsset5View.translatesAutoresizingMaskIntoConstraints = false
+    localAsset6View.translatesAutoresizingMaskIntoConstraints = false
+    view7View.translatesAutoresizingMaskIntoConstraints = false
+    view8View.translatesAutoresizingMaskIntoConstraints = false
+    view9View.translatesAutoresizingMaskIntoConstraints = false
+    localAsset7View.translatesAutoresizingMaskIntoConstraints = false
+    localAsset8View.translatesAutoresizingMaskIntoConstraints = false
+    localAsset9View.translatesAutoresizingMaskIntoConstraints = false
+    column4View.translatesAutoresizingMaskIntoConstraints = false
+    column5View.translatesAutoresizingMaskIntoConstraints = false
+    column6View.translatesAutoresizingMaskIntoConstraints = false
+    view10View.translatesAutoresizingMaskIntoConstraints = false
+    view11View.translatesAutoresizingMaskIntoConstraints = false
+    view12View.translatesAutoresizingMaskIntoConstraints = false
+    localAsset10View.translatesAutoresizingMaskIntoConstraints = false
+    localAsset11View.translatesAutoresizingMaskIntoConstraints = false
+    localAsset12View.translatesAutoresizingMaskIntoConstraints = false
+    view13View.translatesAutoresizingMaskIntoConstraints = false
+    view14View.translatesAutoresizingMaskIntoConstraints = false
+    view15View.translatesAutoresizingMaskIntoConstraints = false
+    localAsset13View.translatesAutoresizingMaskIntoConstraints = false
+    localAsset14View.translatesAutoresizingMaskIntoConstraints = false
+    localAsset15View.translatesAutoresizingMaskIntoConstraints = false
+    view16View.translatesAutoresizingMaskIntoConstraints = false
+    view17View.translatesAutoresizingMaskIntoConstraints = false
+    view18View.translatesAutoresizingMaskIntoConstraints = false
+    localAsset16View.translatesAutoresizingMaskIntoConstraints = false
+    localAsset17View.translatesAutoresizingMaskIntoConstraints = false
+    localAsset18View.translatesAutoresizingMaskIntoConstraints = false
+
+    let topRowViewTopAnchorConstraint = topRowView.topAnchor.constraint(equalTo: topAnchor)
+    let topRowViewLeadingAnchorConstraint = topRowView.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let topRowViewTrailingAnchorConstraint = topRowView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor)
+    let bottomRowViewBottomAnchorConstraint = bottomRowView.bottomAnchor.constraint(equalTo: bottomAnchor)
+    let bottomRowViewTopAnchorConstraint = bottomRowView.topAnchor.constraint(equalTo: topRowView.bottomAnchor)
+    let bottomRowViewLeadingAnchorConstraint = bottomRowView.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let bottomRowViewTrailingAnchorConstraint = bottomRowView
+      .trailingAnchor
+      .constraint(lessThanOrEqualTo: trailingAnchor)
+    let column1ViewHeightAnchorParentConstraint = column1View
+      .heightAnchor
+      .constraint(lessThanOrEqualTo: topRowView.heightAnchor)
+    let column2ViewHeightAnchorParentConstraint = column2View
+      .heightAnchor
+      .constraint(lessThanOrEqualTo: topRowView.heightAnchor)
+    let column3ViewHeightAnchorParentConstraint = column3View
+      .heightAnchor
+      .constraint(lessThanOrEqualTo: topRowView.heightAnchor)
+    let column1ViewLeadingAnchorConstraint = column1View.leadingAnchor.constraint(equalTo: topRowView.leadingAnchor)
+    let column1ViewTopAnchorConstraint = column1View.topAnchor.constraint(equalTo: topRowView.topAnchor)
+    let column1ViewBottomAnchorConstraint = column1View.bottomAnchor.constraint(equalTo: topRowView.bottomAnchor)
+    let column2ViewLeadingAnchorConstraint = column2View.leadingAnchor.constraint(equalTo: column1View.trailingAnchor)
+    let column2ViewTopAnchorConstraint = column2View.topAnchor.constraint(equalTo: topRowView.topAnchor)
+    let column2ViewBottomAnchorConstraint = column2View.bottomAnchor.constraint(equalTo: topRowView.bottomAnchor)
+    let column3ViewTrailingAnchorConstraint = column3View.trailingAnchor.constraint(equalTo: topRowView.trailingAnchor)
+    let column3ViewLeadingAnchorConstraint = column3View.leadingAnchor.constraint(equalTo: column2View.trailingAnchor)
+    let column3ViewTopAnchorConstraint = column3View.topAnchor.constraint(equalTo: topRowView.topAnchor)
+    let column3ViewBottomAnchorConstraint = column3View.bottomAnchor.constraint(equalTo: topRowView.bottomAnchor)
+    let column4ViewHeightAnchorParentConstraint = column4View
+      .heightAnchor
+      .constraint(lessThanOrEqualTo: bottomRowView.heightAnchor)
+    let column5ViewHeightAnchorParentConstraint = column5View
+      .heightAnchor
+      .constraint(lessThanOrEqualTo: bottomRowView.heightAnchor)
+    let column6ViewHeightAnchorParentConstraint = column6View
+      .heightAnchor
+      .constraint(lessThanOrEqualTo: bottomRowView.heightAnchor)
+    let column4ViewLeadingAnchorConstraint = column4View.leadingAnchor.constraint(equalTo: bottomRowView.leadingAnchor)
+    let column4ViewTopAnchorConstraint = column4View.topAnchor.constraint(equalTo: bottomRowView.topAnchor)
+    let column4ViewBottomAnchorConstraint = column4View.bottomAnchor.constraint(equalTo: bottomRowView.bottomAnchor)
+    let column5ViewLeadingAnchorConstraint = column5View.leadingAnchor.constraint(equalTo: column4View.trailingAnchor)
+    let column5ViewTopAnchorConstraint = column5View.topAnchor.constraint(equalTo: bottomRowView.topAnchor)
+    let column5ViewBottomAnchorConstraint = column5View.bottomAnchor.constraint(equalTo: bottomRowView.bottomAnchor)
+    let column6ViewTrailingAnchorConstraint = column6View
+      .trailingAnchor
+      .constraint(equalTo: bottomRowView.trailingAnchor)
+    let column6ViewLeadingAnchorConstraint = column6View.leadingAnchor.constraint(equalTo: column5View.trailingAnchor)
+    let column6ViewTopAnchorConstraint = column6View.topAnchor.constraint(equalTo: bottomRowView.topAnchor)
+    let column6ViewBottomAnchorConstraint = column6View.bottomAnchor.constraint(equalTo: bottomRowView.bottomAnchor)
+    let column1ViewWidthAnchorConstraint = column1View.widthAnchor.constraint(equalToConstant: 150)
+    let view1ViewTopAnchorConstraint = view1View.topAnchor.constraint(equalTo: column1View.topAnchor)
+    let view1ViewLeadingAnchorConstraint = view1View.leadingAnchor.constraint(equalTo: column1View.leadingAnchor)
+    let view2ViewTopAnchorConstraint = view2View.topAnchor.constraint(equalTo: view1View.bottomAnchor)
+    let view2ViewLeadingAnchorConstraint = view2View.leadingAnchor.constraint(equalTo: column1View.leadingAnchor)
+    let view3ViewBottomAnchorConstraint = view3View.bottomAnchor.constraint(equalTo: column1View.bottomAnchor)
+    let view3ViewTopAnchorConstraint = view3View.topAnchor.constraint(equalTo: view2View.bottomAnchor)
+    let view3ViewLeadingAnchorConstraint = view3View.leadingAnchor.constraint(equalTo: column1View.leadingAnchor)
+    let column2ViewWidthAnchorConstraint = column2View.widthAnchor.constraint(equalToConstant: 150)
+    let view4ViewTopAnchorConstraint = view4View.topAnchor.constraint(equalTo: column2View.topAnchor)
+    let view4ViewLeadingAnchorConstraint = view4View.leadingAnchor.constraint(equalTo: column2View.leadingAnchor)
+    let view5ViewTopAnchorConstraint = view5View.topAnchor.constraint(equalTo: view4View.bottomAnchor)
+    let view5ViewLeadingAnchorConstraint = view5View.leadingAnchor.constraint(equalTo: column2View.leadingAnchor)
+    let view6ViewBottomAnchorConstraint = view6View.bottomAnchor.constraint(equalTo: column2View.bottomAnchor)
+    let view6ViewTopAnchorConstraint = view6View.topAnchor.constraint(equalTo: view5View.bottomAnchor)
+    let view6ViewLeadingAnchorConstraint = view6View.leadingAnchor.constraint(equalTo: column2View.leadingAnchor)
+    let column3ViewWidthAnchorConstraint = column3View.widthAnchor.constraint(equalToConstant: 150)
+    let view7ViewTopAnchorConstraint = view7View.topAnchor.constraint(equalTo: column3View.topAnchor)
+    let view7ViewLeadingAnchorConstraint = view7View.leadingAnchor.constraint(equalTo: column3View.leadingAnchor)
+    let view8ViewTopAnchorConstraint = view8View.topAnchor.constraint(equalTo: view7View.bottomAnchor)
+    let view8ViewLeadingAnchorConstraint = view8View.leadingAnchor.constraint(equalTo: column3View.leadingAnchor)
+    let view9ViewBottomAnchorConstraint = view9View.bottomAnchor.constraint(equalTo: column3View.bottomAnchor)
+    let view9ViewTopAnchorConstraint = view9View.topAnchor.constraint(equalTo: view8View.bottomAnchor)
+    let view9ViewLeadingAnchorConstraint = view9View.leadingAnchor.constraint(equalTo: column3View.leadingAnchor)
+    let view1ViewHeightAnchorConstraint = view1View.heightAnchor.constraint(equalToConstant: 150)
+    let view1ViewWidthAnchorConstraint = view1View.widthAnchor.constraint(equalToConstant: 150)
+    let localAssetViewTopAnchorConstraint = localAssetView.topAnchor.constraint(equalTo: view1View.topAnchor)
+    let localAssetViewLeadingAnchorConstraint = localAssetView
+      .leadingAnchor
+      .constraint(equalTo: view1View.leadingAnchor)
+    let localAssetViewTrailingAnchorConstraint = localAssetView
+      .trailingAnchor
+      .constraint(equalTo: view1View.trailingAnchor)
+    let view2ViewHeightAnchorConstraint = view2View.heightAnchor.constraint(equalToConstant: 150)
+    let view2ViewWidthAnchorConstraint = view2View.widthAnchor.constraint(equalToConstant: 150)
+    let localAsset2ViewTopAnchorConstraint = localAsset2View.topAnchor.constraint(equalTo: view2View.topAnchor)
+    let localAsset2ViewLeadingAnchorConstraint = localAsset2View
+      .leadingAnchor
+      .constraint(equalTo: view2View.leadingAnchor)
+    let localAsset2ViewTrailingAnchorConstraint = localAsset2View
+      .trailingAnchor
+      .constraint(equalTo: view2View.trailingAnchor)
+    let view3ViewHeightAnchorConstraint = view3View.heightAnchor.constraint(equalToConstant: 150)
+    let view3ViewWidthAnchorConstraint = view3View.widthAnchor.constraint(equalToConstant: 150)
+    let localAsset3ViewTopAnchorConstraint = localAsset3View.topAnchor.constraint(equalTo: view3View.topAnchor)
+    let localAsset3ViewLeadingAnchorConstraint = localAsset3View
+      .leadingAnchor
+      .constraint(equalTo: view3View.leadingAnchor)
+    let localAsset3ViewTrailingAnchorConstraint = localAsset3View
+      .trailingAnchor
+      .constraint(equalTo: view3View.trailingAnchor)
+    let view4ViewHeightAnchorConstraint = view4View.heightAnchor.constraint(equalToConstant: 150)
+    let view4ViewWidthAnchorConstraint = view4View.widthAnchor.constraint(equalToConstant: 150)
+    let localAsset4ViewTopAnchorConstraint = localAsset4View.topAnchor.constraint(equalTo: view4View.topAnchor)
+    let localAsset4ViewLeadingAnchorConstraint = localAsset4View
+      .leadingAnchor
+      .constraint(equalTo: view4View.leadingAnchor)
+    let localAsset4ViewCenterXAnchorConstraint = localAsset4View
+      .centerXAnchor
+      .constraint(equalTo: view4View.centerXAnchor)
+    let localAsset4ViewTrailingAnchorConstraint = localAsset4View
+      .trailingAnchor
+      .constraint(equalTo: view4View.trailingAnchor)
+    let view5ViewHeightAnchorConstraint = view5View.heightAnchor.constraint(equalToConstant: 150)
+    let view5ViewWidthAnchorConstraint = view5View.widthAnchor.constraint(equalToConstant: 150)
+    let localAsset5ViewTopAnchorConstraint = localAsset5View.topAnchor.constraint(equalTo: view5View.topAnchor)
+    let localAsset5ViewLeadingAnchorConstraint = localAsset5View
+      .leadingAnchor
+      .constraint(equalTo: view5View.leadingAnchor)
+    let localAsset5ViewCenterXAnchorConstraint = localAsset5View
+      .centerXAnchor
+      .constraint(equalTo: view5View.centerXAnchor)
+    let localAsset5ViewTrailingAnchorConstraint = localAsset5View
+      .trailingAnchor
+      .constraint(equalTo: view5View.trailingAnchor)
+    let view6ViewHeightAnchorConstraint = view6View.heightAnchor.constraint(equalToConstant: 150)
+    let view6ViewWidthAnchorConstraint = view6View.widthAnchor.constraint(equalToConstant: 150)
+    let localAsset6ViewTopAnchorConstraint = localAsset6View.topAnchor.constraint(equalTo: view6View.topAnchor)
+    let localAsset6ViewLeadingAnchorConstraint = localAsset6View
+      .leadingAnchor
+      .constraint(equalTo: view6View.leadingAnchor)
+    let localAsset6ViewCenterXAnchorConstraint = localAsset6View
+      .centerXAnchor
+      .constraint(equalTo: view6View.centerXAnchor)
+    let localAsset6ViewTrailingAnchorConstraint = localAsset6View
+      .trailingAnchor
+      .constraint(equalTo: view6View.trailingAnchor)
+    let view7ViewHeightAnchorConstraint = view7View.heightAnchor.constraint(equalToConstant: 150)
+    let view7ViewWidthAnchorConstraint = view7View.widthAnchor.constraint(equalToConstant: 150)
+    let localAsset7ViewTopAnchorConstraint = localAsset7View.topAnchor.constraint(equalTo: view7View.topAnchor)
+    let localAsset7ViewLeadingAnchorConstraint = localAsset7View
+      .leadingAnchor
+      .constraint(equalTo: view7View.leadingAnchor)
+    let localAsset7ViewTrailingAnchorConstraint = localAsset7View
+      .trailingAnchor
+      .constraint(equalTo: view7View.trailingAnchor)
+    let view8ViewHeightAnchorConstraint = view8View.heightAnchor.constraint(equalToConstant: 150)
+    let view8ViewWidthAnchorConstraint = view8View.widthAnchor.constraint(equalToConstant: 150)
+    let localAsset8ViewTopAnchorConstraint = localAsset8View.topAnchor.constraint(equalTo: view8View.topAnchor)
+    let localAsset8ViewLeadingAnchorConstraint = localAsset8View
+      .leadingAnchor
+      .constraint(equalTo: view8View.leadingAnchor)
+    let localAsset8ViewTrailingAnchorConstraint = localAsset8View
+      .trailingAnchor
+      .constraint(equalTo: view8View.trailingAnchor)
+    let view9ViewHeightAnchorConstraint = view9View.heightAnchor.constraint(equalToConstant: 150)
+    let view9ViewWidthAnchorConstraint = view9View.widthAnchor.constraint(equalToConstant: 150)
+    let localAsset9ViewTopAnchorConstraint = localAsset9View.topAnchor.constraint(equalTo: view9View.topAnchor)
+    let localAsset9ViewLeadingAnchorConstraint = localAsset9View
+      .leadingAnchor
+      .constraint(equalTo: view9View.leadingAnchor)
+    let localAsset9ViewTrailingAnchorConstraint = localAsset9View
+      .trailingAnchor
+      .constraint(equalTo: view9View.trailingAnchor)
+    let column4ViewWidthAnchorConstraint = column4View.widthAnchor.constraint(equalToConstant: 150)
+    let view10ViewTopAnchorConstraint = view10View.topAnchor.constraint(equalTo: column4View.topAnchor)
+    let view10ViewLeadingAnchorConstraint = view10View.leadingAnchor.constraint(equalTo: column4View.leadingAnchor)
+    let view11ViewTopAnchorConstraint = view11View.topAnchor.constraint(equalTo: view10View.bottomAnchor)
+    let view11ViewLeadingAnchorConstraint = view11View.leadingAnchor.constraint(equalTo: column4View.leadingAnchor)
+    let view12ViewBottomAnchorConstraint = view12View.bottomAnchor.constraint(equalTo: column4View.bottomAnchor)
+    let view12ViewTopAnchorConstraint = view12View.topAnchor.constraint(equalTo: view11View.bottomAnchor)
+    let view12ViewLeadingAnchorConstraint = view12View.leadingAnchor.constraint(equalTo: column4View.leadingAnchor)
+    let column5ViewWidthAnchorConstraint = column5View.widthAnchor.constraint(equalToConstant: 150)
+    let view13ViewTopAnchorConstraint = view13View.topAnchor.constraint(equalTo: column5View.topAnchor)
+    let view13ViewLeadingAnchorConstraint = view13View.leadingAnchor.constraint(equalTo: column5View.leadingAnchor)
+    let view14ViewTopAnchorConstraint = view14View.topAnchor.constraint(equalTo: view13View.bottomAnchor)
+    let view14ViewLeadingAnchorConstraint = view14View.leadingAnchor.constraint(equalTo: column5View.leadingAnchor)
+    let view15ViewBottomAnchorConstraint = view15View.bottomAnchor.constraint(equalTo: column5View.bottomAnchor)
+    let view15ViewTopAnchorConstraint = view15View.topAnchor.constraint(equalTo: view14View.bottomAnchor)
+    let view15ViewLeadingAnchorConstraint = view15View.leadingAnchor.constraint(equalTo: column5View.leadingAnchor)
+    let column6ViewWidthAnchorConstraint = column6View.widthAnchor.constraint(equalToConstant: 150)
+    let view16ViewTopAnchorConstraint = view16View.topAnchor.constraint(equalTo: column6View.topAnchor)
+    let view16ViewLeadingAnchorConstraint = view16View.leadingAnchor.constraint(equalTo: column6View.leadingAnchor)
+    let view17ViewTopAnchorConstraint = view17View.topAnchor.constraint(equalTo: view16View.bottomAnchor)
+    let view17ViewLeadingAnchorConstraint = view17View.leadingAnchor.constraint(equalTo: column6View.leadingAnchor)
+    let view18ViewBottomAnchorConstraint = view18View.bottomAnchor.constraint(equalTo: column6View.bottomAnchor)
+    let view18ViewTopAnchorConstraint = view18View.topAnchor.constraint(equalTo: view17View.bottomAnchor)
+    let view18ViewLeadingAnchorConstraint = view18View.leadingAnchor.constraint(equalTo: column6View.leadingAnchor)
+    let view10ViewHeightAnchorConstraint = view10View.heightAnchor.constraint(equalToConstant: 150)
+    let view10ViewWidthAnchorConstraint = view10View.widthAnchor.constraint(equalToConstant: 150)
+    let localAsset10ViewLeadingAnchorConstraint = localAsset10View
+      .leadingAnchor
+      .constraint(equalTo: view10View.leadingAnchor)
+    let localAsset10ViewTopAnchorConstraint = localAsset10View.topAnchor.constraint(equalTo: view10View.topAnchor)
+    let localAsset10ViewBottomAnchorConstraint = localAsset10View
+      .bottomAnchor
+      .constraint(equalTo: view10View.bottomAnchor)
+    let view11ViewHeightAnchorConstraint = view11View.heightAnchor.constraint(equalToConstant: 150)
+    let view11ViewWidthAnchorConstraint = view11View.widthAnchor.constraint(equalToConstant: 150)
+    let localAsset11ViewLeadingAnchorConstraint = localAsset11View
+      .leadingAnchor
+      .constraint(equalTo: view11View.leadingAnchor)
+    let localAsset11ViewTopAnchorConstraint = localAsset11View.topAnchor.constraint(equalTo: view11View.topAnchor)
+    let localAsset11ViewCenterYAnchorConstraint = localAsset11View
+      .centerYAnchor
+      .constraint(equalTo: view11View.centerYAnchor)
+    let localAsset11ViewBottomAnchorConstraint = localAsset11View
+      .bottomAnchor
+      .constraint(equalTo: view11View.bottomAnchor)
+    let view12ViewHeightAnchorConstraint = view12View.heightAnchor.constraint(equalToConstant: 150)
+    let view12ViewWidthAnchorConstraint = view12View.widthAnchor.constraint(equalToConstant: 150)
+    let localAsset12ViewLeadingAnchorConstraint = localAsset12View
+      .leadingAnchor
+      .constraint(equalTo: view12View.leadingAnchor)
+    let localAsset12ViewTopAnchorConstraint = localAsset12View.topAnchor.constraint(equalTo: view12View.topAnchor)
+    let localAsset12ViewBottomAnchorConstraint = localAsset12View
+      .bottomAnchor
+      .constraint(equalTo: view12View.bottomAnchor)
+    let view13ViewHeightAnchorConstraint = view13View.heightAnchor.constraint(equalToConstant: 150)
+    let view13ViewWidthAnchorConstraint = view13View.widthAnchor.constraint(equalToConstant: 150)
+    let localAsset13ViewLeadingAnchorConstraint = localAsset13View
+      .leadingAnchor
+      .constraint(equalTo: view13View.leadingAnchor)
+    let localAsset13ViewTopAnchorConstraint = localAsset13View.topAnchor.constraint(equalTo: view13View.topAnchor)
+    let localAsset13ViewBottomAnchorConstraint = localAsset13View
+      .bottomAnchor
+      .constraint(equalTo: view13View.bottomAnchor)
+    let view14ViewHeightAnchorConstraint = view14View.heightAnchor.constraint(equalToConstant: 150)
+    let view14ViewWidthAnchorConstraint = view14View.widthAnchor.constraint(equalToConstant: 150)
+    let localAsset14ViewLeadingAnchorConstraint = localAsset14View
+      .leadingAnchor
+      .constraint(equalTo: view14View.leadingAnchor)
+    let localAsset14ViewTopAnchorConstraint = localAsset14View.topAnchor.constraint(equalTo: view14View.topAnchor)
+    let localAsset14ViewCenterYAnchorConstraint = localAsset14View
+      .centerYAnchor
+      .constraint(equalTo: view14View.centerYAnchor)
+    let localAsset14ViewBottomAnchorConstraint = localAsset14View
+      .bottomAnchor
+      .constraint(equalTo: view14View.bottomAnchor)
+    let view15ViewHeightAnchorConstraint = view15View.heightAnchor.constraint(equalToConstant: 150)
+    let view15ViewWidthAnchorConstraint = view15View.widthAnchor.constraint(equalToConstant: 150)
+    let localAsset15ViewLeadingAnchorConstraint = localAsset15View
+      .leadingAnchor
+      .constraint(equalTo: view15View.leadingAnchor)
+    let localAsset15ViewTopAnchorConstraint = localAsset15View.topAnchor.constraint(equalTo: view15View.topAnchor)
+    let localAsset15ViewBottomAnchorConstraint = localAsset15View
+      .bottomAnchor
+      .constraint(equalTo: view15View.bottomAnchor)
+    let view16ViewHeightAnchorConstraint = view16View.heightAnchor.constraint(equalToConstant: 150)
+    let view16ViewWidthAnchorConstraint = view16View.widthAnchor.constraint(equalToConstant: 150)
+    let localAsset16ViewLeadingAnchorConstraint = localAsset16View
+      .leadingAnchor
+      .constraint(equalTo: view16View.leadingAnchor)
+    let localAsset16ViewTopAnchorConstraint = localAsset16View.topAnchor.constraint(equalTo: view16View.topAnchor)
+    let localAsset16ViewBottomAnchorConstraint = localAsset16View
+      .bottomAnchor
+      .constraint(equalTo: view16View.bottomAnchor)
+    let view17ViewHeightAnchorConstraint = view17View.heightAnchor.constraint(equalToConstant: 150)
+    let view17ViewWidthAnchorConstraint = view17View.widthAnchor.constraint(equalToConstant: 150)
+    let localAsset17ViewLeadingAnchorConstraint = localAsset17View
+      .leadingAnchor
+      .constraint(equalTo: view17View.leadingAnchor)
+    let localAsset17ViewTopAnchorConstraint = localAsset17View.topAnchor.constraint(equalTo: view17View.topAnchor)
+    let localAsset17ViewCenterYAnchorConstraint = localAsset17View
+      .centerYAnchor
+      .constraint(equalTo: view17View.centerYAnchor)
+    let localAsset17ViewBottomAnchorConstraint = localAsset17View
+      .bottomAnchor
+      .constraint(equalTo: view17View.bottomAnchor)
+    let view18ViewHeightAnchorConstraint = view18View.heightAnchor.constraint(equalToConstant: 150)
+    let view18ViewWidthAnchorConstraint = view18View.widthAnchor.constraint(equalToConstant: 150)
+    let localAsset18ViewLeadingAnchorConstraint = localAsset18View
+      .leadingAnchor
+      .constraint(equalTo: view18View.leadingAnchor)
+    let localAsset18ViewTopAnchorConstraint = localAsset18View.topAnchor.constraint(equalTo: view18View.topAnchor)
+    let localAsset18ViewBottomAnchorConstraint = localAsset18View
+      .bottomAnchor
+      .constraint(equalTo: view18View.bottomAnchor)
+
+    column1ViewHeightAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
+    column2ViewHeightAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
+    column3ViewHeightAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
+    column4ViewHeightAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
+    column5ViewHeightAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
+    column6ViewHeightAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
+
+    NSLayoutConstraint.activate([
+      topRowViewTopAnchorConstraint,
+      topRowViewLeadingAnchorConstraint,
+      topRowViewTrailingAnchorConstraint,
+      bottomRowViewBottomAnchorConstraint,
+      bottomRowViewTopAnchorConstraint,
+      bottomRowViewLeadingAnchorConstraint,
+      bottomRowViewTrailingAnchorConstraint,
+      column1ViewHeightAnchorParentConstraint,
+      column2ViewHeightAnchorParentConstraint,
+      column3ViewHeightAnchorParentConstraint,
+      column1ViewLeadingAnchorConstraint,
+      column1ViewTopAnchorConstraint,
+      column1ViewBottomAnchorConstraint,
+      column2ViewLeadingAnchorConstraint,
+      column2ViewTopAnchorConstraint,
+      column2ViewBottomAnchorConstraint,
+      column3ViewTrailingAnchorConstraint,
+      column3ViewLeadingAnchorConstraint,
+      column3ViewTopAnchorConstraint,
+      column3ViewBottomAnchorConstraint,
+      column4ViewHeightAnchorParentConstraint,
+      column5ViewHeightAnchorParentConstraint,
+      column6ViewHeightAnchorParentConstraint,
+      column4ViewLeadingAnchorConstraint,
+      column4ViewTopAnchorConstraint,
+      column4ViewBottomAnchorConstraint,
+      column5ViewLeadingAnchorConstraint,
+      column5ViewTopAnchorConstraint,
+      column5ViewBottomAnchorConstraint,
+      column6ViewTrailingAnchorConstraint,
+      column6ViewLeadingAnchorConstraint,
+      column6ViewTopAnchorConstraint,
+      column6ViewBottomAnchorConstraint,
+      column1ViewWidthAnchorConstraint,
+      view1ViewTopAnchorConstraint,
+      view1ViewLeadingAnchorConstraint,
+      view2ViewTopAnchorConstraint,
+      view2ViewLeadingAnchorConstraint,
+      view3ViewBottomAnchorConstraint,
+      view3ViewTopAnchorConstraint,
+      view3ViewLeadingAnchorConstraint,
+      column2ViewWidthAnchorConstraint,
+      view4ViewTopAnchorConstraint,
+      view4ViewLeadingAnchorConstraint,
+      view5ViewTopAnchorConstraint,
+      view5ViewLeadingAnchorConstraint,
+      view6ViewBottomAnchorConstraint,
+      view6ViewTopAnchorConstraint,
+      view6ViewLeadingAnchorConstraint,
+      column3ViewWidthAnchorConstraint,
+      view7ViewTopAnchorConstraint,
+      view7ViewLeadingAnchorConstraint,
+      view8ViewTopAnchorConstraint,
+      view8ViewLeadingAnchorConstraint,
+      view9ViewBottomAnchorConstraint,
+      view9ViewTopAnchorConstraint,
+      view9ViewLeadingAnchorConstraint,
+      view1ViewHeightAnchorConstraint,
+      view1ViewWidthAnchorConstraint,
+      localAssetViewTopAnchorConstraint,
+      localAssetViewLeadingAnchorConstraint,
+      localAssetViewTrailingAnchorConstraint,
+      view2ViewHeightAnchorConstraint,
+      view2ViewWidthAnchorConstraint,
+      localAsset2ViewTopAnchorConstraint,
+      localAsset2ViewLeadingAnchorConstraint,
+      localAsset2ViewTrailingAnchorConstraint,
+      view3ViewHeightAnchorConstraint,
+      view3ViewWidthAnchorConstraint,
+      localAsset3ViewTopAnchorConstraint,
+      localAsset3ViewLeadingAnchorConstraint,
+      localAsset3ViewTrailingAnchorConstraint,
+      view4ViewHeightAnchorConstraint,
+      view4ViewWidthAnchorConstraint,
+      localAsset4ViewTopAnchorConstraint,
+      localAsset4ViewLeadingAnchorConstraint,
+      localAsset4ViewCenterXAnchorConstraint,
+      localAsset4ViewTrailingAnchorConstraint,
+      view5ViewHeightAnchorConstraint,
+      view5ViewWidthAnchorConstraint,
+      localAsset5ViewTopAnchorConstraint,
+      localAsset5ViewLeadingAnchorConstraint,
+      localAsset5ViewCenterXAnchorConstraint,
+      localAsset5ViewTrailingAnchorConstraint,
+      view6ViewHeightAnchorConstraint,
+      view6ViewWidthAnchorConstraint,
+      localAsset6ViewTopAnchorConstraint,
+      localAsset6ViewLeadingAnchorConstraint,
+      localAsset6ViewCenterXAnchorConstraint,
+      localAsset6ViewTrailingAnchorConstraint,
+      view7ViewHeightAnchorConstraint,
+      view7ViewWidthAnchorConstraint,
+      localAsset7ViewTopAnchorConstraint,
+      localAsset7ViewLeadingAnchorConstraint,
+      localAsset7ViewTrailingAnchorConstraint,
+      view8ViewHeightAnchorConstraint,
+      view8ViewWidthAnchorConstraint,
+      localAsset8ViewTopAnchorConstraint,
+      localAsset8ViewLeadingAnchorConstraint,
+      localAsset8ViewTrailingAnchorConstraint,
+      view9ViewHeightAnchorConstraint,
+      view9ViewWidthAnchorConstraint,
+      localAsset9ViewTopAnchorConstraint,
+      localAsset9ViewLeadingAnchorConstraint,
+      localAsset9ViewTrailingAnchorConstraint,
+      column4ViewWidthAnchorConstraint,
+      view10ViewTopAnchorConstraint,
+      view10ViewLeadingAnchorConstraint,
+      view11ViewTopAnchorConstraint,
+      view11ViewLeadingAnchorConstraint,
+      view12ViewBottomAnchorConstraint,
+      view12ViewTopAnchorConstraint,
+      view12ViewLeadingAnchorConstraint,
+      column5ViewWidthAnchorConstraint,
+      view13ViewTopAnchorConstraint,
+      view13ViewLeadingAnchorConstraint,
+      view14ViewTopAnchorConstraint,
+      view14ViewLeadingAnchorConstraint,
+      view15ViewBottomAnchorConstraint,
+      view15ViewTopAnchorConstraint,
+      view15ViewLeadingAnchorConstraint,
+      column6ViewWidthAnchorConstraint,
+      view16ViewTopAnchorConstraint,
+      view16ViewLeadingAnchorConstraint,
+      view17ViewTopAnchorConstraint,
+      view17ViewLeadingAnchorConstraint,
+      view18ViewBottomAnchorConstraint,
+      view18ViewTopAnchorConstraint,
+      view18ViewLeadingAnchorConstraint,
+      view10ViewHeightAnchorConstraint,
+      view10ViewWidthAnchorConstraint,
+      localAsset10ViewLeadingAnchorConstraint,
+      localAsset10ViewTopAnchorConstraint,
+      localAsset10ViewBottomAnchorConstraint,
+      view11ViewHeightAnchorConstraint,
+      view11ViewWidthAnchorConstraint,
+      localAsset11ViewLeadingAnchorConstraint,
+      localAsset11ViewTopAnchorConstraint,
+      localAsset11ViewCenterYAnchorConstraint,
+      localAsset11ViewBottomAnchorConstraint,
+      view12ViewHeightAnchorConstraint,
+      view12ViewWidthAnchorConstraint,
+      localAsset12ViewLeadingAnchorConstraint,
+      localAsset12ViewTopAnchorConstraint,
+      localAsset12ViewBottomAnchorConstraint,
+      view13ViewHeightAnchorConstraint,
+      view13ViewWidthAnchorConstraint,
+      localAsset13ViewLeadingAnchorConstraint,
+      localAsset13ViewTopAnchorConstraint,
+      localAsset13ViewBottomAnchorConstraint,
+      view14ViewHeightAnchorConstraint,
+      view14ViewWidthAnchorConstraint,
+      localAsset14ViewLeadingAnchorConstraint,
+      localAsset14ViewTopAnchorConstraint,
+      localAsset14ViewCenterYAnchorConstraint,
+      localAsset14ViewBottomAnchorConstraint,
+      view15ViewHeightAnchorConstraint,
+      view15ViewWidthAnchorConstraint,
+      localAsset15ViewLeadingAnchorConstraint,
+      localAsset15ViewTopAnchorConstraint,
+      localAsset15ViewBottomAnchorConstraint,
+      view16ViewHeightAnchorConstraint,
+      view16ViewWidthAnchorConstraint,
+      localAsset16ViewLeadingAnchorConstraint,
+      localAsset16ViewTopAnchorConstraint,
+      localAsset16ViewBottomAnchorConstraint,
+      view17ViewHeightAnchorConstraint,
+      view17ViewWidthAnchorConstraint,
+      localAsset17ViewLeadingAnchorConstraint,
+      localAsset17ViewTopAnchorConstraint,
+      localAsset17ViewCenterYAnchorConstraint,
+      localAsset17ViewBottomAnchorConstraint,
+      view18ViewHeightAnchorConstraint,
+      view18ViewWidthAnchorConstraint,
+      localAsset18ViewLeadingAnchorConstraint,
+      localAsset18ViewTopAnchorConstraint,
+      localAsset18ViewBottomAnchorConstraint
+    ])
+  }
+
+  private func update() {}
+}

--- a/examples/generated/test/appkit/images/LocalAsset.swift
+++ b/examples/generated/test/appkit/images/LocalAsset.swift
@@ -44,6 +44,7 @@ public class LocalAsset: NSBox {
 
     addSubview(imageView)
 
+    fillColor = Colors.red400
     imageView.image = #imageLiteral(resourceName: "icon_128x128")
     imageView.fillColor = #colorLiteral(red: 0.847058823529, green: 0.847058823529, blue: 0.847058823529, alpha: 1)
   }

--- a/examples/generated/test/appkit/images/LocalAsset.swift
+++ b/examples/generated/test/appkit/images/LocalAsset.swift
@@ -52,13 +52,17 @@ public class LocalAsset: NSBox {
     translatesAutoresizingMaskIntoConstraints = false
     imageView.translatesAutoresizingMaskIntoConstraints = false
 
+    let imageViewWidthAnchorParentConstraint = imageView.widthAnchor.constraint(lessThanOrEqualTo: widthAnchor)
     let imageViewTopAnchorConstraint = imageView.topAnchor.constraint(equalTo: topAnchor)
     let imageViewBottomAnchorConstraint = imageView.bottomAnchor.constraint(equalTo: bottomAnchor)
     let imageViewLeadingAnchorConstraint = imageView.leadingAnchor.constraint(equalTo: leadingAnchor)
     let imageViewHeightAnchorConstraint = imageView.heightAnchor.constraint(equalToConstant: 100)
     let imageViewWidthAnchorConstraint = imageView.widthAnchor.constraint(equalToConstant: 100)
 
+    imageViewWidthAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
+
     NSLayoutConstraint.activate([
+      imageViewWidthAnchorParentConstraint,
       imageViewTopAnchorConstraint,
       imageViewBottomAnchorConstraint,
       imageViewLeadingAnchorConstraint,

--- a/examples/generated/test/appkit/layouts/MultipleFlexText.swift
+++ b/examples/generated/test/appkit/layouts/MultipleFlexText.swift
@@ -1,0 +1,135 @@
+import AppKit
+import Foundation
+
+// MARK: - MultipleFlexText
+
+public class MultipleFlexText: NSBox {
+
+  // MARK: Lifecycle
+
+  public init() {
+    super.init(frame: .zero)
+
+    setUpViews()
+    setUpConstraints()
+
+    update()
+  }
+
+  public required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: Private
+
+  private var view1View = NSBox()
+  private var view3View = NSBox()
+  private var textView = NSTextField(labelWithString: "")
+  private var view2View = NSBox()
+  private var view4View = NSBox()
+  private var text1View = NSTextField(labelWithString: "")
+
+  private var textViewTextStyle = TextStyles.body1
+  private var text1ViewTextStyle = TextStyles.body1
+
+  private func setUpViews() {
+    boxType = .custom
+    borderType = .noBorder
+    contentViewMargins = .zero
+    view1View.boxType = .custom
+    view1View.borderType = .noBorder
+    view1View.contentViewMargins = .zero
+    view2View.boxType = .custom
+    view2View.borderType = .noBorder
+    view2View.contentViewMargins = .zero
+    view3View.boxType = .custom
+    view3View.borderType = .noBorder
+    view3View.contentViewMargins = .zero
+    textView.lineBreakMode = .byWordWrapping
+    view4View.boxType = .custom
+    view4View.borderType = .noBorder
+    view4View.contentViewMargins = .zero
+    text1View.lineBreakMode = .byWordWrapping
+
+    addSubview(view1View)
+    addSubview(view2View)
+    view1View.addSubview(view3View)
+    view3View.addSubview(textView)
+    view2View.addSubview(view4View)
+    view4View.addSubview(text1View)
+
+    view1View.fillColor = Colors.red50
+    textView.attributedStringValue = textViewTextStyle.apply(to: "Some long text (currently LS lays out incorrectly)")
+    view2View.fillColor = Colors.blue50
+    text1View.attributedStringValue = text1ViewTextStyle.apply(to: "Short")
+  }
+
+  private func setUpConstraints() {
+    translatesAutoresizingMaskIntoConstraints = false
+    view1View.translatesAutoresizingMaskIntoConstraints = false
+    view2View.translatesAutoresizingMaskIntoConstraints = false
+    view3View.translatesAutoresizingMaskIntoConstraints = false
+    textView.translatesAutoresizingMaskIntoConstraints = false
+    view4View.translatesAutoresizingMaskIntoConstraints = false
+    text1View.translatesAutoresizingMaskIntoConstraints = false
+
+    let view1ViewView2ViewWidthAnchorSiblingConstraint = view1View
+      .widthAnchor
+      .constraint(equalTo: view2View.widthAnchor)
+    let view1ViewHeightAnchorParentConstraint = view1View.heightAnchor.constraint(lessThanOrEqualTo: heightAnchor)
+    let view2ViewHeightAnchorParentConstraint = view2View.heightAnchor.constraint(lessThanOrEqualTo: heightAnchor)
+    let view1ViewLeadingAnchorConstraint = view1View.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let view1ViewTopAnchorConstraint = view1View.topAnchor.constraint(equalTo: topAnchor)
+    let view2ViewTrailingAnchorConstraint = view2View.trailingAnchor.constraint(equalTo: trailingAnchor)
+    let view2ViewLeadingAnchorConstraint = view2View.leadingAnchor.constraint(equalTo: view1View.trailingAnchor)
+    let view2ViewTopAnchorConstraint = view2View.topAnchor.constraint(equalTo: topAnchor)
+    let view1ViewHeightAnchorConstraint = view1View.heightAnchor.constraint(equalToConstant: 100)
+    let view3ViewTopAnchorConstraint = view3View.topAnchor.constraint(equalTo: view1View.topAnchor)
+    let view3ViewBottomAnchorConstraint = view3View.bottomAnchor.constraint(equalTo: view1View.bottomAnchor)
+    let view3ViewLeadingAnchorConstraint = view3View.leadingAnchor.constraint(equalTo: view1View.leadingAnchor)
+    let view3ViewTrailingAnchorConstraint = view3View.trailingAnchor.constraint(equalTo: view1View.trailingAnchor)
+    let view2ViewHeightAnchorConstraint = view2View.heightAnchor.constraint(equalToConstant: 100)
+    let view4ViewTopAnchorConstraint = view4View.topAnchor.constraint(equalTo: view2View.topAnchor)
+    let view4ViewBottomAnchorConstraint = view4View.bottomAnchor.constraint(equalTo: view2View.bottomAnchor)
+    let view4ViewLeadingAnchorConstraint = view4View.leadingAnchor.constraint(equalTo: view2View.leadingAnchor)
+    let view4ViewTrailingAnchorConstraint = view4View.trailingAnchor.constraint(equalTo: view2View.trailingAnchor)
+    let textViewTopAnchorConstraint = textView.topAnchor.constraint(equalTo: view3View.topAnchor)
+    let textViewLeadingAnchorConstraint = textView.leadingAnchor.constraint(equalTo: view3View.leadingAnchor)
+    let textViewTrailingAnchorConstraint = textView.trailingAnchor.constraint(equalTo: view3View.trailingAnchor)
+    let text1ViewTopAnchorConstraint = text1View.topAnchor.constraint(equalTo: view4View.topAnchor)
+    let text1ViewLeadingAnchorConstraint = text1View.leadingAnchor.constraint(equalTo: view4View.leadingAnchor)
+    let text1ViewTrailingAnchorConstraint = text1View.trailingAnchor.constraint(equalTo: view4View.trailingAnchor)
+
+    view1ViewHeightAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
+    view2ViewHeightAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
+
+    NSLayoutConstraint.activate([
+      view1ViewView2ViewWidthAnchorSiblingConstraint,
+      view1ViewHeightAnchorParentConstraint,
+      view2ViewHeightAnchorParentConstraint,
+      view1ViewLeadingAnchorConstraint,
+      view1ViewTopAnchorConstraint,
+      view2ViewTrailingAnchorConstraint,
+      view2ViewLeadingAnchorConstraint,
+      view2ViewTopAnchorConstraint,
+      view1ViewHeightAnchorConstraint,
+      view3ViewTopAnchorConstraint,
+      view3ViewBottomAnchorConstraint,
+      view3ViewLeadingAnchorConstraint,
+      view3ViewTrailingAnchorConstraint,
+      view2ViewHeightAnchorConstraint,
+      view4ViewTopAnchorConstraint,
+      view4ViewBottomAnchorConstraint,
+      view4ViewLeadingAnchorConstraint,
+      view4ViewTrailingAnchorConstraint,
+      textViewTopAnchorConstraint,
+      textViewLeadingAnchorConstraint,
+      textViewTrailingAnchorConstraint,
+      text1ViewTopAnchorConstraint,
+      text1ViewLeadingAnchorConstraint,
+      text1ViewTrailingAnchorConstraint
+    ])
+  }
+
+  private func update() {}
+}

--- a/examples/generated/test/react-dom/components/ComponentParameterInstance.js
+++ b/examples/generated/test/react-dom/components/ComponentParameterInstance.js
@@ -34,12 +34,12 @@ let styles = {
     alignItems: "flex-start",
     display: "flex",
     flex: "1 1 0%",
-    flexDirection: "column"
+    flexDirection: "column",
+    justifyContent: "flex-start"
   },
   componentParameterTemplate: {
-    alignItems: "flex-start",
+    alignSelf: "stretch",
     display: "flex",
-    flex: "0 0 auto",
     flexDirection: "row"
   }
 }

--- a/examples/generated/test/react-dom/components/ComponentParameterInstance.js
+++ b/examples/generated/test/react-dom/components/ComponentParameterInstance.js
@@ -15,13 +15,14 @@ export default class ComponentParameterInstance extends React.Component {
     }
     return (
       <ThemeProvider theme={theme}>
-        <div style={Object.assign(styles.view, {})}>
-          <ComponentParameterTemplate
-            style={Object.assign(styles.componentParameterTemplate, {})}
-            subtitleComponent={{"parameters":{"text":"Subtitle","textStyle":"subheading2"},"type":"Lona:Text"}}
-            titleComponent={{"parameters":{"text":"Title","textStyle":"headline"},"type":"Lona:Text"}}
+        <div style={Object.assign({}, styles.view, {})}>
+          <div style={Object.assign({}, styles.componentParameterTemplate, {})}>
+            <ComponentParameterTemplate
+              subtitleComponent={{"parameters":{"text":"Subtitle","textStyle":"subheading2"},"type":"Lona:Text"}}
+              titleComponent={{"parameters":{"text":"Title","textStyle":"headline"},"type":"Lona:Text"}}
 
-          />
+            />
+          </div>
         </div>
       </ThemeProvider>
     );
@@ -30,14 +31,15 @@ export default class ComponentParameterInstance extends React.Component {
 
 let styles = {
   view: {
-    alignItems: "stretch",
-    alignSelf: "stretch",
+    alignItems: "flex-start",
     display: "flex",
+    flex: "1 1 0%",
     flexDirection: "column"
   },
   componentParameterTemplate: {
-    alignItems: "stretch",
+    alignItems: "flex-start",
     display: "flex",
-    flexDirection: "column"
+    flex: "0 0 auto",
+    flexDirection: "row"
   }
 }

--- a/examples/generated/test/react-dom/components/NestedBottomLeftLayout.js
+++ b/examples/generated/test/react-dom/components/NestedBottomLeftLayout.js
@@ -3,25 +3,22 @@ import styled, { ThemeProvider } from "styled-components"
 
 import colors from "../colors"
 import textStyles from "../textStyles"
-import ComponentParameterTemplate from "./ComponentParameterTemplate"
+import LocalAsset from "../images/LocalAsset"
 
-export default class ComponentParameterInstance extends React.Component {
+export default class NestedBottomLeftLayout extends React.Component {
   render() {
 
 
     let theme = {
       "view": { "normal": {} },
-      "componentParameterTemplate": { "normal": {} }
+      "view1": { "normal": {} },
+      "localAsset": { "normal": {} }
     }
     return (
       <ThemeProvider theme={theme}>
         <div style={Object.assign({}, styles.view, {})}>
-          <div style={Object.assign({}, styles.componentParameterTemplate, {})}>
-            <ComponentParameterTemplate
-              subtitleComponent={{"parameters":{"text":"Subtitle","textStyle":"subheading2"},"type":"Lona:Text"}}
-              titleComponent={{"parameters":{"text":"Title","textStyle":"headline"},"type":"Lona:Text"}}
-
-            />
+          <div style={Object.assign({}, styles.view1, {})}>
+            <LocalAsset />
           </div>
         </div>
       </ThemeProvider>
@@ -37,8 +34,17 @@ let styles = {
     flexDirection: "column",
     justifyContent: "flex-start"
   },
-  componentParameterTemplate: {
-    alignItems: "flex-start",
+  view1: {
+    alignItems: "flex-end",
+    backgroundColor: colors.red100,
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "flex-start",
+    width: "150px",
+    height: "150px"
+  },
+  localAsset: {
+    alignItems: "flex-end",
     alignSelf: "stretch",
     display: "flex",
     flex: "1 1 auto",

--- a/examples/generated/test/react-dom/components/NestedButtons.js
+++ b/examples/generated/test/react-dom/components/NestedButtons.js
@@ -37,28 +37,20 @@ let styles = {
     display: "flex",
     flex: "1 1 0%",
     flexDirection: "column",
+    justifyContent: "flex-start",
     paddingTop: "24px",
     paddingRight: "24px",
     paddingBottom: "24px",
     paddingLeft: "24px"
   },
-  button: {
-    alignItems: "flex-start",
-    display: "flex",
-    flex: "0 0 auto",
-    flexDirection: "row"
-  },
+  button: { alignSelf: "stretch", display: "flex", flexDirection: "row" },
   view1: {
     alignItems: "flex-start",
     alignSelf: "stretch",
     display: "flex",
     flexDirection: "column",
+    justifyContent: "flex-start",
     height: "8px"
   },
-  button2: {
-    alignItems: "flex-start",
-    display: "flex",
-    flex: "0 0 auto",
-    flexDirection: "row"
-  }
+  button2: { alignSelf: "stretch", display: "flex", flexDirection: "row" }
 }

--- a/examples/generated/test/react-dom/components/NestedButtons.js
+++ b/examples/generated/test/react-dom/components/NestedButtons.js
@@ -43,7 +43,14 @@ let styles = {
     paddingBottom: "24px",
     paddingLeft: "24px"
   },
-  button: { alignSelf: "stretch", display: "flex", flexDirection: "row" },
+  button: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    display: "flex",
+    flex: "1 1 auto",
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  },
   view1: {
     alignItems: "flex-start",
     alignSelf: "stretch",
@@ -52,5 +59,12 @@ let styles = {
     justifyContent: "flex-start",
     height: "8px"
   },
-  button2: { alignSelf: "stretch", display: "flex", flexDirection: "row" }
+  button2: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    display: "flex",
+    flex: "1 1 auto",
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  }
 }

--- a/examples/generated/test/react-dom/components/NestedButtons.js
+++ b/examples/generated/test/react-dom/components/NestedButtons.js
@@ -17,14 +17,14 @@ export default class NestedButtons extends React.Component {
     }
     return (
       <ThemeProvider theme={theme}>
-        <div style={Object.assign(styles.view, {})}>
-          <Button style={Object.assign(styles.button, {})} label={"Button 1"} />
-          <div style={Object.assign(styles.view1, {})} />
-          <Button
-            style={Object.assign(styles.button2, {})}
-            label={"Button 2"}
-
-          />
+        <div style={Object.assign({}, styles.view, {})}>
+          <div style={Object.assign({}, styles.button, {})}>
+            <Button label={"Button 1"} />
+          </div>
+          <div style={Object.assign({}, styles.view1, {})} />
+          <div style={Object.assign({}, styles.button2, {})}>
+            <Button label={"Button 2"} />
+          </div>
         </div>
       </ThemeProvider>
     );
@@ -33,22 +33,32 @@ export default class NestedButtons extends React.Component {
 
 let styles = {
   view: {
-    alignItems: "stretch",
-    alignSelf: "stretch",
+    alignItems: "flex-start",
     display: "flex",
+    flex: "1 1 0%",
     flexDirection: "column",
     paddingTop: "24px",
     paddingRight: "24px",
     paddingBottom: "24px",
     paddingLeft: "24px"
   },
-  button: { alignItems: "stretch", display: "flex", flexDirection: "column" },
+  button: {
+    alignItems: "flex-start",
+    display: "flex",
+    flex: "0 0 auto",
+    flexDirection: "row"
+  },
   view1: {
-    alignItems: "stretch",
+    alignItems: "flex-start",
     alignSelf: "stretch",
     display: "flex",
     flexDirection: "column",
     height: "8px"
   },
-  button2: { alignItems: "stretch", display: "flex", flexDirection: "column" }
+  button2: {
+    alignItems: "flex-start",
+    display: "flex",
+    flex: "0 0 auto",
+    flexDirection: "row"
+  }
 }

--- a/examples/generated/test/react-dom/components/NestedComponent.js
+++ b/examples/generated/test/react-dom/components/NestedComponent.js
@@ -21,19 +21,23 @@ export default class NestedComponent extends React.Component {
     }
     return (
       <ThemeProvider theme={theme}>
-        <div style={Object.assign(styles.view, {})}>
-          <span style={Object.assign(styles.text, {})}>
+        <div style={Object.assign({}, styles.view, {})}>
+          <span style={Object.assign({}, styles.text, {})}>
             {"Example nested component"}
           </span>
-          <FitContentParentSecondaryChildren
-            style={Object.assign(styles.fitContentParentSecondaryChildren, {})}
-
-          />
-          <span style={Object.assign(styles.text1, {})}>
+          <div
+            style={Object.assign({}, styles
+            .fitContentParentSecondaryChildren, {})}
+          >
+            <FitContentParentSecondaryChildren />
+          </div>
+          <span style={Object.assign({}, styles.text1, {})}>
             {"Text below"}
           </span>
-          <LocalAsset style={Object.assign(styles.localAsset, {})} />
-          <span style={Object.assign(styles.text2, {})}>
+          <div style={Object.assign({}, styles.localAsset, {})}>
+            <LocalAsset />
+          </div>
+          <span style={Object.assign({}, styles.text2, {})}>
             {"Very bottom"}
           </span>
         </div>
@@ -44,9 +48,9 @@ export default class NestedComponent extends React.Component {
 
 let styles = {
   view: {
-    alignItems: "stretch",
-    alignSelf: "stretch",
+    alignItems: "flex-start",
     display: "flex",
+    flex: "1 1 0%",
     flexDirection: "column",
     paddingTop: "10px",
     paddingRight: "10px",
@@ -55,26 +59,34 @@ let styles = {
   },
   text: {
     ...textStyles.subheading2,
-    alignItems: "stretch",
     display: "flex",
+    flex: "0 0 auto",
     flexDirection: "column",
     marginBottom: "8px"
   },
   fitContentParentSecondaryChildren: {
-    alignItems: "stretch",
+    alignItems: "flex-start",
     display: "flex",
-    flexDirection: "column"
+    flex: "0 0 auto",
+    flexDirection: "row"
   },
   text1: {
-    alignItems: "stretch",
+    ...textStyles.body1,
     display: "flex",
+    flex: "0 0 auto",
     flexDirection: "column",
     marginTop: "12px"
   },
   localAsset: {
-    alignItems: "stretch",
+    alignItems: "flex-start",
     display: "flex",
-    flexDirection: "column"
+    flex: "0 0 auto",
+    flexDirection: "row"
   },
-  text2: { alignItems: "stretch", display: "flex", flexDirection: "column" }
+  text2: {
+    ...textStyles.body1,
+    display: "flex",
+    flex: "0 0 auto",
+    flexDirection: "column"
+  }
 }

--- a/examples/generated/test/react-dom/components/NestedComponent.js
+++ b/examples/generated/test/react-dom/components/NestedComponent.js
@@ -52,6 +52,7 @@ let styles = {
     display: "flex",
     flex: "1 1 0%",
     flexDirection: "column",
+    justifyContent: "flex-start",
     paddingTop: "10px",
     paddingRight: "10px",
     paddingBottom: "10px",
@@ -59,34 +60,31 @@ let styles = {
   },
   text: {
     ...textStyles.subheading2,
-    display: "flex",
+    alignItems: "flex-start",
     flex: "0 0 auto",
     flexDirection: "column",
+    justifyContent: "flex-start",
     marginBottom: "8px"
   },
   fitContentParentSecondaryChildren: {
-    alignItems: "flex-start",
+    alignSelf: "stretch",
     display: "flex",
-    flex: "0 0 auto",
     flexDirection: "row"
   },
   text1: {
     ...textStyles.body1,
-    display: "flex",
+    alignItems: "flex-start",
     flex: "0 0 auto",
     flexDirection: "column",
+    justifyContent: "flex-start",
     marginTop: "12px"
   },
-  localAsset: {
-    alignItems: "flex-start",
-    display: "flex",
-    flex: "0 0 auto",
-    flexDirection: "row"
-  },
+  localAsset: { alignSelf: "stretch", display: "flex", flexDirection: "row" },
   text2: {
     ...textStyles.body1,
-    display: "flex",
+    alignItems: "flex-start",
     flex: "0 0 auto",
-    flexDirection: "column"
+    flexDirection: "column",
+    justifyContent: "flex-start"
   }
 }

--- a/examples/generated/test/react-dom/components/NestedComponent.js
+++ b/examples/generated/test/react-dom/components/NestedComponent.js
@@ -67,9 +67,12 @@ let styles = {
     marginBottom: "8px"
   },
   fitContentParentSecondaryChildren: {
+    alignItems: "flex-start",
     alignSelf: "stretch",
     display: "flex",
-    flexDirection: "row"
+    flex: "1 1 auto",
+    flexDirection: "row",
+    justifyContent: "flex-start"
   },
   text1: {
     ...textStyles.body1,
@@ -79,7 +82,14 @@ let styles = {
     justifyContent: "flex-start",
     marginTop: "12px"
   },
-  localAsset: { alignSelf: "stretch", display: "flex", flexDirection: "row" },
+  localAsset: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    display: "flex",
+    flex: "1 1 auto",
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  },
   text2: {
     ...textStyles.body1,
     alignItems: "flex-start",

--- a/examples/generated/test/react-dom/components/NestedLayout.js
+++ b/examples/generated/test/react-dom/components/NestedLayout.js
@@ -1,0 +1,520 @@
+import React from "react"
+import styled, { ThemeProvider } from "styled-components"
+
+import colors from "../colors"
+import textStyles from "../textStyles"
+import LocalAsset from "../images/LocalAsset"
+
+export default class NestedLayout extends React.Component {
+  render() {
+
+
+    let theme = {
+      "view": { "normal": {} },
+      "topRow": { "normal": {} },
+      "column1": { "normal": {} },
+      "view1": { "normal": {} },
+      "localAsset": { "normal": {} },
+      "view2": { "normal": {} },
+      "localAsset2": { "normal": {} },
+      "view3": { "normal": {} },
+      "localAsset3": { "normal": {} },
+      "column2": { "normal": {} },
+      "view4": { "normal": {} },
+      "localAsset4": { "normal": {} },
+      "view5": { "normal": {} },
+      "localAsset5": { "normal": {} },
+      "view6": { "normal": {} },
+      "localAsset6": { "normal": {} },
+      "column3": { "normal": {} },
+      "view7": { "normal": {} },
+      "localAsset7": { "normal": {} },
+      "view8": { "normal": {} },
+      "localAsset8": { "normal": {} },
+      "view9": { "normal": {} },
+      "localAsset9": { "normal": {} },
+      "bottomRow": { "normal": {} },
+      "column4": { "normal": {} },
+      "view10": { "normal": {} },
+      "localAsset10": { "normal": {} },
+      "view11": { "normal": {} },
+      "localAsset11": { "normal": {} },
+      "view12": { "normal": {} },
+      "localAsset12": { "normal": {} },
+      "column5": { "normal": {} },
+      "view13": { "normal": {} },
+      "localAsset13": { "normal": {} },
+      "view14": { "normal": {} },
+      "localAsset14": { "normal": {} },
+      "view15": { "normal": {} },
+      "localAsset15": { "normal": {} },
+      "column6": { "normal": {} },
+      "view16": { "normal": {} },
+      "localAsset16": { "normal": {} },
+      "view17": { "normal": {} },
+      "localAsset17": { "normal": {} },
+      "view18": { "normal": {} },
+      "localAsset18": { "normal": {} }
+    }
+    return (
+      <ThemeProvider theme={theme}>
+        <div style={Object.assign({}, styles.view, {})}>
+          <div style={Object.assign({}, styles.topRow, {})}>
+            <div style={Object.assign({}, styles.column1, {})}>
+              <div style={Object.assign({}, styles.view1, {})}>
+                <div style={Object.assign({}, styles.localAsset, {})}>
+                  <LocalAsset />
+                </div>
+              </div>
+              <div style={Object.assign({}, styles.view2, {})}>
+                <div style={Object.assign({}, styles.localAsset2, {})}>
+                  <LocalAsset />
+                </div>
+              </div>
+              <div style={Object.assign({}, styles.view3, {})}>
+                <div style={Object.assign({}, styles.localAsset3, {})}>
+                  <LocalAsset />
+                </div>
+              </div>
+            </div>
+            <div style={Object.assign({}, styles.column2, {})}>
+              <div style={Object.assign({}, styles.view4, {})}>
+                <div style={Object.assign({}, styles.localAsset4, {})}>
+                  <LocalAsset />
+                </div>
+              </div>
+              <div style={Object.assign({}, styles.view5, {})}>
+                <div style={Object.assign({}, styles.localAsset5, {})}>
+                  <LocalAsset />
+                </div>
+              </div>
+              <div style={Object.assign({}, styles.view6, {})}>
+                <div style={Object.assign({}, styles.localAsset6, {})}>
+                  <LocalAsset />
+                </div>
+              </div>
+            </div>
+            <div style={Object.assign({}, styles.column3, {})}>
+              <div style={Object.assign({}, styles.view7, {})}>
+                <div style={Object.assign({}, styles.localAsset7, {})}>
+                  <LocalAsset />
+                </div>
+              </div>
+              <div style={Object.assign({}, styles.view8, {})}>
+                <div style={Object.assign({}, styles.localAsset8, {})}>
+                  <LocalAsset />
+                </div>
+              </div>
+              <div style={Object.assign({}, styles.view9, {})}>
+                <div style={Object.assign({}, styles.localAsset9, {})}>
+                  <LocalAsset />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div style={Object.assign({}, styles.bottomRow, {})}>
+            <div style={Object.assign({}, styles.column4, {})}>
+              <div style={Object.assign({}, styles.view10, {})}>
+                <LocalAsset />
+              </div>
+              <div style={Object.assign({}, styles.view11, {})}>
+                <LocalAsset />
+              </div>
+              <div style={Object.assign({}, styles.view12, {})}>
+                <LocalAsset />
+              </div>
+            </div>
+            <div style={Object.assign({}, styles.column5, {})}>
+              <div style={Object.assign({}, styles.view13, {})}>
+                <LocalAsset />
+              </div>
+              <div style={Object.assign({}, styles.view14, {})}>
+                <LocalAsset />
+              </div>
+              <div style={Object.assign({}, styles.view15, {})}>
+                <LocalAsset />
+              </div>
+            </div>
+            <div style={Object.assign({}, styles.column6, {})}>
+              <div style={Object.assign({}, styles.view16, {})}>
+                <LocalAsset />
+              </div>
+              <div style={Object.assign({}, styles.view17, {})}>
+                <LocalAsset />
+              </div>
+              <div style={Object.assign({}, styles.view18, {})}>
+                <LocalAsset />
+              </div>
+            </div>
+          </div>
+        </div>
+      </ThemeProvider>
+    );
+  }
+};
+
+let styles = {
+  view: {
+    alignItems: "flex-start",
+    display: "flex",
+    flex: "1 1 0%",
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  topRow: {
+    alignItems: "flex-start",
+    display: "flex",
+    flex: "0 0 auto",
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  },
+  bottomRow: {
+    alignItems: "flex-start",
+    display: "flex",
+    flex: "0 0 auto",
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  },
+  column1: {
+    alignItems: "flex-start",
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: "150px"
+  },
+  column2: {
+    alignItems: "flex-start",
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: "150px"
+  },
+  column3: {
+    alignItems: "flex-start",
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: "150px"
+  },
+  view1: {
+    alignItems: "flex-start",
+    backgroundColor: colors.grey50,
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: "150px",
+    height: "150px"
+  },
+  view2: {
+    alignItems: "flex-start",
+    backgroundColor: "transparent",
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "center",
+    width: "150px",
+    height: "150px"
+  },
+  view3: {
+    alignItems: "flex-start",
+    backgroundColor: colors.grey50,
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "flex-end",
+    width: "150px",
+    height: "150px"
+  },
+  localAsset: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    display: "flex",
+    flex: "1 1 auto",
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  },
+  localAsset2: {
+    alignItems: "center",
+    alignSelf: "stretch",
+    display: "flex",
+    flex: "1 1 auto",
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  },
+  localAsset3: {
+    alignItems: "flex-end",
+    alignSelf: "stretch",
+    display: "flex",
+    flex: "1 1 auto",
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  },
+  view4: {
+    alignItems: "center",
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: "150px",
+    height: "150px"
+  },
+  view5: {
+    alignItems: "center",
+    backgroundColor: colors.grey50,
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "center",
+    width: "150px",
+    height: "150px"
+  },
+  view6: {
+    alignItems: "center",
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "flex-end",
+    width: "150px",
+    height: "150px"
+  },
+  localAsset4: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    display: "flex",
+    flex: "1 1 auto",
+    flexDirection: "row",
+    justifyContent: "center"
+  },
+  localAsset5: {
+    alignItems: "center",
+    alignSelf: "stretch",
+    display: "flex",
+    flex: "1 1 auto",
+    flexDirection: "row",
+    justifyContent: "center"
+  },
+  localAsset6: {
+    alignItems: "flex-end",
+    alignSelf: "stretch",
+    display: "flex",
+    flex: "1 1 auto",
+    flexDirection: "row",
+    justifyContent: "center"
+  },
+  view7: {
+    alignItems: "flex-end",
+    backgroundColor: colors.grey50,
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: "150px",
+    height: "150px"
+  },
+  view8: {
+    alignItems: "flex-end",
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "center",
+    width: "150px",
+    height: "150px"
+  },
+  view9: {
+    alignItems: "flex-end",
+    backgroundColor: colors.grey50,
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "flex-end",
+    width: "150px",
+    height: "150px"
+  },
+  localAsset7: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    display: "flex",
+    flex: "1 1 auto",
+    flexDirection: "row",
+    justifyContent: "flex-end"
+  },
+  localAsset8: {
+    alignItems: "center",
+    alignSelf: "stretch",
+    display: "flex",
+    flex: "1 1 auto",
+    flexDirection: "row",
+    justifyContent: "flex-end"
+  },
+  localAsset9: {
+    alignItems: "flex-end",
+    alignSelf: "stretch",
+    display: "flex",
+    flex: "1 1 auto",
+    flexDirection: "row",
+    justifyContent: "flex-end"
+  },
+  column4: {
+    alignItems: "flex-start",
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: "150px"
+  },
+  column5: {
+    alignItems: "flex-start",
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: "150px"
+  },
+  column6: {
+    alignItems: "flex-start",
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: "150px"
+  },
+  view10: {
+    alignItems: "flex-start",
+    backgroundColor: colors.grey50,
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "flex-start",
+    width: "150px",
+    height: "150px"
+  },
+  view11: {
+    alignItems: "center",
+    backgroundColor: "transparent",
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "flex-start",
+    width: "150px",
+    height: "150px"
+  },
+  view12: {
+    alignItems: "flex-end",
+    backgroundColor: colors.grey50,
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "flex-start",
+    width: "150px",
+    height: "150px"
+  },
+  localAsset10: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    display: "flex",
+    flex: "1 1 auto",
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  },
+  localAsset11: {
+    alignItems: "center",
+    alignSelf: "stretch",
+    display: "flex",
+    flex: "1 1 auto",
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  },
+  localAsset12: {
+    alignItems: "flex-end",
+    alignSelf: "stretch",
+    display: "flex",
+    flex: "1 1 auto",
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  },
+  view13: {
+    alignItems: "flex-start",
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "center",
+    width: "150px",
+    height: "150px"
+  },
+  view14: {
+    alignItems: "center",
+    backgroundColor: colors.grey50,
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "center",
+    width: "150px",
+    height: "150px"
+  },
+  view15: {
+    alignItems: "flex-end",
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "center",
+    width: "150px",
+    height: "150px"
+  },
+  localAsset13: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    display: "flex",
+    flex: "1 1 auto",
+    flexDirection: "row",
+    justifyContent: "center"
+  },
+  localAsset14: {
+    alignItems: "center",
+    alignSelf: "stretch",
+    display: "flex",
+    flex: "1 1 auto",
+    flexDirection: "row",
+    justifyContent: "center"
+  },
+  localAsset15: {
+    alignItems: "flex-end",
+    alignSelf: "stretch",
+    display: "flex",
+    flex: "1 1 auto",
+    flexDirection: "row",
+    justifyContent: "center"
+  },
+  view16: {
+    alignItems: "flex-start",
+    backgroundColor: colors.grey50,
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    width: "150px",
+    height: "150px"
+  },
+  view17: {
+    alignItems: "center",
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    width: "150px",
+    height: "150px"
+  },
+  view18: {
+    alignItems: "flex-end",
+    backgroundColor: colors.grey50,
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    width: "150px",
+    height: "150px"
+  },
+  localAsset16: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    display: "flex",
+    flex: "1 1 auto",
+    flexDirection: "row",
+    justifyContent: "flex-end"
+  },
+  localAsset17: {
+    alignItems: "center",
+    alignSelf: "stretch",
+    display: "flex",
+    flex: "1 1 auto",
+    flexDirection: "row",
+    justifyContent: "flex-end"
+  },
+  localAsset18: {
+    alignItems: "flex-end",
+    alignSelf: "stretch",
+    display: "flex",
+    flex: "1 1 auto",
+    flexDirection: "row",
+    justifyContent: "flex-end"
+  }
+}

--- a/examples/generated/test/react-dom/images/LocalAsset.js
+++ b/examples/generated/test/react-dom/images/LocalAsset.js
@@ -11,9 +11,9 @@ export default class LocalAsset extends React.Component {
     let theme = { "view": { "normal": {} }, "image": { "normal": {} } }
     return (
       <ThemeProvider theme={theme}>
-        <div style={Object.assign(styles.view, {})}>
+        <div style={Object.assign({}, styles.view, {})}>
           <img
-            style={Object.assign(styles.image, {})}
+            style={Object.assign({}, styles.image, {})}
             src={require("../assets/icon_128x128.png")}
 
           />
@@ -25,13 +25,13 @@ export default class LocalAsset extends React.Component {
 
 let styles = {
   view: {
-    alignItems: "stretch",
-    alignSelf: "stretch",
+    alignItems: "flex-start",
     display: "flex",
+    flex: "1 1 0%",
     flexDirection: "column"
   },
   image: {
-    alignItems: "stretch",
+    alignItems: "flex-start",
     backgroundColor: "#D8D8D8",
     display: "flex",
     flexDirection: "column",

--- a/examples/generated/test/react-dom/images/LocalAsset.js
+++ b/examples/generated/test/react-dom/images/LocalAsset.js
@@ -26,6 +26,7 @@ export default class LocalAsset extends React.Component {
 let styles = {
   view: {
     alignItems: "flex-start",
+    backgroundColor: colors.red400,
     display: "flex",
     flex: "0 0 auto",
     flexDirection: "column",

--- a/examples/generated/test/react-dom/images/LocalAsset.js
+++ b/examples/generated/test/react-dom/images/LocalAsset.js
@@ -27,14 +27,16 @@ let styles = {
   view: {
     alignItems: "flex-start",
     display: "flex",
-    flex: "1 1 0%",
-    flexDirection: "column"
+    flex: "0 0 auto",
+    flexDirection: "column",
+    justifyContent: "flex-start"
   },
   image: {
     alignItems: "flex-start",
     backgroundColor: "#D8D8D8",
     display: "flex",
     flexDirection: "column",
+    justifyContent: "flex-start",
     width: "100px",
     height: "100px"
   }

--- a/examples/generated/test/react-dom/interactivity/Button.js
+++ b/examples/generated/test/react-dom/interactivity/Button.js
@@ -50,6 +50,7 @@ let styles = {
     display: "flex",
     flex: "0 0 auto",
     flexDirection: "column",
+    justifyContent: "flex-start",
     paddingTop: "12px",
     paddingRight: "16px",
     paddingBottom: "12px",
@@ -57,8 +58,9 @@ let styles = {
   },
   text: {
     ...textStyles.button,
-    display: "flex",
+    alignItems: "flex-start",
     flex: "0 0 auto",
-    flexDirection: "column"
+    flexDirection: "column",
+    justifyContent: "flex-start"
   }
 }

--- a/examples/generated/test/react-dom/interactivity/Button.js
+++ b/examples/generated/test/react-dom/interactivity/Button.js
@@ -29,12 +29,12 @@ export default class Button extends React.Component {
     return (
       <ThemeProvider theme={theme}>
         <div
-          style={Object.assign(styles.view, {
+          style={Object.assign({}, styles.view, {
             backgroundColor: View$backgroundColor
           })}
           onClick={View$onPress}
         >
-          <span style={Object.assign(styles.text, {})}>
+          <span style={Object.assign({}, styles.text, {})}>
             {Text$text}
           </span>
         </div>
@@ -45,9 +45,10 @@ export default class Button extends React.Component {
 
 let styles = {
   view: {
-    alignItems: "stretch",
+    alignItems: "flex-start",
     backgroundColor: colors.blue100,
     display: "flex",
+    flex: "0 0 auto",
     flexDirection: "column",
     paddingTop: "12px",
     paddingRight: "16px",
@@ -56,8 +57,8 @@ let styles = {
   },
   text: {
     ...textStyles.button,
-    alignItems: "stretch",
     display: "flex",
+    flex: "0 0 auto",
     flexDirection: "column"
   }
 }

--- a/examples/generated/test/react-dom/interactivity/PressableRootView.js
+++ b/examples/generated/test/react-dom/interactivity/PressableRootView.js
@@ -49,18 +49,18 @@ export default class PressableRootView extends React.Component {
     return (
       <ThemeProvider theme={theme}>
         <div
-          style={Object.assign(styles.outer, {
+          style={Object.assign({}, styles.outer, {
             backgroundColor: Outer$backgroundColor
           })}
           onClick={Outer$onPress}
         >
           <div
-            style={Object.assign(styles.inner, {
+            style={Object.assign({}, styles.inner, {
               backgroundColor: Inner$backgroundColor
             })}
             onClick={Inner$onPress}
           >
-            <span style={Object.assign(styles.innerText, {})}>
+            <span style={Object.assign({}, styles.innerText, {})}>
               {InnerText$text}
             </span>
           </div>
@@ -72,10 +72,10 @@ export default class PressableRootView extends React.Component {
 
 let styles = {
   outer: {
-    alignItems: "stretch",
-    alignSelf: "stretch",
+    alignItems: "flex-start",
     backgroundColor: colors.grey50,
     display: "flex",
+    flex: "1 1 0%",
     flexDirection: "column",
     paddingTop: "24px",
     paddingRight: "24px",
@@ -83,7 +83,7 @@ let styles = {
     paddingLeft: "24px"
   },
   inner: {
-    alignItems: "stretch",
+    alignItems: "flex-start",
     backgroundColor: colors.blue500,
     display: "flex",
     flexDirection: "column",
@@ -92,8 +92,8 @@ let styles = {
   },
   innerText: {
     ...textStyles.headline,
-    alignItems: "stretch",
     display: "flex",
+    flex: "0 0 auto",
     flexDirection: "column"
   }
 }

--- a/examples/generated/test/react-dom/interactivity/PressableRootView.js
+++ b/examples/generated/test/react-dom/interactivity/PressableRootView.js
@@ -77,6 +77,7 @@ let styles = {
     display: "flex",
     flex: "1 1 0%",
     flexDirection: "column",
+    justifyContent: "flex-start",
     paddingTop: "24px",
     paddingRight: "24px",
     paddingBottom: "24px",
@@ -87,13 +88,15 @@ let styles = {
     backgroundColor: colors.blue500,
     display: "flex",
     flexDirection: "column",
+    justifyContent: "flex-start",
     width: "100px",
     height: "100px"
   },
   innerText: {
     ...textStyles.headline,
-    display: "flex",
+    alignItems: "flex-start",
     flex: "0 0 auto",
-    flexDirection: "column"
+    flexDirection: "column",
+    justifyContent: "flex-start"
   }
 }

--- a/examples/generated/test/react-dom/layouts/FitContentParentSecondaryChildren.js
+++ b/examples/generated/test/react-dom/layouts/FitContentParentSecondaryChildren.js
@@ -32,6 +32,8 @@ let styles = {
     backgroundColor: colors.bluegrey50,
     display: "flex",
     flex: "1 1 0%",
+    flexDirection: "row",
+    justifyContent: "flex-start",
     paddingTop: "24px",
     paddingRight: "24px",
     paddingBottom: "24px",
@@ -42,6 +44,7 @@ let styles = {
     backgroundColor: colors.blue500,
     display: "flex",
     flexDirection: "column",
+    justifyContent: "flex-start",
     width: "60px",
     height: "60px"
   },
@@ -50,6 +53,7 @@ let styles = {
     backgroundColor: colors.lightblue500,
     display: "flex",
     flexDirection: "column",
+    justifyContent: "flex-start",
     width: "100px",
     height: "120px"
   },
@@ -58,6 +62,7 @@ let styles = {
     backgroundColor: colors.cyan500,
     display: "flex",
     flexDirection: "column",
+    justifyContent: "flex-start",
     width: "100px",
     height: "180px"
   }

--- a/examples/generated/test/react-dom/layouts/FitContentParentSecondaryChildren.js
+++ b/examples/generated/test/react-dom/layouts/FitContentParentSecondaryChildren.js
@@ -16,10 +16,10 @@ export default class FitContentParentSecondaryChildren extends React.Component {
     }
     return (
       <ThemeProvider theme={theme}>
-        <div style={Object.assign(styles.container, {})}>
-          <div style={Object.assign(styles.view1, {})} />
-          <div style={Object.assign(styles.view3, {})} />
-          <div style={Object.assign(styles.view2, {})} />
+        <div style={Object.assign({}, styles.container, {})}>
+          <div style={Object.assign({}, styles.view1, {})} />
+          <div style={Object.assign({}, styles.view3, {})} />
+          <div style={Object.assign({}, styles.view2, {})} />
         </div>
       </ThemeProvider>
     );
@@ -28,18 +28,17 @@ export default class FitContentParentSecondaryChildren extends React.Component {
 
 let styles = {
   container: {
-    alignItems: "stretch",
-    alignSelf: "stretch",
+    alignItems: "flex-start",
     backgroundColor: colors.bluegrey50,
     display: "flex",
-    flexDirection: "row",
+    flex: "1 1 0%",
     paddingTop: "24px",
     paddingRight: "24px",
     paddingBottom: "24px",
     paddingLeft: "24px"
   },
   view1: {
-    alignItems: "stretch",
+    alignItems: "flex-start",
     backgroundColor: colors.blue500,
     display: "flex",
     flexDirection: "column",
@@ -47,7 +46,7 @@ let styles = {
     height: "60px"
   },
   view3: {
-    alignItems: "stretch",
+    alignItems: "flex-start",
     backgroundColor: colors.lightblue500,
     display: "flex",
     flexDirection: "column",
@@ -55,7 +54,7 @@ let styles = {
     height: "120px"
   },
   view2: {
-    alignItems: "stretch",
+    alignItems: "flex-start",
     backgroundColor: colors.cyan500,
     display: "flex",
     flexDirection: "column",

--- a/examples/generated/test/react-dom/layouts/FixedParentFillAndFitChildren.js
+++ b/examples/generated/test/react-dom/layouts/FixedParentFillAndFitChildren.js
@@ -37,6 +37,7 @@ let styles = {
     display: "flex",
     flex: "1 1 0%",
     flexDirection: "column",
+    justifyContent: "flex-start",
     paddingTop: "24px",
     paddingRight: "24px",
     paddingBottom: "24px",
@@ -49,6 +50,8 @@ let styles = {
     backgroundColor: colors.red50,
     display: "flex",
     flex: "0 0 auto",
+    flexDirection: "row",
+    justifyContent: "flex-start",
     paddingTop: "24px",
     paddingRight: "24px",
     paddingBottom: "24px",
@@ -60,7 +63,8 @@ let styles = {
     backgroundColor: colors.indigo100,
     display: "flex",
     flex: "1 1 0%",
-    flexDirection: "column"
+    flexDirection: "column",
+    justifyContent: "flex-start"
   },
   view3: {
     alignItems: "flex-start",
@@ -68,13 +72,15 @@ let styles = {
     backgroundColor: colors.teal100,
     display: "flex",
     flex: "1 1 0%",
-    flexDirection: "column"
+    flexDirection: "column",
+    justifyContent: "flex-start"
   },
   view4: {
     alignItems: "flex-start",
     backgroundColor: colors.red200,
     display: "flex",
     flexDirection: "column",
+    justifyContent: "flex-start",
     width: "60px",
     height: "100px"
   },
@@ -83,6 +89,7 @@ let styles = {
     backgroundColor: colors.deeporange200,
     display: "flex",
     flexDirection: "column",
+    justifyContent: "flex-start",
     marginLeft: "12px",
     width: "60px",
     height: "60px"

--- a/examples/generated/test/react-dom/layouts/FixedParentFillAndFitChildren.js
+++ b/examples/generated/test/react-dom/layouts/FixedParentFillAndFitChildren.js
@@ -18,13 +18,13 @@ export default class FixedParentFillAndFitChildren extends React.Component {
     }
     return (
       <ThemeProvider theme={theme}>
-        <div style={Object.assign(styles.view, {})}>
-          <div style={Object.assign(styles.view1, {})}>
-            <div style={Object.assign(styles.view4, {})} />
-            <div style={Object.assign(styles.view5, {})} />
+        <div style={Object.assign({}, styles.view, {})}>
+          <div style={Object.assign({}, styles.view1, {})}>
+            <div style={Object.assign({}, styles.view4, {})} />
+            <div style={Object.assign({}, styles.view5, {})} />
           </div>
-          <div style={Object.assign(styles.view2, {})} />
-          <div style={Object.assign(styles.view3, {})} />
+          <div style={Object.assign({}, styles.view2, {})} />
+          <div style={Object.assign({}, styles.view3, {})} />
         </div>
       </ThemeProvider>
     );
@@ -33,9 +33,9 @@ export default class FixedParentFillAndFitChildren extends React.Component {
 
 let styles = {
   view: {
-    alignItems: "stretch",
-    alignSelf: "stretch",
+    alignItems: "flex-start",
     display: "flex",
+    flex: "1 1 0%",
     flexDirection: "column",
     paddingTop: "24px",
     paddingRight: "24px",
@@ -44,18 +44,34 @@ let styles = {
     height: "600px"
   },
   view1: {
-    alignItems: "stretch",
+    alignItems: "flex-start",
     alignSelf: "stretch",
     backgroundColor: colors.red50,
     display: "flex",
-    flexDirection: "row",
+    flex: "0 0 auto",
     paddingTop: "24px",
     paddingRight: "24px",
     paddingBottom: "24px",
     paddingLeft: "24px"
   },
+  view2: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    backgroundColor: colors.indigo100,
+    display: "flex",
+    flex: "1 1 0%",
+    flexDirection: "column"
+  },
+  view3: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    backgroundColor: colors.teal100,
+    display: "flex",
+    flex: "1 1 0%",
+    flexDirection: "column"
+  },
   view4: {
-    alignItems: "stretch",
+    alignItems: "flex-start",
     backgroundColor: colors.red200,
     display: "flex",
     flexDirection: "column",
@@ -63,28 +79,12 @@ let styles = {
     height: "100px"
   },
   view5: {
-    alignItems: "stretch",
+    alignItems: "flex-start",
     backgroundColor: colors.deeporange200,
     display: "flex",
     flexDirection: "column",
     marginLeft: "12px",
     width: "60px",
     height: "60px"
-  },
-  view2: {
-    alignItems: "stretch",
-    alignSelf: "stretch",
-    backgroundColor: colors.indigo100,
-    display: "flex",
-    flex: 1,
-    flexDirection: "column"
-  },
-  view3: {
-    alignItems: "stretch",
-    alignSelf: "stretch",
-    backgroundColor: colors.teal100,
-    display: "flex",
-    flex: 1,
-    flexDirection: "column"
   }
 }

--- a/examples/generated/test/react-dom/layouts/FixedParentFitChild.js
+++ b/examples/generated/test/react-dom/layouts/FixedParentFitChild.js
@@ -16,10 +16,10 @@ export default class FixedParentFitChild extends React.Component {
     }
     return (
       <ThemeProvider theme={theme}>
-        <div style={Object.assign(styles.view, {})}>
-          <div style={Object.assign(styles.view1, {})}>
-            <div style={Object.assign(styles.view4, {})} />
-            <div style={Object.assign(styles.view5, {})} />
+        <div style={Object.assign({}, styles.view, {})}>
+          <div style={Object.assign({}, styles.view1, {})}>
+            <div style={Object.assign({}, styles.view4, {})} />
+            <div style={Object.assign({}, styles.view5, {})} />
           </div>
         </div>
       </ThemeProvider>
@@ -29,10 +29,10 @@ export default class FixedParentFitChild extends React.Component {
 
 let styles = {
   view: {
-    alignItems: "stretch",
-    alignSelf: "stretch",
+    alignItems: "flex-start",
     backgroundColor: colors.bluegrey100,
     display: "flex",
+    flex: "1 1 0%",
     flexDirection: "column",
     paddingTop: "24px",
     paddingRight: "24px",
@@ -41,18 +41,18 @@ let styles = {
     height: "600px"
   },
   view1: {
-    alignItems: "stretch",
+    alignItems: "flex-start",
     alignSelf: "stretch",
     backgroundColor: colors.red50,
     display: "flex",
-    flexDirection: "row",
+    flex: "0 0 auto",
     paddingTop: "24px",
     paddingRight: "24px",
     paddingBottom: "24px",
     paddingLeft: "24px"
   },
   view4: {
-    alignItems: "stretch",
+    alignItems: "flex-start",
     backgroundColor: colors.red200,
     display: "flex",
     flexDirection: "column",
@@ -60,7 +60,7 @@ let styles = {
     height: "100px"
   },
   view5: {
-    alignItems: "stretch",
+    alignItems: "flex-start",
     backgroundColor: colors.deeporange200,
     display: "flex",
     flexDirection: "column",

--- a/examples/generated/test/react-dom/layouts/FixedParentFitChild.js
+++ b/examples/generated/test/react-dom/layouts/FixedParentFitChild.js
@@ -34,6 +34,7 @@ let styles = {
     display: "flex",
     flex: "1 1 0%",
     flexDirection: "column",
+    justifyContent: "flex-start",
     paddingTop: "24px",
     paddingRight: "24px",
     paddingBottom: "24px",
@@ -46,6 +47,8 @@ let styles = {
     backgroundColor: colors.red50,
     display: "flex",
     flex: "0 0 auto",
+    flexDirection: "row",
+    justifyContent: "flex-start",
     paddingTop: "24px",
     paddingRight: "24px",
     paddingBottom: "24px",
@@ -56,6 +59,7 @@ let styles = {
     backgroundColor: colors.red200,
     display: "flex",
     flexDirection: "column",
+    justifyContent: "flex-start",
     width: "60px",
     height: "100px"
   },
@@ -64,6 +68,7 @@ let styles = {
     backgroundColor: colors.deeporange200,
     display: "flex",
     flexDirection: "column",
+    justifyContent: "flex-start",
     marginLeft: "12px",
     width: "60px",
     height: "60px"

--- a/examples/generated/test/react-dom/layouts/MultipleFlexText.js
+++ b/examples/generated/test/react-dom/layouts/MultipleFlexText.js
@@ -1,0 +1,101 @@
+import React from "react"
+import styled, { ThemeProvider } from "styled-components"
+
+import colors from "../colors"
+import textStyles from "../textStyles"
+
+export default class MultipleFlexText extends React.Component {
+  render() {
+
+
+    let theme = {
+      "view": { "normal": {} },
+      "view1": { "normal": {} },
+      "view3": { "normal": {} },
+      "text": { "normal": {} },
+      "view2": { "normal": {} },
+      "view4": { "normal": {} },
+      "text1": { "normal": {} }
+    }
+    return (
+      <ThemeProvider theme={theme}>
+        <div style={Object.assign({}, styles.view, {})}>
+          <div style={Object.assign({}, styles.view1, {})}>
+            <div style={Object.assign({}, styles.view3, {})}>
+              <span style={Object.assign({}, styles.text, {})}>
+                {"Some long text (currently LS lays out incorrectly)"}
+              </span>
+            </div>
+          </div>
+          <div style={Object.assign({}, styles.view2, {})}>
+            <div style={Object.assign({}, styles.view4, {})}>
+              <span style={Object.assign({}, styles.text1, {})}>
+                {"Short"}
+              </span>
+            </div>
+          </div>
+        </div>
+      </ThemeProvider>
+    );
+  }
+};
+
+let styles = {
+  view: {
+    alignItems: "flex-start",
+    display: "flex",
+    flex: "1 1 0%",
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  },
+  view1: {
+    alignItems: "flex-start",
+    backgroundColor: colors.red50,
+    display: "flex",
+    flex: "1 1 0%",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    height: "100px"
+  },
+  view2: {
+    alignItems: "flex-start",
+    backgroundColor: colors.blue50,
+    display: "flex",
+    flex: "1 1 0%",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    height: "100px"
+  },
+  view3: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    display: "flex",
+    flex: "1 1 0%",
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  text: {
+    ...textStyles.body1,
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: "0 0 auto",
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  view4: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    display: "flex",
+    flex: "1 1 0%",
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  text1: {
+    ...textStyles.body1,
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: "0 0 auto",
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  }
+}

--- a/examples/generated/test/react-dom/layouts/PrimaryAxis.js
+++ b/examples/generated/test/react-dom/layouts/PrimaryAxis.js
@@ -39,6 +39,7 @@ let styles = {
     display: "flex",
     flex: "1 1 0%",
     flexDirection: "column",
+    justifyContent: "flex-start",
     paddingTop: "24px",
     paddingRight: "24px",
     paddingBottom: "24px",
@@ -50,6 +51,7 @@ let styles = {
     backgroundColor: "#D8D8D8",
     display: "flex",
     flexDirection: "column",
+    justifyContent: "flex-start",
     marginBottom: "24px",
     width: "100px",
     height: "100px"
@@ -60,6 +62,7 @@ let styles = {
     display: "flex",
     flex: "0 0 auto",
     flexDirection: "column",
+    justifyContent: "flex-start",
     marginBottom: "24px",
     width: "100px"
   },
@@ -69,6 +72,7 @@ let styles = {
     display: "flex",
     flex: "1 1 0%",
     flexDirection: "column",
+    justifyContent: "flex-start",
     width: "100px"
   },
   fill2: {
@@ -77,12 +81,14 @@ let styles = {
     display: "flex",
     flex: "1 1 0%",
     flexDirection: "column",
+    justifyContent: "flex-start",
     width: "100px"
   },
   text: {
     ...textStyles.body1,
-    display: "flex",
+    alignItems: "flex-start",
     flex: "0 0 auto",
-    flexDirection: "column"
+    flexDirection: "column",
+    justifyContent: "flex-start"
   }
 }

--- a/examples/generated/test/react-dom/layouts/PrimaryAxis.js
+++ b/examples/generated/test/react-dom/layouts/PrimaryAxis.js
@@ -18,15 +18,15 @@ export default class PrimaryAxis extends React.Component {
     }
     return (
       <ThemeProvider theme={theme}>
-        <div style={Object.assign(styles.view, {})}>
-          <div style={Object.assign(styles.fixed, {})} />
-          <div style={Object.assign(styles.fit, {})}>
-            <span style={Object.assign(styles.text, {})}>
+        <div style={Object.assign({}, styles.view, {})}>
+          <div style={Object.assign({}, styles.fixed, {})} />
+          <div style={Object.assign({}, styles.fit, {})}>
+            <span style={Object.assign({}, styles.text, {})}>
               {"Text goes here"}
             </span>
           </div>
-          <div style={Object.assign(styles.fill1, {})} />
-          <div style={Object.assign(styles.fill2, {})} />
+          <div style={Object.assign({}, styles.fill1, {})} />
+          <div style={Object.assign({}, styles.fill2, {})} />
         </div>
       </ThemeProvider>
     );
@@ -35,9 +35,9 @@ export default class PrimaryAxis extends React.Component {
 
 let styles = {
   view: {
-    alignItems: "stretch",
-    alignSelf: "stretch",
+    alignItems: "flex-start",
     display: "flex",
+    flex: "1 1 0%",
     flexDirection: "column",
     paddingTop: "24px",
     paddingRight: "24px",
@@ -46,7 +46,7 @@ let styles = {
     height: "500px"
   },
   fixed: {
-    alignItems: "stretch",
+    alignItems: "flex-start",
     backgroundColor: "#D8D8D8",
     display: "flex",
     flexDirection: "column",
@@ -55,28 +55,34 @@ let styles = {
     height: "100px"
   },
   fit: {
-    alignItems: "stretch",
+    alignItems: "flex-start",
     backgroundColor: "#D8D8D8",
     display: "flex",
+    flex: "0 0 auto",
     flexDirection: "column",
     marginBottom: "24px",
     width: "100px"
   },
-  text: { alignItems: "stretch", display: "flex", flexDirection: "column" },
   fill1: {
-    alignItems: "stretch",
+    alignItems: "flex-start",
     backgroundColor: colors.cyan500,
     display: "flex",
-    flex: 1,
+    flex: "1 1 0%",
     flexDirection: "column",
     width: "100px"
   },
   fill2: {
-    alignItems: "stretch",
+    alignItems: "flex-start",
     backgroundColor: colors.blue500,
     display: "flex",
-    flex: 1,
+    flex: "1 1 0%",
     flexDirection: "column",
     width: "100px"
+  },
+  text: {
+    ...textStyles.body1,
+    display: "flex",
+    flex: "0 0 auto",
+    flexDirection: "column"
   }
 }

--- a/examples/generated/test/react-dom/layouts/SecondaryAxis.js
+++ b/examples/generated/test/react-dom/layouts/SecondaryAxis.js
@@ -37,6 +37,7 @@ let styles = {
     display: "flex",
     flex: "1 1 0%",
     flexDirection: "column",
+    justifyContent: "flex-start",
     paddingTop: "24px",
     paddingRight: "24px",
     paddingBottom: "24px",
@@ -47,6 +48,7 @@ let styles = {
     backgroundColor: "#D8D8D8",
     display: "flex",
     flexDirection: "column",
+    justifyContent: "flex-start",
     marginBottom: "24px",
     width: "100px",
     height: "100px"
@@ -56,6 +58,7 @@ let styles = {
     backgroundColor: "#D8D8D8",
     display: "flex",
     flexDirection: "column",
+    justifyContent: "flex-start",
     marginBottom: "24px",
     paddingTop: "12px",
     paddingRight: "12px",
@@ -69,12 +72,14 @@ let styles = {
     backgroundColor: "#D8D8D8",
     display: "flex",
     flexDirection: "column",
+    justifyContent: "flex-start",
     height: "100px"
   },
   text: {
     ...textStyles.body1,
-    display: "flex",
+    alignItems: "flex-start",
     flex: "0 0 auto",
-    flexDirection: "column"
+    flexDirection: "column",
+    justifyContent: "flex-start"
   }
 }

--- a/examples/generated/test/react-dom/layouts/SecondaryAxis.js
+++ b/examples/generated/test/react-dom/layouts/SecondaryAxis.js
@@ -17,14 +17,14 @@ export default class SecondaryAxis extends React.Component {
     }
     return (
       <ThemeProvider theme={theme}>
-        <div style={Object.assign(styles.container, {})}>
-          <div style={Object.assign(styles.fixed, {})} />
-          <div style={Object.assign(styles.fit, {})}>
-            <span style={Object.assign(styles.text, {})}>
+        <div style={Object.assign({}, styles.container, {})}>
+          <div style={Object.assign({}, styles.fixed, {})} />
+          <div style={Object.assign({}, styles.fit, {})}>
+            <span style={Object.assign({}, styles.text, {})}>
               {"Text goes here"}
             </span>
           </div>
-          <div style={Object.assign(styles.fill, {})} />
+          <div style={Object.assign({}, styles.fill, {})} />
         </div>
       </ThemeProvider>
     );
@@ -33,9 +33,9 @@ export default class SecondaryAxis extends React.Component {
 
 let styles = {
   container: {
-    alignItems: "stretch",
-    alignSelf: "stretch",
+    alignItems: "flex-start",
     display: "flex",
+    flex: "1 1 0%",
     flexDirection: "column",
     paddingTop: "24px",
     paddingRight: "24px",
@@ -43,7 +43,7 @@ let styles = {
     paddingLeft: "24px"
   },
   fixed: {
-    alignItems: "stretch",
+    alignItems: "flex-start",
     backgroundColor: "#D8D8D8",
     display: "flex",
     flexDirection: "column",
@@ -52,7 +52,7 @@ let styles = {
     height: "100px"
   },
   fit: {
-    alignItems: "stretch",
+    alignItems: "flex-start",
     backgroundColor: "#D8D8D8",
     display: "flex",
     flexDirection: "column",
@@ -63,13 +63,18 @@ let styles = {
     paddingLeft: "12px",
     height: "100px"
   },
-  text: { alignItems: "stretch", display: "flex", flexDirection: "column" },
   fill: {
-    alignItems: "stretch",
+    alignItems: "flex-start",
     alignSelf: "stretch",
     backgroundColor: "#D8D8D8",
     display: "flex",
     flexDirection: "column",
     height: "100px"
+  },
+  text: {
+    ...textStyles.body1,
+    display: "flex",
+    flex: "0 0 auto",
+    flexDirection: "column"
   }
 }

--- a/examples/generated/test/react-dom/logic/Assign.js
+++ b/examples/generated/test/react-dom/logic/Assign.js
@@ -28,12 +28,14 @@ let styles = {
     alignItems: "flex-start",
     display: "flex",
     flex: "1 1 0%",
-    flexDirection: "column"
+    flexDirection: "column",
+    justifyContent: "flex-start"
   },
   text: {
     ...textStyles.body1,
-    display: "flex",
+    alignItems: "flex-start",
     flex: "0 0 auto",
-    flexDirection: "column"
+    flexDirection: "column",
+    justifyContent: "flex-start"
   }
 }

--- a/examples/generated/test/react-dom/logic/Assign.js
+++ b/examples/generated/test/react-dom/logic/Assign.js
@@ -13,8 +13,8 @@ export default class Assign extends React.Component {
     let theme = { "view": { "normal": {} }, "text": { "normal": {} } }
     return (
       <ThemeProvider theme={theme}>
-        <div style={Object.assign(styles.view, {})}>
-          <span style={Object.assign(styles.text, {})}>
+        <div style={Object.assign({}, styles.view, {})}>
+          <span style={Object.assign({}, styles.text, {})}>
             {Text$text}
           </span>
         </div>
@@ -25,10 +25,15 @@ export default class Assign extends React.Component {
 
 let styles = {
   view: {
-    alignItems: "stretch",
-    alignSelf: "stretch",
+    alignItems: "flex-start",
     display: "flex",
+    flex: "1 1 0%",
     flexDirection: "column"
   },
-  text: { alignItems: "stretch", display: "flex", flexDirection: "column" }
+  text: {
+    ...textStyles.body1,
+    display: "flex",
+    flex: "0 0 auto",
+    flexDirection: "column"
+  }
 }

--- a/examples/generated/test/react-dom/logic/If.js
+++ b/examples/generated/test/react-dom/logic/If.js
@@ -17,7 +17,7 @@ export default class If extends React.Component {
     return (
       <ThemeProvider theme={theme}>
         <div
-          style={Object.assign(styles.view, {
+          style={Object.assign({}, styles.view, {
             backgroundColor: View$backgroundColor
           })}
 
@@ -29,9 +29,9 @@ export default class If extends React.Component {
 
 let styles = {
   view: {
-    alignItems: "stretch",
-    alignSelf: "stretch",
+    alignItems: "flex-start",
     display: "flex",
+    flex: "1 1 0%",
     flexDirection: "column"
   }
 }

--- a/examples/generated/test/react-dom/logic/If.js
+++ b/examples/generated/test/react-dom/logic/If.js
@@ -32,6 +32,7 @@ let styles = {
     alignItems: "flex-start",
     display: "flex",
     flex: "1 1 0%",
-    flexDirection: "column"
+    flexDirection: "column",
+    justifyContent: "flex-start"
   }
 }

--- a/examples/generated/test/react-dom/style/BorderWidthColor.js
+++ b/examples/generated/test/react-dom/style/BorderWidthColor.js
@@ -24,12 +24,14 @@ let styles = {
     alignItems: "flex-start",
     display: "flex",
     flex: "1 1 0%",
-    flexDirection: "column"
+    flexDirection: "column",
+    justifyContent: "flex-start"
   },
   view1: {
     alignItems: "flex-start",
     display: "flex",
     flexDirection: "column",
+    justifyContent: "flex-start",
     borderRadius: "10px",
     borderWidth: "20px",
     borderColor: colors.blue300,

--- a/examples/generated/test/react-dom/style/BorderWidthColor.js
+++ b/examples/generated/test/react-dom/style/BorderWidthColor.js
@@ -11,8 +11,8 @@ export default class BorderWidthColor extends React.Component {
     let theme = { "view": { "normal": {} }, "view1": { "normal": {} } }
     return (
       <ThemeProvider theme={theme}>
-        <div style={Object.assign(styles.view, {})}>
-          <div style={Object.assign(styles.view1, {})} />
+        <div style={Object.assign({}, styles.view, {})}>
+          <div style={Object.assign({}, styles.view1, {})} />
         </div>
       </ThemeProvider>
     );
@@ -21,13 +21,13 @@ export default class BorderWidthColor extends React.Component {
 
 let styles = {
   view: {
-    alignItems: "stretch",
-    alignSelf: "stretch",
+    alignItems: "flex-start",
     display: "flex",
+    flex: "1 1 0%",
     flexDirection: "column"
   },
   view1: {
-    alignItems: "stretch",
+    alignItems: "flex-start",
     display: "flex",
     flexDirection: "column",
     borderRadius: "10px",

--- a/examples/generated/test/react-dom/style/BoxModelConditional.js
+++ b/examples/generated/test/react-dom/style/BoxModelConditional.js
@@ -47,6 +47,7 @@ let styles = {
     display: "flex",
     flex: "1 1 0%",
     flexDirection: "column",
+    justifyContent: "flex-start",
     paddingTop: "4px",
     paddingRight: "4px",
     paddingBottom: "4px",
@@ -57,6 +58,7 @@ let styles = {
     backgroundColor: "#D8D8D8",
     display: "flex",
     flexDirection: "column",
+    justifyContent: "flex-start",
     width: "60px",
     height: "60px"
   }

--- a/examples/generated/test/react-dom/style/BoxModelConditional.js
+++ b/examples/generated/test/react-dom/style/BoxModelConditional.js
@@ -23,9 +23,9 @@ export default class BoxModelConditional extends React.Component {
     let theme = { "outer": { "normal": {} }, "inner": { "normal": {} } }
     return (
       <ThemeProvider theme={theme}>
-        <div style={Object.assign(styles.outer, {})}>
+        <div style={Object.assign({}, styles.outer, {})}>
           <div
-            style={Object.assign(styles.inner, {
+            style={Object.assign({}, styles.inner, {
               marginTop: Inner$marginTop,
               marginRight: Inner$marginRight,
               marginBottom: Inner$marginBottom,
@@ -43,9 +43,9 @@ export default class BoxModelConditional extends React.Component {
 
 let styles = {
   outer: {
-    alignItems: "stretch",
-    alignSelf: "stretch",
+    alignItems: "flex-start",
     display: "flex",
+    flex: "1 1 0%",
     flexDirection: "column",
     paddingTop: "4px",
     paddingRight: "4px",
@@ -53,7 +53,7 @@ let styles = {
     paddingLeft: "4px"
   },
   inner: {
-    alignItems: "stretch",
+    alignItems: "flex-start",
     backgroundColor: "#D8D8D8",
     display: "flex",
     flexDirection: "column",

--- a/examples/generated/test/react-dom/style/TextAlignment.js
+++ b/examples/generated/test/react-dom/style/TextAlignment.js
@@ -33,59 +33,59 @@ export default class TextAlignment extends React.Component {
     }
     return (
       <ThemeProvider theme={theme}>
-        <div style={Object.assign(styles.view, {})}>
-          <div style={Object.assign(styles.view1, {})}>
+        <div style={Object.assign({}, styles.view, {})}>
+          <div style={Object.assign({}, styles.view1, {})}>
             <img
-              style={Object.assign(styles.image, {})}
+              style={Object.assign({}, styles.image, {})}
               src={require("../assets/icon_128x128.png")}
 
             />
-            <div style={Object.assign(styles.view2, {})} />
-            <span style={Object.assign(styles.text, {})}>
+            <div style={Object.assign({}, styles.view2, {})} />
+            <span style={Object.assign({}, styles.text, {})}>
               {"Welcome to Lona Studio"}
             </span>
-            <span style={Object.assign(styles.text1, {})}>
+            <span style={Object.assign({}, styles.text1, {})}>
               {"Centered - Width: Fit"}
             </span>
-            <span style={Object.assign(styles.text2, {})}>
+            <span style={Object.assign({}, styles.text2, {})}>
               {"Left aligned - Width: Fill"}
             </span>
-            <span style={Object.assign(styles.text3, {})}>
+            <span style={Object.assign({}, styles.text3, {})}>
               {"Right aligned - Width: Fill"}
             </span>
-            <span style={Object.assign(styles.text4, {})}>
+            <span style={Object.assign({}, styles.text4, {})}>
               {"Centered - Width: 80"}
             </span>
           </div>
-          <div style={Object.assign(styles.view3, {})}>
-            <span style={Object.assign(styles.text5, {})}>
+          <div style={Object.assign({}, styles.view3, {})}>
+            <span style={Object.assign({}, styles.text5, {})}>
               {"Left aligned text, Fit w/ secondary centering"}
             </span>
           </div>
-          <div style={Object.assign(styles.view4, {})}>
-            <span style={Object.assign(styles.text6, {})}>
+          <div style={Object.assign({}, styles.view4, {})}>
+            <span style={Object.assign({}, styles.text6, {})}>
               {"Left aligned text, Fixed w/ secondary centering"}
             </span>
           </div>
-          <div style={Object.assign(styles.view5, {})}>
-            <span style={Object.assign(styles.text7, {})}>
+          <div style={Object.assign({}, styles.view5, {})}>
+            <span style={Object.assign({}, styles.text7, {})}>
               {"Centered text, Fit parent no centering"}
             </span>
           </div>
-          <div style={Object.assign(styles.view6, {})}>
-            <span style={Object.assign(styles.text8, {})}>
+          <div style={Object.assign({}, styles.view6, {})}>
+            <span style={Object.assign({}, styles.text8, {})}>
               {"Centered text, Fixed parent no centering"}
             </span>
           </div>
-          <div style={Object.assign(styles.rightAlignmentContainer, {})}>
-            <span style={Object.assign(styles.text9, {})}>
+          <div style={Object.assign({}, styles.rightAlignmentContainer, {})}>
+            <span style={Object.assign({}, styles.text9, {})}>
               {"Fit Text"}
             </span>
-            <span style={Object.assign(styles.text10, {})}>
+            <span style={Object.assign({}, styles.text10, {})}>
               {"Fill and center aligned text"}
             </span>
             <img
-              style={Object.assign(styles.image1, {})}
+              style={Object.assign({}, styles.image1, {})}
               src={require("../assets/icon_128x128.png")}
 
             />
@@ -99,8 +99,8 @@ export default class TextAlignment extends React.Component {
 let styles = {
   view: {
     alignItems: "flex-start",
-    alignSelf: "stretch",
     display: "flex",
+    flex: "1 1 0%",
     flexDirection: "column",
     paddingTop: "10px",
     paddingRight: "10px",
@@ -112,126 +112,154 @@ let styles = {
     alignSelf: "stretch",
     backgroundColor: colors.indigo50,
     display: "flex",
+    flex: "0 0 auto",
     flexDirection: "column",
     justifyContent: "center"
-  },
-  image: {
-    alignItems: "stretch",
-    display: "flex",
-    flexDirection: "column",
-    width: "100px",
-    height: "100px"
-  },
-  view2: {
-    alignItems: "stretch",
-    backgroundColor: "#D8D8D8",
-    display: "flex",
-    flexDirection: "column"
-  },
-  text: {
-    textAlign: "center",
-    ...textStyles.display1,
-    alignItems: "stretch",
-    alignSelf: "stretch",
-    display: "flex",
-    flexDirection: "column",
-    marginTop: "16px"
-  },
-  text1: {
-    textAlign: "center",
-    ...textStyles.subheading2,
-    alignItems: "stretch",
-    display: "flex",
-    flexDirection: "column",
-    marginTop: "16px"
-  },
-  text2: {
-    alignItems: "stretch",
-    alignSelf: "stretch",
-    display: "flex",
-    flexDirection: "column",
-    marginTop: "12px"
-  },
-  text3: {
-    textAlign: "right",
-    alignItems: "stretch",
-    alignSelf: "stretch",
-    display: "flex",
-    flexDirection: "column"
-  },
-  text4: {
-    textAlign: "center",
-    alignItems: "stretch",
-    display: "flex",
-    flexDirection: "column",
-    width: "80px"
   },
   view3: {
     alignItems: "center",
     backgroundColor: "#D8D8D8",
     display: "flex",
+    flex: "0 0 auto",
     flexDirection: "column",
     paddingRight: "12px",
     paddingLeft: "12px"
   },
-  text5: { alignItems: "stretch", display: "flex", flexDirection: "column" },
   view4: {
     alignItems: "center",
     backgroundColor: "#D8D8D8",
     display: "flex",
+    flex: "0 0 auto",
     flexDirection: "column",
     paddingRight: "12px",
     paddingLeft: "12px",
     width: "400px"
   },
-  text6: { alignItems: "stretch", display: "flex", flexDirection: "column" },
   view5: {
-    alignItems: "stretch",
+    alignItems: "flex-start",
     backgroundColor: "#D8D8D8",
     display: "flex",
+    flex: "0 0 auto",
     flexDirection: "column",
     paddingRight: "12px",
     paddingLeft: "12px"
   },
-  text7: {
-    textAlign: "center",
-    alignItems: "stretch",
-    display: "flex",
-    flexDirection: "column"
-  },
   view6: {
-    alignItems: "stretch",
+    alignItems: "flex-start",
     backgroundColor: "#D8D8D8",
     display: "flex",
+    flex: "0 0 auto",
     flexDirection: "column",
     paddingRight: "12px",
     paddingLeft: "12px",
     width: "400px"
-  },
-  text8: {
-    textAlign: "center",
-    alignItems: "stretch",
-    alignSelf: "stretch",
-    display: "flex",
-    flexDirection: "column"
   },
   rightAlignmentContainer: {
     alignItems: "flex-end",
     alignSelf: "stretch",
     backgroundColor: "#D8D8D8",
     display: "flex",
+    flex: "0 0 auto",
     flexDirection: "column"
   },
-  text9: { alignItems: "stretch", display: "flex", flexDirection: "column" },
-  text10: {
+  image: {
+    alignItems: "flex-start",
+    display: "flex",
+    flexDirection: "column",
+    width: "100px",
+    height: "100px"
+  },
+  view2: {
+    alignItems: "flex-start",
+    backgroundColor: "#D8D8D8",
+    display: "flex",
+    flex: "0 0 auto",
+    flexDirection: "column"
+  },
+  text: {
     textAlign: "center",
-    alignItems: "stretch",
+    ...textStyles.display1,
     alignSelf: "stretch",
     display: "flex",
+    flex: "0 0 auto",
+    flexDirection: "column",
+    marginTop: "16px"
+  },
+  text1: {
+    textAlign: "center",
+    ...textStyles.subheading2,
+    display: "flex",
+    flex: "0 0 auto",
+    flexDirection: "column",
+    marginTop: "16px"
+  },
+  text2: {
+    ...textStyles.body1,
+    alignSelf: "stretch",
+    display: "flex",
+    flex: "0 0 auto",
+    flexDirection: "column",
+    marginTop: "12px"
+  },
+  text3: {
+    textAlign: "right",
+    ...textStyles.body1,
+    alignSelf: "stretch",
+    display: "flex",
+    flex: "0 0 auto",
+    flexDirection: "column"
+  },
+  text4: {
+    textAlign: "center",
+    ...textStyles.body1,
+    display: "flex",
+    flex: "0 0 auto",
+    flexDirection: "column",
+    width: "80px"
+  },
+  text5: {
+    ...textStyles.body1,
+    display: "flex",
+    flex: "0 0 auto",
+    flexDirection: "column"
+  },
+  text6: {
+    ...textStyles.body1,
+    display: "flex",
+    flex: "0 0 auto",
+    flexDirection: "column"
+  },
+  text7: {
+    textAlign: "center",
+    ...textStyles.body1,
+    display: "flex",
+    flex: "0 0 auto",
+    flexDirection: "column"
+  },
+  text8: {
+    textAlign: "center",
+    ...textStyles.body1,
+    alignSelf: "stretch",
+    display: "flex",
+    flex: "0 0 auto",
+    flexDirection: "column"
+  },
+  text9: {
+    ...textStyles.body1,
+    display: "flex",
+    flex: "0 0 auto",
+    flexDirection: "column"
+  },
+  text10: {
+    textAlign: "center",
+    ...textStyles.body1,
+    alignSelf: "stretch",
+    display: "flex",
+    flex: "0 0 auto",
     flexDirection: "column"
   },
   image1: {
-    alignItems: "stretch",
+    alignItems: "flex-start",
     display: "flex",
     flexDirection: "column",
     width: "100px",

--- a/examples/generated/test/react-dom/style/TextAlignment.js
+++ b/examples/generated/test/react-dom/style/TextAlignment.js
@@ -102,6 +102,7 @@ let styles = {
     display: "flex",
     flex: "1 1 0%",
     flexDirection: "column",
+    justifyContent: "flex-start",
     paddingTop: "10px",
     paddingRight: "10px",
     paddingBottom: "10px",
@@ -122,6 +123,7 @@ let styles = {
     display: "flex",
     flex: "0 0 auto",
     flexDirection: "column",
+    justifyContent: "flex-start",
     paddingRight: "12px",
     paddingLeft: "12px"
   },
@@ -131,6 +133,7 @@ let styles = {
     display: "flex",
     flex: "0 0 auto",
     flexDirection: "column",
+    justifyContent: "flex-start",
     paddingRight: "12px",
     paddingLeft: "12px",
     width: "400px"
@@ -141,6 +144,7 @@ let styles = {
     display: "flex",
     flex: "0 0 auto",
     flexDirection: "column",
+    justifyContent: "flex-start",
     paddingRight: "12px",
     paddingLeft: "12px"
   },
@@ -150,6 +154,7 @@ let styles = {
     display: "flex",
     flex: "0 0 auto",
     flexDirection: "column",
+    justifyContent: "flex-start",
     paddingRight: "12px",
     paddingLeft: "12px",
     width: "400px"
@@ -160,12 +165,14 @@ let styles = {
     backgroundColor: "#D8D8D8",
     display: "flex",
     flex: "0 0 auto",
-    flexDirection: "column"
+    flexDirection: "column",
+    justifyContent: "flex-start"
   },
   image: {
     alignItems: "flex-start",
     display: "flex",
     flexDirection: "column",
+    justifyContent: "flex-start",
     width: "100px",
     height: "100px"
   },
@@ -174,94 +181,107 @@ let styles = {
     backgroundColor: "#D8D8D8",
     display: "flex",
     flex: "0 0 auto",
-    flexDirection: "column"
+    flexDirection: "column",
+    justifyContent: "flex-start"
   },
   text: {
     textAlign: "center",
     ...textStyles.display1,
+    alignItems: "flex-start",
     alignSelf: "stretch",
-    display: "flex",
     flex: "0 0 auto",
     flexDirection: "column",
+    justifyContent: "flex-start",
     marginTop: "16px"
   },
   text1: {
     textAlign: "center",
     ...textStyles.subheading2,
-    display: "flex",
+    alignItems: "flex-start",
     flex: "0 0 auto",
     flexDirection: "column",
+    justifyContent: "flex-start",
     marginTop: "16px"
   },
   text2: {
     ...textStyles.body1,
+    alignItems: "flex-start",
     alignSelf: "stretch",
-    display: "flex",
     flex: "0 0 auto",
     flexDirection: "column",
+    justifyContent: "flex-start",
     marginTop: "12px"
   },
   text3: {
     textAlign: "right",
     ...textStyles.body1,
+    alignItems: "flex-start",
     alignSelf: "stretch",
-    display: "flex",
     flex: "0 0 auto",
-    flexDirection: "column"
+    flexDirection: "column",
+    justifyContent: "flex-start"
   },
   text4: {
     textAlign: "center",
     ...textStyles.body1,
-    display: "flex",
+    alignItems: "flex-start",
     flex: "0 0 auto",
     flexDirection: "column",
+    justifyContent: "flex-start",
     width: "80px"
   },
   text5: {
     ...textStyles.body1,
-    display: "flex",
+    alignItems: "flex-start",
     flex: "0 0 auto",
-    flexDirection: "column"
+    flexDirection: "column",
+    justifyContent: "flex-start"
   },
   text6: {
     ...textStyles.body1,
-    display: "flex",
+    alignItems: "flex-start",
     flex: "0 0 auto",
-    flexDirection: "column"
+    flexDirection: "column",
+    justifyContent: "flex-start"
   },
   text7: {
     textAlign: "center",
     ...textStyles.body1,
-    display: "flex",
+    alignItems: "flex-start",
     flex: "0 0 auto",
-    flexDirection: "column"
+    flexDirection: "column",
+    justifyContent: "flex-start"
   },
   text8: {
     textAlign: "center",
     ...textStyles.body1,
+    alignItems: "flex-start",
     alignSelf: "stretch",
-    display: "flex",
     flex: "0 0 auto",
-    flexDirection: "column"
+    flexDirection: "column",
+    justifyContent: "flex-start"
   },
   text9: {
     ...textStyles.body1,
-    display: "flex",
+    alignItems: "flex-start",
     flex: "0 0 auto",
-    flexDirection: "column"
+    flexDirection: "column",
+    justifyContent: "flex-start"
   },
   text10: {
     textAlign: "center",
     ...textStyles.body1,
+    alignItems: "flex-start",
     alignSelf: "stretch",
-    display: "flex",
     flex: "0 0 auto",
-    flexDirection: "column"
+    flexDirection: "column",
+    justifyContent: "flex-start"
   },
   image1: {
     alignItems: "flex-start",
     display: "flex",
     flexDirection: "column",
+    justifyContent: "flex-start",
     width: "100px",
     height: "100px"
   }

--- a/examples/generated/test/react-dom/style/TextStyleConditional.js
+++ b/examples/generated/test/react-dom/style/TextStyleConditional.js
@@ -16,8 +16,8 @@ export default class TextStyleConditional extends React.Component {
     let theme = { "view": { "normal": {} }, "text": { "normal": {} } }
     return (
       <ThemeProvider theme={theme}>
-        <div style={Object.assign(styles.view, {})}>
-          <span style={Object.assign(styles.text, { ...Text$textStyle })}>
+        <div style={Object.assign({}, styles.view, {})}>
+          <span style={Object.assign({}, styles.text, { ...Text$textStyle })}>
             {"Text goes here"}
           </span>
         </div>
@@ -28,15 +28,15 @@ export default class TextStyleConditional extends React.Component {
 
 let styles = {
   view: {
-    alignItems: "stretch",
-    alignSelf: "stretch",
+    alignItems: "flex-start",
     display: "flex",
+    flex: "1 1 0%",
     flexDirection: "column"
   },
   text: {
     ...textStyles.headline,
-    alignItems: "stretch",
     display: "flex",
+    flex: "0 0 auto",
     flexDirection: "column"
   }
 }

--- a/examples/generated/test/react-dom/style/TextStyleConditional.js
+++ b/examples/generated/test/react-dom/style/TextStyleConditional.js
@@ -31,12 +31,14 @@ let styles = {
     alignItems: "flex-start",
     display: "flex",
     flex: "1 1 0%",
-    flexDirection: "column"
+    flexDirection: "column",
+    justifyContent: "flex-start"
   },
   text: {
     ...textStyles.headline,
-    display: "flex",
+    alignItems: "flex-start",
     flex: "0 0 auto",
-    flexDirection: "column"
+    flexDirection: "column",
+    justifyContent: "flex-start"
   }
 }

--- a/examples/generated/test/react-dom/style/TextStylesTest.js
+++ b/examples/generated/test/react-dom/style/TextStylesTest.js
@@ -23,35 +23,35 @@ export default class TextStylesTest extends React.Component {
     }
     return (
       <ThemeProvider theme={theme}>
-        <div style={Object.assign(styles.view, {})}>
-          <span style={Object.assign(styles.text, {})}>
+        <div style={Object.assign({}, styles.view, {})}>
+          <span style={Object.assign({}, styles.text, {})}>
             {"Text goes here"}
           </span>
-          <span style={Object.assign(styles.text1, {})}>
+          <span style={Object.assign({}, styles.text1, {})}>
             {"Text goes here"}
           </span>
-          <span style={Object.assign(styles.text2, {})}>
+          <span style={Object.assign({}, styles.text2, {})}>
             {"Text goes here"}
           </span>
-          <span style={Object.assign(styles.text3, {})}>
+          <span style={Object.assign({}, styles.text3, {})}>
             {"Text goes here"}
           </span>
-          <span style={Object.assign(styles.text4, {})}>
+          <span style={Object.assign({}, styles.text4, {})}>
             {"Text goes here"}
           </span>
-          <span style={Object.assign(styles.text5, {})}>
+          <span style={Object.assign({}, styles.text5, {})}>
             {"Text goes here"}
           </span>
-          <span style={Object.assign(styles.text6, {})}>
+          <span style={Object.assign({}, styles.text6, {})}>
             {"Text goes here"}
           </span>
-          <span style={Object.assign(styles.text7, {})}>
+          <span style={Object.assign({}, styles.text7, {})}>
             {"Text goes here"}
           </span>
-          <span style={Object.assign(styles.text8, {})}>
+          <span style={Object.assign({}, styles.text8, {})}>
             {"Text goes here"}
           </span>
-          <span style={Object.assign(styles.text9, {})}>
+          <span style={Object.assign({}, styles.text9, {})}>
             {"Text goes here"}
           </span>
         </div>
@@ -62,69 +62,69 @@ export default class TextStylesTest extends React.Component {
 
 let styles = {
   view: {
-    alignItems: "stretch",
-    alignSelf: "stretch",
+    alignItems: "flex-start",
     display: "flex",
+    flex: "1 1 0%",
     flexDirection: "column"
   },
   text: {
     ...textStyles.display4,
-    alignItems: "stretch",
     display: "flex",
+    flex: "0 0 auto",
     flexDirection: "column"
   },
   text1: {
     ...textStyles.display3,
-    alignItems: "stretch",
     display: "flex",
+    flex: "0 0 auto",
     flexDirection: "column"
   },
   text2: {
     ...textStyles.display2,
-    alignItems: "stretch",
     display: "flex",
+    flex: "0 0 auto",
     flexDirection: "column"
   },
   text3: {
     ...textStyles.display1,
-    alignItems: "stretch",
     display: "flex",
+    flex: "0 0 auto",
     flexDirection: "column"
   },
   text4: {
     ...textStyles.headline,
-    alignItems: "stretch",
     display: "flex",
+    flex: "0 0 auto",
     flexDirection: "column"
   },
   text5: {
     ...textStyles.subheading2,
-    alignItems: "stretch",
     display: "flex",
+    flex: "0 0 auto",
     flexDirection: "column"
   },
   text6: {
     ...textStyles.subheading1,
-    alignItems: "stretch",
     display: "flex",
+    flex: "0 0 auto",
     flexDirection: "column"
   },
   text7: {
     ...textStyles.body2,
-    alignItems: "stretch",
     display: "flex",
+    flex: "0 0 auto",
     flexDirection: "column"
   },
   text8: {
     ...textStyles.body1,
-    alignItems: "stretch",
     display: "flex",
+    flex: "0 0 auto",
     flexDirection: "column"
   },
   text9: {
     ...textStyles.caption,
-    alignItems: "stretch",
     display: "flex",
+    flex: "0 0 auto",
     flexDirection: "column"
   }
 }

--- a/examples/generated/test/react-dom/style/TextStylesTest.js
+++ b/examples/generated/test/react-dom/style/TextStylesTest.js
@@ -65,66 +65,77 @@ let styles = {
     alignItems: "flex-start",
     display: "flex",
     flex: "1 1 0%",
-    flexDirection: "column"
+    flexDirection: "column",
+    justifyContent: "flex-start"
   },
   text: {
     ...textStyles.display4,
-    display: "flex",
+    alignItems: "flex-start",
     flex: "0 0 auto",
-    flexDirection: "column"
+    flexDirection: "column",
+    justifyContent: "flex-start"
   },
   text1: {
     ...textStyles.display3,
-    display: "flex",
+    alignItems: "flex-start",
     flex: "0 0 auto",
-    flexDirection: "column"
+    flexDirection: "column",
+    justifyContent: "flex-start"
   },
   text2: {
     ...textStyles.display2,
-    display: "flex",
+    alignItems: "flex-start",
     flex: "0 0 auto",
-    flexDirection: "column"
+    flexDirection: "column",
+    justifyContent: "flex-start"
   },
   text3: {
     ...textStyles.display1,
-    display: "flex",
+    alignItems: "flex-start",
     flex: "0 0 auto",
-    flexDirection: "column"
+    flexDirection: "column",
+    justifyContent: "flex-start"
   },
   text4: {
     ...textStyles.headline,
-    display: "flex",
+    alignItems: "flex-start",
     flex: "0 0 auto",
-    flexDirection: "column"
+    flexDirection: "column",
+    justifyContent: "flex-start"
   },
   text5: {
     ...textStyles.subheading2,
-    display: "flex",
+    alignItems: "flex-start",
     flex: "0 0 auto",
-    flexDirection: "column"
+    flexDirection: "column",
+    justifyContent: "flex-start"
   },
   text6: {
     ...textStyles.subheading1,
-    display: "flex",
+    alignItems: "flex-start",
     flex: "0 0 auto",
-    flexDirection: "column"
+    flexDirection: "column",
+    justifyContent: "flex-start"
   },
   text7: {
     ...textStyles.body2,
-    display: "flex",
+    alignItems: "flex-start",
     flex: "0 0 auto",
-    flexDirection: "column"
+    flexDirection: "column",
+    justifyContent: "flex-start"
   },
   text8: {
     ...textStyles.body1,
-    display: "flex",
+    alignItems: "flex-start",
     flex: "0 0 auto",
-    flexDirection: "column"
+    flexDirection: "column",
+    justifyContent: "flex-start"
   },
   text9: {
     ...textStyles.caption,
-    display: "flex",
+    alignItems: "flex-start",
     flex: "0 0 auto",
-    flexDirection: "column"
+    flexDirection: "column",
+    justifyContent: "flex-start"
   }
 }

--- a/examples/generated/test/react-dom/textStyles.js
+++ b/examples/generated/test/react-dom/textStyles.js
@@ -2,77 +2,77 @@ import colors from "./colors"
 
 export default {
   display4: {
-    family: "Arial",
+    fontFamily: "Arial",
     fontWeight: "300",
     fontSize: "112px",
     lineHeight: "120px",
     color: colors.grey900
   },
   display3: {
-    family: "Arial",
+    fontFamily: "Arial",
     fontWeight: "400",
     fontSize: "56px",
     lineHeight: "60px",
     color: colors.grey900
   },
   display2: {
-    family: "Arial",
+    fontFamily: "Arial",
     fontWeight: "400",
     fontSize: "45px",
     lineHeight: "48px",
     color: colors.grey900
   },
   display1: {
-    family: "Arial",
+    fontFamily: "Arial",
     fontWeight: "400",
     fontSize: "34px",
     lineHeight: "40px",
     color: colors.grey900
   },
   headline: {
-    family: "Arial",
+    fontFamily: "Arial",
     fontWeight: "400",
     fontSize: "24px",
     lineHeight: "32px",
     color: colors.grey900
   },
   subheading2: {
-    family: "Arial",
+    fontFamily: "Arial",
     fontWeight: "400",
     fontSize: "16px",
     lineHeight: "28px",
     color: colors.grey900
   },
   subheading1: {
-    family: "Arial",
+    fontFamily: "Arial",
     fontWeight: "400",
     fontSize: "16px",
     lineHeight: "24px",
     color: colors.grey900
   },
   body2: {
-    family: "Arial",
+    fontFamily: "Arial",
     fontWeight: "500",
     fontSize: "14px",
     lineHeight: "24px",
     color: colors.grey900
   },
   body1: {
-    family: "Arial",
+    fontFamily: "Arial",
     fontWeight: "400",
     fontSize: "14px",
     lineHeight: "20px",
     color: colors.grey900
   },
   caption: {
-    family: "Arial",
+    fontFamily: "Arial",
     fontWeight: "400",
     fontSize: "12px",
     lineHeight: "15px",
     color: colors.grey900
   },
   button: {
-    family: "Arial",
+    fontFamily: "Arial",
     fontWeight: "500",
     fontSize: "14px",
     lineHeight: "18px",

--- a/examples/generated/test/react-native/components/ComponentParameterInstance.js
+++ b/examples/generated/test/react-native/components/ComponentParameterInstance.js
@@ -23,6 +23,10 @@ export default class ComponentParameterInstance extends React.Component {
 };
 
 let styles = StyleSheet.create({
-  view: { alignSelf: "stretch" },
-  componentParameterTemplate: {}
+  view: { alignItems: "flex-start", alignSelf: "stretch", flex: 0 },
+  componentParameterTemplate: {
+    alignItems: "stretch",
+    flex: 0,
+    flexDirection: "column"
+  }
 })

--- a/examples/generated/test/react-native/components/ComponentParameterInstance.js
+++ b/examples/generated/test/react-native/components/ComponentParameterInstance.js
@@ -11,22 +11,25 @@ export default class ComponentParameterInstance extends React.Component {
 
     return (
       <View style={[ styles.view, {} ]}>
-        <ComponentParameterTemplate
-          style={[ styles.componentParameterTemplate, {} ]}
-          subtitleComponent={{"parameters":{"text":"Subtitle","textStyle":"subheading2"},"type":"Lona:Text"}}
-          titleComponent={{"parameters":{"text":"Title","textStyle":"headline"},"type":"Lona:Text"}}
+        <View style={[ styles.componentParameterTemplate, {} ]}>
+          <ComponentParameterTemplate
+            subtitleComponent={{"parameters":{"text":"Subtitle","textStyle":"subheading2"},"type":"Lona:Text"}}
+            titleComponent={{"parameters":{"text":"Title","textStyle":"headline"},"type":"Lona:Text"}}
 
-        />
+          />
+        </View>
       </View>
     );
   }
 };
 
 let styles = StyleSheet.create({
-  view: { alignItems: "flex-start", alignSelf: "stretch", flex: 0 },
-  componentParameterTemplate: {
-    alignItems: "stretch",
+  view: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
     flex: 0,
-    flexDirection: "column"
-  }
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  componentParameterTemplate: { alignItems: "stretch", flexDirection: "column" }
 })

--- a/examples/generated/test/react-native/components/NestedBottomLeftLayout.js
+++ b/examples/generated/test/react-native/components/NestedBottomLeftLayout.js
@@ -3,19 +3,19 @@ import { View, StyleSheet } from "react-native"
 
 import colors from "../colors"
 import textStyles from "../textStyles"
-import ComponentParameterTemplate from "./ComponentParameterTemplate"
+import LocalAsset from "../images/LocalAsset"
 
-export default class ComponentParameterInstance extends React.Component {
+export default class NestedBottomLeftLayout extends React.Component {
   render() {
 
 
     return (
       <View style={[ styles.view, {} ]}>
-        <ComponentParameterTemplate
-          subtitleComponent={{"parameters":{"text":"Subtitle","textStyle":"subheading2"},"type":"Lona:Text"}}
-          titleComponent={{"parameters":{"text":"Title","textStyle":"headline"},"type":"Lona:Text"}}
-
-        />
+        <View style={[ styles.view1, {} ]}>
+          <View style={[ styles.localAsset, {} ]}>
+            <LocalAsset />
+          </View>
+        </View>
       </View>
     );
   }
@@ -29,8 +29,16 @@ let styles = StyleSheet.create({
     flexDirection: "column",
     justifyContent: "flex-start"
   },
-  componentParameterTemplate: {
-    alignItems: "flex-start",
+  view1: {
+    alignItems: "flex-end",
+    backgroundColor: colors.red100,
+    flexDirection: "row",
+    justifyContent: "flex-start",
+    width: 150,
+    height: 150
+  },
+  localAsset: {
+    alignItems: "flex-end",
     alignSelf: "stretch",
     flex: 1,
     flexDirection: "row",

--- a/examples/generated/test/react-native/components/NestedButtons.js
+++ b/examples/generated/test/react-native/components/NestedButtons.js
@@ -11,9 +11,13 @@ export default class NestedButtons extends React.Component {
 
     return (
       <View style={[ styles.view, {} ]}>
-        <Button style={[ styles.button, {} ]} label={"Button 1"} />
+        <View style={[ styles.button, {} ]}>
+          <Button label={"Button 1"} />
+        </View>
         <View style={[ styles.view1, {} ]} />
-        <Button style={[ styles.button2, {} ]} label={"Button 2"} />
+        <View style={[ styles.button2, {} ]}>
+          <Button label={"Button 2"} />
+        </View>
       </View>
     );
   }
@@ -24,12 +28,20 @@ let styles = StyleSheet.create({
     alignItems: "flex-start",
     alignSelf: "stretch",
     flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     paddingTop: 24,
     paddingRight: 24,
     paddingBottom: 24,
     paddingLeft: 24
   },
-  button: { alignItems: "stretch", flex: 0, flexDirection: "column" },
-  view1: { alignItems: "flex-start", alignSelf: "stretch", height: 8 },
-  button2: { alignItems: "stretch", flex: 0, flexDirection: "column" }
+  button: { alignItems: "stretch", flexDirection: "column" },
+  view1: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    height: 8
+  },
+  button2: { alignItems: "stretch", flexDirection: "column" }
 })

--- a/examples/generated/test/react-native/components/NestedButtons.js
+++ b/examples/generated/test/react-native/components/NestedButtons.js
@@ -11,13 +11,9 @@ export default class NestedButtons extends React.Component {
 
     return (
       <View style={[ styles.view, {} ]}>
-        <View style={[ styles.button, {} ]}>
-          <Button label={"Button 1"} />
-        </View>
+        <Button label={"Button 1"} />
         <View style={[ styles.view1, {} ]} />
-        <View style={[ styles.button2, {} ]}>
-          <Button label={"Button 2"} />
-        </View>
+        <Button label={"Button 2"} />
       </View>
     );
   }
@@ -35,7 +31,13 @@ let styles = StyleSheet.create({
     paddingBottom: 24,
     paddingLeft: 24
   },
-  button: { alignItems: "stretch", flexDirection: "column" },
+  button: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  },
   view1: {
     alignItems: "flex-start",
     alignSelf: "stretch",
@@ -43,5 +45,11 @@ let styles = StyleSheet.create({
     justifyContent: "flex-start",
     height: 8
   },
-  button2: { alignItems: "stretch", flexDirection: "column" }
+  button2: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  }
 })

--- a/examples/generated/test/react-native/components/NestedButtons.js
+++ b/examples/generated/test/react-native/components/NestedButtons.js
@@ -21,13 +21,15 @@ export default class NestedButtons extends React.Component {
 
 let styles = StyleSheet.create({
   view: {
+    alignItems: "flex-start",
     alignSelf: "stretch",
+    flex: 0,
     paddingTop: 24,
     paddingRight: 24,
     paddingBottom: 24,
     paddingLeft: 24
   },
-  button: {},
-  view1: { alignSelf: "stretch", height: 8 },
-  button2: {}
+  button: { alignItems: "stretch", flex: 0, flexDirection: "column" },
+  view1: { alignItems: "flex-start", alignSelf: "stretch", height: 8 },
+  button2: { alignItems: "stretch", flex: 0, flexDirection: "column" }
 })

--- a/examples/generated/test/react-native/components/NestedComponent.js
+++ b/examples/generated/test/react-native/components/NestedComponent.js
@@ -16,14 +16,15 @@ export default class NestedComponent extends React.Component {
         <Text style={[ styles.text, {} ]}>
           {"Example nested component"}
         </Text>
-        <FitContentParentSecondaryChildren
-          style={[ styles.fitContentParentSecondaryChildren, {} ]}
-
-        />
+        <View style={[ styles.fitContentParentSecondaryChildren, {} ]}>
+          <FitContentParentSecondaryChildren />
+        </View>
         <Text style={[ styles.text1, {} ]}>
           {"Text below"}
         </Text>
-        <LocalAsset style={[ styles.localAsset, {} ]} />
+        <View style={[ styles.localAsset, {} ]}>
+          <LocalAsset />
+        </View>
         <Text style={[ styles.text2, {} ]}>
           {"Very bottom"}
         </Text>
@@ -37,6 +38,8 @@ let styles = StyleSheet.create({
     alignItems: "flex-start",
     alignSelf: "stretch",
     flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     paddingTop: 10,
     paddingRight: 10,
     paddingBottom: 10,
@@ -46,19 +49,28 @@ let styles = StyleSheet.create({
     ...textStyles.subheading2,
     alignItems: "flex-start",
     flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     marginBottom: 8
   },
   fitContentParentSecondaryChildren: {
     alignItems: "stretch",
-    flex: 0,
     flexDirection: "column"
   },
   text1: {
     ...textStyles.body1,
     alignItems: "flex-start",
     flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     marginTop: 12
   },
-  localAsset: { alignItems: "stretch", flex: 0, flexDirection: "column" },
-  text2: { ...textStyles.body1, alignItems: "flex-start", flex: 0 }
+  localAsset: { alignItems: "stretch", flexDirection: "column" },
+  text2: {
+    ...textStyles.body1,
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  }
 })

--- a/examples/generated/test/react-native/components/NestedComponent.js
+++ b/examples/generated/test/react-native/components/NestedComponent.js
@@ -34,15 +34,31 @@ export default class NestedComponent extends React.Component {
 
 let styles = StyleSheet.create({
   view: {
+    alignItems: "flex-start",
     alignSelf: "stretch",
+    flex: 0,
     paddingTop: 10,
     paddingRight: 10,
     paddingBottom: 10,
     paddingLeft: 10
   },
-  text: { ...textStyles.subheading2, marginBottom: 8 },
-  fitContentParentSecondaryChildren: {},
-  text1: { marginTop: 12 },
-  localAsset: {},
-  text2: {}
+  text: {
+    ...textStyles.subheading2,
+    alignItems: "flex-start",
+    flex: 0,
+    marginBottom: 8
+  },
+  fitContentParentSecondaryChildren: {
+    alignItems: "stretch",
+    flex: 0,
+    flexDirection: "column"
+  },
+  text1: {
+    ...textStyles.body1,
+    alignItems: "flex-start",
+    flex: 0,
+    marginTop: 12
+  },
+  localAsset: { alignItems: "stretch", flex: 0, flexDirection: "column" },
+  text2: { ...textStyles.body1, alignItems: "flex-start", flex: 0 }
 })

--- a/examples/generated/test/react-native/components/NestedLayout.js
+++ b/examples/generated/test/react-native/components/NestedLayout.js
@@ -1,0 +1,427 @@
+import React from "react"
+import { View, StyleSheet } from "react-native"
+
+import colors from "../colors"
+import textStyles from "../textStyles"
+import LocalAsset from "../images/LocalAsset"
+
+export default class NestedLayout extends React.Component {
+  render() {
+
+
+    return (
+      <View style={[ styles.view, {} ]}>
+        <View style={[ styles.topRow, {} ]}>
+          <View style={[ styles.column1, {} ]}>
+            <View style={[ styles.view1, {} ]}>
+              <LocalAsset />
+            </View>
+            <View style={[ styles.view2, {} ]}>
+              <LocalAsset />
+            </View>
+            <View style={[ styles.view3, {} ]}>
+              <LocalAsset />
+            </View>
+          </View>
+          <View style={[ styles.column2, {} ]}>
+            <View style={[ styles.view4, {} ]}>
+              <LocalAsset />
+            </View>
+            <View style={[ styles.view5, {} ]}>
+              <LocalAsset />
+            </View>
+            <View style={[ styles.view6, {} ]}>
+              <LocalAsset />
+            </View>
+          </View>
+          <View style={[ styles.column3, {} ]}>
+            <View style={[ styles.view7, {} ]}>
+              <LocalAsset />
+            </View>
+            <View style={[ styles.view8, {} ]}>
+              <LocalAsset />
+            </View>
+            <View style={[ styles.view9, {} ]}>
+              <LocalAsset />
+            </View>
+          </View>
+        </View>
+        <View style={[ styles.bottomRow, {} ]}>
+          <View style={[ styles.column4, {} ]}>
+            <View style={[ styles.view10, {} ]}>
+              <View style={[ styles.localAsset10, {} ]}>
+                <LocalAsset />
+              </View>
+            </View>
+            <View style={[ styles.view11, {} ]}>
+              <View style={[ styles.localAsset11, {} ]}>
+                <LocalAsset />
+              </View>
+            </View>
+            <View style={[ styles.view12, {} ]}>
+              <View style={[ styles.localAsset12, {} ]}>
+                <LocalAsset />
+              </View>
+            </View>
+          </View>
+          <View style={[ styles.column5, {} ]}>
+            <View style={[ styles.view13, {} ]}>
+              <View style={[ styles.localAsset13, {} ]}>
+                <LocalAsset />
+              </View>
+            </View>
+            <View style={[ styles.view14, {} ]}>
+              <View style={[ styles.localAsset14, {} ]}>
+                <LocalAsset />
+              </View>
+            </View>
+            <View style={[ styles.view15, {} ]}>
+              <View style={[ styles.localAsset15, {} ]}>
+                <LocalAsset />
+              </View>
+            </View>
+          </View>
+          <View style={[ styles.column6, {} ]}>
+            <View style={[ styles.view16, {} ]}>
+              <View style={[ styles.localAsset16, {} ]}>
+                <LocalAsset />
+              </View>
+            </View>
+            <View style={[ styles.view17, {} ]}>
+              <View style={[ styles.localAsset17, {} ]}>
+                <LocalAsset />
+              </View>
+            </View>
+            <View style={[ styles.view18, {} ]}>
+              <View style={[ styles.localAsset18, {} ]}>
+                <LocalAsset />
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    );
+  }
+};
+
+let styles = StyleSheet.create({
+  view: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  topRow: {
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  },
+  bottomRow: {
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  },
+  column1: {
+    alignItems: "flex-start",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: 150
+  },
+  column2: {
+    alignItems: "flex-start",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: 150
+  },
+  column3: {
+    alignItems: "flex-start",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: 150
+  },
+  view1: {
+    alignItems: "flex-start",
+    backgroundColor: colors.grey50,
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: 150,
+    height: 150
+  },
+  view2: {
+    alignItems: "flex-start",
+    backgroundColor: "transparent",
+    flexDirection: "column",
+    justifyContent: "center",
+    width: 150,
+    height: 150
+  },
+  view3: {
+    alignItems: "flex-start",
+    backgroundColor: colors.grey50,
+    flexDirection: "column",
+    justifyContent: "flex-end",
+    width: 150,
+    height: 150
+  },
+  localAsset: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  },
+  localAsset2: {
+    alignItems: "center",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  },
+  localAsset3: {
+    alignItems: "flex-end",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  },
+  view4: {
+    alignItems: "center",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: 150,
+    height: 150
+  },
+  view5: {
+    alignItems: "center",
+    backgroundColor: colors.grey50,
+    flexDirection: "column",
+    justifyContent: "center",
+    width: 150,
+    height: 150
+  },
+  view6: {
+    alignItems: "center",
+    flexDirection: "column",
+    justifyContent: "flex-end",
+    width: 150,
+    height: 150
+  },
+  localAsset4: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "center"
+  },
+  localAsset5: {
+    alignItems: "center",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "center"
+  },
+  localAsset6: {
+    alignItems: "flex-end",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "center"
+  },
+  view7: {
+    alignItems: "flex-end",
+    backgroundColor: colors.grey50,
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: 150,
+    height: 150
+  },
+  view8: {
+    alignItems: "flex-end",
+    flexDirection: "column",
+    justifyContent: "center",
+    width: 150,
+    height: 150
+  },
+  view9: {
+    alignItems: "flex-end",
+    backgroundColor: colors.grey50,
+    flexDirection: "column",
+    justifyContent: "flex-end",
+    width: 150,
+    height: 150
+  },
+  localAsset7: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "flex-end"
+  },
+  localAsset8: {
+    alignItems: "center",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "flex-end"
+  },
+  localAsset9: {
+    alignItems: "flex-end",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "flex-end"
+  },
+  column4: {
+    alignItems: "flex-start",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: 150
+  },
+  column5: {
+    alignItems: "flex-start",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: 150
+  },
+  column6: {
+    alignItems: "flex-start",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: 150
+  },
+  view10: {
+    alignItems: "flex-start",
+    backgroundColor: colors.grey50,
+    flexDirection: "row",
+    justifyContent: "flex-start",
+    width: 150,
+    height: 150
+  },
+  view11: {
+    alignItems: "center",
+    backgroundColor: "transparent",
+    flexDirection: "row",
+    justifyContent: "flex-start",
+    width: 150,
+    height: 150
+  },
+  view12: {
+    alignItems: "flex-end",
+    backgroundColor: colors.grey50,
+    flexDirection: "row",
+    justifyContent: "flex-start",
+    width: 150,
+    height: 150
+  },
+  localAsset10: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  },
+  localAsset11: {
+    alignItems: "center",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  },
+  localAsset12: {
+    alignItems: "flex-end",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  },
+  view13: {
+    alignItems: "flex-start",
+    flexDirection: "row",
+    justifyContent: "center",
+    width: 150,
+    height: 150
+  },
+  view14: {
+    alignItems: "center",
+    backgroundColor: colors.grey50,
+    flexDirection: "row",
+    justifyContent: "center",
+    width: 150,
+    height: 150
+  },
+  view15: {
+    alignItems: "flex-end",
+    flexDirection: "row",
+    justifyContent: "center",
+    width: 150,
+    height: 150
+  },
+  localAsset13: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "center"
+  },
+  localAsset14: {
+    alignItems: "center",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "center"
+  },
+  localAsset15: {
+    alignItems: "flex-end",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "center"
+  },
+  view16: {
+    alignItems: "flex-start",
+    backgroundColor: colors.grey50,
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    width: 150,
+    height: 150
+  },
+  view17: {
+    alignItems: "center",
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    width: 150,
+    height: 150
+  },
+  view18: {
+    alignItems: "flex-end",
+    backgroundColor: colors.grey50,
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    width: 150,
+    height: 150
+  },
+  localAsset16: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "flex-end"
+  },
+  localAsset17: {
+    alignItems: "center",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "flex-end"
+  },
+  localAsset18: {
+    alignItems: "flex-end",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "flex-end"
+  }
+})

--- a/examples/generated/test/react-native/images/LocalAsset.js
+++ b/examples/generated/test/react-native/images/LocalAsset.js
@@ -21,10 +21,17 @@ export default class LocalAsset extends React.Component {
 };
 
 let styles = StyleSheet.create({
-  view: { alignItems: "flex-start", alignSelf: "stretch", flex: 0 },
+  view: {
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
   image: {
     alignItems: "flex-start",
     backgroundColor: "#D8D8D8",
+    flexDirection: "column",
+    justifyContent: "flex-start",
     width: 100,
     height: 100
   }

--- a/examples/generated/test/react-native/images/LocalAsset.js
+++ b/examples/generated/test/react-native/images/LocalAsset.js
@@ -23,6 +23,7 @@ export default class LocalAsset extends React.Component {
 let styles = StyleSheet.create({
   view: {
     alignItems: "flex-start",
+    backgroundColor: colors.red400,
     flex: 0,
     flexDirection: "column",
     justifyContent: "flex-start"

--- a/examples/generated/test/react-native/images/LocalAsset.js
+++ b/examples/generated/test/react-native/images/LocalAsset.js
@@ -21,6 +21,11 @@ export default class LocalAsset extends React.Component {
 };
 
 let styles = StyleSheet.create({
-  view: { alignSelf: "stretch" },
-  image: { backgroundColor: "#D8D8D8", width: 100, height: 100 }
+  view: { alignItems: "flex-start", alignSelf: "stretch", flex: 0 },
+  image: {
+    alignItems: "flex-start",
+    backgroundColor: "#D8D8D8",
+    width: 100,
+    height: 100
+  }
 })

--- a/examples/generated/test/react-native/interactivity/Button.js
+++ b/examples/generated/test/react-native/interactivity/Button.js
@@ -43,10 +43,18 @@ let styles = StyleSheet.create({
     alignItems: "flex-start",
     backgroundColor: colors.blue100,
     flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     paddingTop: 12,
     paddingRight: 16,
     paddingBottom: 12,
     paddingLeft: 16
   },
-  text: { ...textStyles.button, alignItems: "flex-start", flex: 0 }
+  text: {
+    ...textStyles.button,
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  }
 })

--- a/examples/generated/test/react-native/interactivity/Button.js
+++ b/examples/generated/test/react-native/interactivity/Button.js
@@ -40,11 +40,13 @@ export default class Button extends React.Component {
 
 let styles = StyleSheet.create({
   view: {
+    alignItems: "flex-start",
     backgroundColor: colors.blue100,
+    flex: 0,
     paddingTop: 12,
     paddingRight: 16,
     paddingBottom: 12,
     paddingLeft: 16
   },
-  text: { ...textStyles.button }
+  text: { ...textStyles.button, alignItems: "flex-start", flex: 0 }
 })

--- a/examples/generated/test/react-native/interactivity/PressableRootView.js
+++ b/examples/generated/test/react-native/interactivity/PressableRootView.js
@@ -65,6 +65,8 @@ let styles = StyleSheet.create({
     alignSelf: "stretch",
     backgroundColor: colors.grey50,
     flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     paddingTop: 24,
     paddingRight: 24,
     paddingBottom: 24,
@@ -73,8 +75,16 @@ let styles = StyleSheet.create({
   inner: {
     alignItems: "flex-start",
     backgroundColor: colors.blue500,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     width: 100,
     height: 100
   },
-  innerText: { ...textStyles.headline, alignItems: "flex-start", flex: 0 }
+  innerText: {
+    ...textStyles.headline,
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  }
 })

--- a/examples/generated/test/react-native/interactivity/PressableRootView.js
+++ b/examples/generated/test/react-native/interactivity/PressableRootView.js
@@ -61,13 +61,20 @@ export default class PressableRootView extends React.Component {
 
 let styles = StyleSheet.create({
   outer: {
+    alignItems: "flex-start",
     alignSelf: "stretch",
     backgroundColor: colors.grey50,
+    flex: 0,
     paddingTop: 24,
     paddingRight: 24,
     paddingBottom: 24,
     paddingLeft: 24
   },
-  inner: { backgroundColor: colors.blue500, width: 100, height: 100 },
-  innerText: { ...textStyles.headline }
+  inner: {
+    alignItems: "flex-start",
+    backgroundColor: colors.blue500,
+    width: 100,
+    height: 100
+  },
+  innerText: { ...textStyles.headline, alignItems: "flex-start", flex: 0 }
 })

--- a/examples/generated/test/react-native/layouts/FitContentParentSecondaryChildren.js
+++ b/examples/generated/test/react-native/layouts/FitContentParentSecondaryChildren.js
@@ -20,15 +20,32 @@ export default class FitContentParentSecondaryChildren extends React.Component {
 
 let styles = StyleSheet.create({
   container: {
+    alignItems: "flex-start",
     alignSelf: "stretch",
     backgroundColor: colors.bluegrey50,
+    flex: 0,
     flexDirection: "row",
     paddingTop: 24,
     paddingRight: 24,
     paddingBottom: 24,
     paddingLeft: 24
   },
-  view1: { backgroundColor: colors.blue500, width: 60, height: 60 },
-  view3: { backgroundColor: colors.lightblue500, width: 100, height: 120 },
-  view2: { backgroundColor: colors.cyan500, width: 100, height: 180 }
+  view1: {
+    alignItems: "flex-start",
+    backgroundColor: colors.blue500,
+    width: 60,
+    height: 60
+  },
+  view3: {
+    alignItems: "flex-start",
+    backgroundColor: colors.lightblue500,
+    width: 100,
+    height: 120
+  },
+  view2: {
+    alignItems: "flex-start",
+    backgroundColor: colors.cyan500,
+    width: 100,
+    height: 180
+  }
 })

--- a/examples/generated/test/react-native/layouts/FitContentParentSecondaryChildren.js
+++ b/examples/generated/test/react-native/layouts/FitContentParentSecondaryChildren.js
@@ -25,6 +25,7 @@ let styles = StyleSheet.create({
     backgroundColor: colors.bluegrey50,
     flex: 0,
     flexDirection: "row",
+    justifyContent: "flex-start",
     paddingTop: 24,
     paddingRight: 24,
     paddingBottom: 24,
@@ -33,18 +34,24 @@ let styles = StyleSheet.create({
   view1: {
     alignItems: "flex-start",
     backgroundColor: colors.blue500,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     width: 60,
     height: 60
   },
   view3: {
     alignItems: "flex-start",
     backgroundColor: colors.lightblue500,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     width: 100,
     height: 120
   },
   view2: {
     alignItems: "flex-start",
     backgroundColor: colors.cyan500,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     width: 100,
     height: 180
   }

--- a/examples/generated/test/react-native/layouts/FixedParentFillAndFitChildren.js
+++ b/examples/generated/test/react-native/layouts/FixedParentFillAndFitChildren.js
@@ -23,6 +23,7 @@ export default class FixedParentFillAndFitChildren extends React.Component {
 
 let styles = StyleSheet.create({
   view: {
+    alignItems: "flex-start",
     alignSelf: "stretch",
     paddingTop: 24,
     paddingRight: 24,
@@ -31,21 +32,39 @@ let styles = StyleSheet.create({
     height: 600
   },
   view1: {
+    alignItems: "flex-start",
     alignSelf: "stretch",
     backgroundColor: colors.red50,
+    flex: 0,
     flexDirection: "row",
     paddingTop: 24,
     paddingRight: 24,
     paddingBottom: 24,
     paddingLeft: 24
   },
-  view4: { backgroundColor: colors.red200, width: 60, height: 100 },
+  view2: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    backgroundColor: colors.indigo100,
+    flex: 1
+  },
+  view3: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    backgroundColor: colors.teal100,
+    flex: 1
+  },
+  view4: {
+    alignItems: "flex-start",
+    backgroundColor: colors.red200,
+    width: 60,
+    height: 100
+  },
   view5: {
+    alignItems: "flex-start",
     backgroundColor: colors.deeporange200,
     marginLeft: 12,
     width: 60,
     height: 60
-  },
-  view2: { alignSelf: "stretch", backgroundColor: colors.indigo100, flex: 1 },
-  view3: { alignSelf: "stretch", backgroundColor: colors.teal100, flex: 1 }
+  }
 })

--- a/examples/generated/test/react-native/layouts/FixedParentFillAndFitChildren.js
+++ b/examples/generated/test/react-native/layouts/FixedParentFillAndFitChildren.js
@@ -25,6 +25,8 @@ let styles = StyleSheet.create({
   view: {
     alignItems: "flex-start",
     alignSelf: "stretch",
+    flexDirection: "column",
+    justifyContent: "flex-start",
     paddingTop: 24,
     paddingRight: 24,
     paddingBottom: 24,
@@ -37,6 +39,7 @@ let styles = StyleSheet.create({
     backgroundColor: colors.red50,
     flex: 0,
     flexDirection: "row",
+    justifyContent: "flex-start",
     paddingTop: 24,
     paddingRight: 24,
     paddingBottom: 24,
@@ -46,23 +49,31 @@ let styles = StyleSheet.create({
     alignItems: "flex-start",
     alignSelf: "stretch",
     backgroundColor: colors.indigo100,
-    flex: 1
+    flex: 1,
+    flexDirection: "column",
+    justifyContent: "flex-start"
   },
   view3: {
     alignItems: "flex-start",
     alignSelf: "stretch",
     backgroundColor: colors.teal100,
-    flex: 1
+    flex: 1,
+    flexDirection: "column",
+    justifyContent: "flex-start"
   },
   view4: {
     alignItems: "flex-start",
     backgroundColor: colors.red200,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     width: 60,
     height: 100
   },
   view5: {
     alignItems: "flex-start",
     backgroundColor: colors.deeporange200,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     marginLeft: 12,
     width: 60,
     height: 60

--- a/examples/generated/test/react-native/layouts/FixedParentFitChild.js
+++ b/examples/generated/test/react-native/layouts/FixedParentFitChild.js
@@ -21,6 +21,7 @@ export default class FixedParentFitChild extends React.Component {
 
 let styles = StyleSheet.create({
   view: {
+    alignItems: "flex-start",
     alignSelf: "stretch",
     backgroundColor: colors.bluegrey100,
     paddingTop: 24,
@@ -30,16 +31,24 @@ let styles = StyleSheet.create({
     height: 600
   },
   view1: {
+    alignItems: "flex-start",
     alignSelf: "stretch",
     backgroundColor: colors.red50,
+    flex: 0,
     flexDirection: "row",
     paddingTop: 24,
     paddingRight: 24,
     paddingBottom: 24,
     paddingLeft: 24
   },
-  view4: { backgroundColor: colors.red200, width: 60, height: 100 },
+  view4: {
+    alignItems: "flex-start",
+    backgroundColor: colors.red200,
+    width: 60,
+    height: 100
+  },
   view5: {
+    alignItems: "flex-start",
     backgroundColor: colors.deeporange200,
     marginLeft: 12,
     width: 60,

--- a/examples/generated/test/react-native/layouts/FixedParentFitChild.js
+++ b/examples/generated/test/react-native/layouts/FixedParentFitChild.js
@@ -24,6 +24,8 @@ let styles = StyleSheet.create({
     alignItems: "flex-start",
     alignSelf: "stretch",
     backgroundColor: colors.bluegrey100,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     paddingTop: 24,
     paddingRight: 24,
     paddingBottom: 24,
@@ -36,6 +38,7 @@ let styles = StyleSheet.create({
     backgroundColor: colors.red50,
     flex: 0,
     flexDirection: "row",
+    justifyContent: "flex-start",
     paddingTop: 24,
     paddingRight: 24,
     paddingBottom: 24,
@@ -44,12 +47,16 @@ let styles = StyleSheet.create({
   view4: {
     alignItems: "flex-start",
     backgroundColor: colors.red200,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     width: 60,
     height: 100
   },
   view5: {
     alignItems: "flex-start",
     backgroundColor: colors.deeporange200,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     marginLeft: 12,
     width: 60,
     height: 60

--- a/examples/generated/test/react-native/layouts/MultipleFlexText.js
+++ b/examples/generated/test/react-native/layouts/MultipleFlexText.js
@@ -3,27 +3,27 @@ import { Text, View, StyleSheet } from "react-native"
 
 import colors from "../colors"
 import textStyles from "../textStyles"
-import FitContentParentSecondaryChildren from
-  "../layouts/FitContentParentSecondaryChildren"
-import LocalAsset from "../images/LocalAsset"
 
-export default class NestedComponent extends React.Component {
+export default class MultipleFlexText extends React.Component {
   render() {
 
 
     return (
       <View style={[ styles.view, {} ]}>
-        <Text style={[ styles.text, {} ]}>
-          {"Example nested component"}
-        </Text>
-        <FitContentParentSecondaryChildren />
-        <Text style={[ styles.text1, {} ]}>
-          {"Text below"}
-        </Text>
-        <LocalAsset />
-        <Text style={[ styles.text2, {} ]}>
-          {"Very bottom"}
-        </Text>
+        <View style={[ styles.view1, {} ]}>
+          <View style={[ styles.view3, {} ]}>
+            <Text style={[ styles.text, {} ]}>
+              {"Some long text (currently LS lays out incorrectly)"}
+            </Text>
+          </View>
+        </View>
+        <View style={[ styles.view2, {} ]}>
+          <View style={[ styles.view4, {} ]}>
+            <Text style={[ styles.text1, {} ]}>
+              {"Short"}
+            </Text>
+          </View>
+        </View>
       </View>
     );
   }
@@ -34,46 +34,51 @@ let styles = StyleSheet.create({
     alignItems: "flex-start",
     alignSelf: "stretch",
     flex: 0,
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    paddingTop: 10,
-    paddingRight: 10,
-    paddingBottom: 10,
-    paddingLeft: 10
+    flexDirection: "row",
+    justifyContent: "flex-start"
   },
-  text: {
-    ...textStyles.subheading2,
+  view1: {
     alignItems: "flex-start",
-    flex: 0,
+    backgroundColor: colors.red50,
+    flex: 1,
     flexDirection: "column",
     justifyContent: "flex-start",
-    marginBottom: 8
+    height: 100
   },
-  fitContentParentSecondaryChildren: {
+  view2: {
+    alignItems: "flex-start",
+    backgroundColor: colors.blue50,
+    flex: 1,
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    height: 100
+  },
+  view3: {
     alignItems: "flex-start",
     alignSelf: "stretch",
     flex: 1,
-    flexDirection: "row",
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  text: {
+    ...textStyles.body1,
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  view4: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "column",
     justifyContent: "flex-start"
   },
   text1: {
     ...textStyles.body1,
     alignItems: "flex-start",
-    flex: 0,
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    marginTop: 12
-  },
-  localAsset: {
-    alignItems: "flex-start",
     alignSelf: "stretch",
-    flex: 1,
-    flexDirection: "row",
-    justifyContent: "flex-start"
-  },
-  text2: {
-    ...textStyles.body1,
-    alignItems: "flex-start",
     flex: 0,
     flexDirection: "column",
     justifyContent: "flex-start"

--- a/examples/generated/test/react-native/layouts/PrimaryAxis.js
+++ b/examples/generated/test/react-native/layouts/PrimaryAxis.js
@@ -27,6 +27,8 @@ let styles = StyleSheet.create({
   view: {
     alignItems: "flex-start",
     alignSelf: "stretch",
+    flexDirection: "column",
+    justifyContent: "flex-start",
     paddingTop: 24,
     paddingRight: 24,
     paddingBottom: 24,
@@ -36,6 +38,8 @@ let styles = StyleSheet.create({
   fixed: {
     alignItems: "flex-start",
     backgroundColor: "#D8D8D8",
+    flexDirection: "column",
+    justifyContent: "flex-start",
     marginBottom: 24,
     width: 100,
     height: 100
@@ -44,6 +48,8 @@ let styles = StyleSheet.create({
     alignItems: "flex-start",
     backgroundColor: "#D8D8D8",
     flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     marginBottom: 24,
     width: 100
   },
@@ -51,13 +57,23 @@ let styles = StyleSheet.create({
     alignItems: "flex-start",
     backgroundColor: colors.cyan500,
     flex: 1,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     width: 100
   },
   fill2: {
     alignItems: "flex-start",
     backgroundColor: colors.blue500,
     flex: 1,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     width: 100
   },
-  text: { ...textStyles.body1, alignItems: "flex-start", flex: 0 }
+  text: {
+    ...textStyles.body1,
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  }
 })

--- a/examples/generated/test/react-native/layouts/PrimaryAxis.js
+++ b/examples/generated/test/react-native/layouts/PrimaryAxis.js
@@ -25,6 +25,7 @@ export default class PrimaryAxis extends React.Component {
 
 let styles = StyleSheet.create({
   view: {
+    alignItems: "flex-start",
     alignSelf: "stretch",
     paddingTop: 24,
     paddingRight: 24,
@@ -33,13 +34,30 @@ let styles = StyleSheet.create({
     height: 500
   },
   fixed: {
+    alignItems: "flex-start",
     backgroundColor: "#D8D8D8",
     marginBottom: 24,
     width: 100,
     height: 100
   },
-  fit: { backgroundColor: "#D8D8D8", marginBottom: 24, width: 100 },
-  text: {},
-  fill1: { backgroundColor: colors.cyan500, flex: 1, width: 100 },
-  fill2: { backgroundColor: colors.blue500, flex: 1, width: 100 }
+  fit: {
+    alignItems: "flex-start",
+    backgroundColor: "#D8D8D8",
+    flex: 0,
+    marginBottom: 24,
+    width: 100
+  },
+  fill1: {
+    alignItems: "flex-start",
+    backgroundColor: colors.cyan500,
+    flex: 1,
+    width: 100
+  },
+  fill2: {
+    alignItems: "flex-start",
+    backgroundColor: colors.blue500,
+    flex: 1,
+    width: 100
+  },
+  text: { ...textStyles.body1, alignItems: "flex-start", flex: 0 }
 })

--- a/examples/generated/test/react-native/layouts/SecondaryAxis.js
+++ b/examples/generated/test/react-native/layouts/SecondaryAxis.js
@@ -27,6 +27,8 @@ let styles = StyleSheet.create({
     alignItems: "flex-start",
     alignSelf: "stretch",
     flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     paddingTop: 24,
     paddingRight: 24,
     paddingBottom: 24,
@@ -35,6 +37,8 @@ let styles = StyleSheet.create({
   fixed: {
     alignItems: "flex-start",
     backgroundColor: "#D8D8D8",
+    flexDirection: "column",
+    justifyContent: "flex-start",
     marginBottom: 24,
     width: 100,
     height: 100
@@ -42,6 +46,8 @@ let styles = StyleSheet.create({
   fit: {
     alignItems: "flex-start",
     backgroundColor: "#D8D8D8",
+    flexDirection: "column",
+    justifyContent: "flex-start",
     marginBottom: 24,
     paddingTop: 12,
     paddingRight: 12,
@@ -53,7 +59,15 @@ let styles = StyleSheet.create({
     alignItems: "flex-start",
     alignSelf: "stretch",
     backgroundColor: "#D8D8D8",
+    flexDirection: "column",
+    justifyContent: "flex-start",
     height: 100
   },
-  text: { ...textStyles.body1, alignItems: "flex-start", flex: 0 }
+  text: {
+    ...textStyles.body1,
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  }
 })

--- a/examples/generated/test/react-native/layouts/SecondaryAxis.js
+++ b/examples/generated/test/react-native/layouts/SecondaryAxis.js
@@ -24,19 +24,23 @@ export default class SecondaryAxis extends React.Component {
 
 let styles = StyleSheet.create({
   container: {
+    alignItems: "flex-start",
     alignSelf: "stretch",
+    flex: 0,
     paddingTop: 24,
     paddingRight: 24,
     paddingBottom: 24,
     paddingLeft: 24
   },
   fixed: {
+    alignItems: "flex-start",
     backgroundColor: "#D8D8D8",
     marginBottom: 24,
     width: 100,
     height: 100
   },
   fit: {
+    alignItems: "flex-start",
     backgroundColor: "#D8D8D8",
     marginBottom: 24,
     paddingTop: 12,
@@ -45,6 +49,11 @@ let styles = StyleSheet.create({
     paddingLeft: 12,
     height: 100
   },
-  text: {},
-  fill: { alignSelf: "stretch", backgroundColor: "#D8D8D8", height: 100 }
+  fill: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    backgroundColor: "#D8D8D8",
+    height: 100
+  },
+  text: { ...textStyles.body1, alignItems: "flex-start", flex: 0 }
 })

--- a/examples/generated/test/react-native/logic/Assign.js
+++ b/examples/generated/test/react-native/logic/Assign.js
@@ -21,6 +21,18 @@ export default class Assign extends React.Component {
 };
 
 let styles = StyleSheet.create({
-  view: { alignItems: "flex-start", alignSelf: "stretch", flex: 0 },
-  text: { ...textStyles.body1, alignItems: "flex-start", flex: 0 }
+  view: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  text: {
+    ...textStyles.body1,
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  }
 })

--- a/examples/generated/test/react-native/logic/Assign.js
+++ b/examples/generated/test/react-native/logic/Assign.js
@@ -20,4 +20,7 @@ export default class Assign extends React.Component {
   }
 };
 
-let styles = StyleSheet.create({ view: { alignSelf: "stretch" }, text: {} })
+let styles = StyleSheet.create({
+  view: { alignItems: "flex-start", alignSelf: "stretch", flex: 0 },
+  text: { ...textStyles.body1, alignItems: "flex-start", flex: 0 }
+})

--- a/examples/generated/test/react-native/logic/If.js
+++ b/examples/generated/test/react-native/logic/If.js
@@ -23,5 +23,11 @@ export default class If extends React.Component {
 };
 
 let styles = StyleSheet.create({
-  view: { alignItems: "flex-start", alignSelf: "stretch", flex: 0 }
+  view: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  }
 })

--- a/examples/generated/test/react-native/logic/If.js
+++ b/examples/generated/test/react-native/logic/If.js
@@ -22,4 +22,6 @@ export default class If extends React.Component {
   }
 };
 
-let styles = StyleSheet.create({ view: { alignSelf: "stretch" } })
+let styles = StyleSheet.create({
+  view: { alignItems: "flex-start", alignSelf: "stretch", flex: 0 }
+})

--- a/examples/generated/test/react-native/style/BorderWidthColor.js
+++ b/examples/generated/test/react-native/style/BorderWidthColor.js
@@ -17,8 +17,9 @@ export default class BorderWidthColor extends React.Component {
 };
 
 let styles = StyleSheet.create({
-  view: { alignSelf: "stretch" },
+  view: { alignItems: "flex-start", alignSelf: "stretch", flex: 0 },
   view1: {
+    alignItems: "flex-start",
     borderRadius: 10,
     borderWidth: 20,
     borderColor: colors.blue300,

--- a/examples/generated/test/react-native/style/BorderWidthColor.js
+++ b/examples/generated/test/react-native/style/BorderWidthColor.js
@@ -17,9 +17,17 @@ export default class BorderWidthColor extends React.Component {
 };
 
 let styles = StyleSheet.create({
-  view: { alignItems: "flex-start", alignSelf: "stretch", flex: 0 },
+  view: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
   view1: {
     alignItems: "flex-start",
+    flexDirection: "column",
+    justifyContent: "flex-start",
     borderRadius: 10,
     borderWidth: 20,
     borderColor: colors.blue300,

--- a/examples/generated/test/react-native/style/BoxModelConditional.js
+++ b/examples/generated/test/react-native/style/BoxModelConditional.js
@@ -43,11 +43,18 @@ export default class BoxModelConditional extends React.Component {
 
 let styles = StyleSheet.create({
   outer: {
+    alignItems: "flex-start",
     alignSelf: "stretch",
+    flex: 0,
     paddingTop: 4,
     paddingRight: 4,
     paddingBottom: 4,
     paddingLeft: 4
   },
-  inner: { backgroundColor: "#D8D8D8", width: 60, height: 60 }
+  inner: {
+    alignItems: "flex-start",
+    backgroundColor: "#D8D8D8",
+    width: 60,
+    height: 60
+  }
 })

--- a/examples/generated/test/react-native/style/BoxModelConditional.js
+++ b/examples/generated/test/react-native/style/BoxModelConditional.js
@@ -46,6 +46,8 @@ let styles = StyleSheet.create({
     alignItems: "flex-start",
     alignSelf: "stretch",
     flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     paddingTop: 4,
     paddingRight: 4,
     paddingBottom: 4,
@@ -54,6 +56,8 @@ let styles = StyleSheet.create({
   inner: {
     alignItems: "flex-start",
     backgroundColor: "#D8D8D8",
+    flexDirection: "column",
+    justifyContent: "flex-start",
     width: 60,
     height: 60
   }

--- a/examples/generated/test/react-native/style/TextAlignment.js
+++ b/examples/generated/test/react-native/style/TextAlignment.js
@@ -76,6 +76,8 @@ let styles = StyleSheet.create({
     alignItems: "flex-start",
     alignSelf: "stretch",
     flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     paddingTop: 10,
     paddingRight: 10,
     paddingBottom: 10,
@@ -86,12 +88,15 @@ let styles = StyleSheet.create({
     alignSelf: "stretch",
     backgroundColor: colors.indigo50,
     flex: 0,
+    flexDirection: "column",
     justifyContent: "center"
   },
   view3: {
     alignItems: "center",
     backgroundColor: "#D8D8D8",
     flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     paddingRight: 12,
     paddingLeft: 12
   },
@@ -99,6 +104,8 @@ let styles = StyleSheet.create({
     alignItems: "center",
     backgroundColor: "#D8D8D8",
     flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     paddingRight: 12,
     paddingLeft: 12,
     width: 400
@@ -107,6 +114,8 @@ let styles = StyleSheet.create({
     alignItems: "flex-start",
     backgroundColor: "#D8D8D8",
     flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     paddingRight: 12,
     paddingLeft: 12
   },
@@ -114,6 +123,8 @@ let styles = StyleSheet.create({
     alignItems: "flex-start",
     backgroundColor: "#D8D8D8",
     flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     paddingRight: 12,
     paddingLeft: 12,
     width: 400
@@ -122,16 +133,32 @@ let styles = StyleSheet.create({
     alignItems: "flex-end",
     alignSelf: "stretch",
     backgroundColor: "#D8D8D8",
-    flex: 0
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
   },
-  image: { alignItems: "flex-start", width: 100, height: 100 },
-  view2: { alignItems: "flex-start", backgroundColor: "#D8D8D8", flex: 0 },
+  image: {
+    alignItems: "flex-start",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: 100,
+    height: 100
+  },
+  view2: {
+    alignItems: "flex-start",
+    backgroundColor: "#D8D8D8",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
   text: {
     textAlign: "center",
     ...textStyles.display1,
     alignItems: "flex-start",
     alignSelf: "stretch",
     flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     marginTop: 16
   },
   text1: {
@@ -139,6 +166,8 @@ let styles = StyleSheet.create({
     ...textStyles.subheading2,
     alignItems: "flex-start",
     flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     marginTop: 16
   },
   text2: {
@@ -146,6 +175,8 @@ let styles = StyleSheet.create({
     alignItems: "flex-start",
     alignSelf: "stretch",
     flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     marginTop: 12
   },
   text3: {
@@ -153,37 +184,71 @@ let styles = StyleSheet.create({
     ...textStyles.body1,
     alignItems: "flex-start",
     alignSelf: "stretch",
-    flex: 0
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
   },
   text4: {
     textAlign: "center",
     ...textStyles.body1,
     alignItems: "flex-start",
     flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     width: 80
   },
-  text5: { ...textStyles.body1, alignItems: "flex-start", flex: 0 },
-  text6: { ...textStyles.body1, alignItems: "flex-start", flex: 0 },
+  text5: {
+    ...textStyles.body1,
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  text6: {
+    ...textStyles.body1,
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
   text7: {
     textAlign: "center",
     ...textStyles.body1,
     alignItems: "flex-start",
-    flex: 0
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
   },
   text8: {
     textAlign: "center",
     ...textStyles.body1,
     alignItems: "flex-start",
     alignSelf: "stretch",
-    flex: 0
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
   },
-  text9: { ...textStyles.body1, alignItems: "flex-start", flex: 0 },
+  text9: {
+    ...textStyles.body1,
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
   text10: {
     textAlign: "center",
     ...textStyles.body1,
     alignItems: "flex-start",
     alignSelf: "stretch",
-    flex: 0
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
   },
-  image1: { alignItems: "flex-start", width: 100, height: 100 }
+  image1: {
+    alignItems: "flex-start",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: 100,
+    height: 100
+  }
 })

--- a/examples/generated/test/react-native/style/TextAlignment.js
+++ b/examples/generated/test/react-native/style/TextAlignment.js
@@ -75,6 +75,7 @@ let styles = StyleSheet.create({
   view: {
     alignItems: "flex-start",
     alignSelf: "stretch",
+    flex: 0,
     paddingTop: 10,
     paddingRight: 10,
     paddingBottom: 10,
@@ -84,50 +85,105 @@ let styles = StyleSheet.create({
     alignItems: "center",
     alignSelf: "stretch",
     backgroundColor: colors.indigo50,
+    flex: 0,
     justifyContent: "center"
   },
-  image: { width: 100, height: 100 },
-  view2: { backgroundColor: "#D8D8D8" },
-  text: {
-    textAlign: "center",
-    ...textStyles.display1,
-    alignSelf: "stretch",
-    marginTop: 16
-  },
-  text1: { textAlign: "center", ...textStyles.subheading2, marginTop: 16 },
-  text2: { alignSelf: "stretch", marginTop: 12 },
-  text3: { textAlign: "right", alignSelf: "stretch" },
-  text4: { textAlign: "center", width: 80 },
   view3: {
     alignItems: "center",
     backgroundColor: "#D8D8D8",
+    flex: 0,
     paddingRight: 12,
     paddingLeft: 12
   },
-  text5: {},
   view4: {
     alignItems: "center",
     backgroundColor: "#D8D8D8",
+    flex: 0,
     paddingRight: 12,
     paddingLeft: 12,
     width: 400
   },
-  text6: {},
-  view5: { backgroundColor: "#D8D8D8", paddingRight: 12, paddingLeft: 12 },
-  text7: { textAlign: "center" },
-  view6: {
+  view5: {
+    alignItems: "flex-start",
     backgroundColor: "#D8D8D8",
+    flex: 0,
+    paddingRight: 12,
+    paddingLeft: 12
+  },
+  view6: {
+    alignItems: "flex-start",
+    backgroundColor: "#D8D8D8",
+    flex: 0,
     paddingRight: 12,
     paddingLeft: 12,
     width: 400
   },
-  text8: { textAlign: "center", alignSelf: "stretch" },
   rightAlignmentContainer: {
     alignItems: "flex-end",
     alignSelf: "stretch",
-    backgroundColor: "#D8D8D8"
+    backgroundColor: "#D8D8D8",
+    flex: 0
   },
-  text9: {},
-  text10: { textAlign: "center", alignSelf: "stretch" },
-  image1: { width: 100, height: 100 }
+  image: { alignItems: "flex-start", width: 100, height: 100 },
+  view2: { alignItems: "flex-start", backgroundColor: "#D8D8D8", flex: 0 },
+  text: {
+    textAlign: "center",
+    ...textStyles.display1,
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0,
+    marginTop: 16
+  },
+  text1: {
+    textAlign: "center",
+    ...textStyles.subheading2,
+    alignItems: "flex-start",
+    flex: 0,
+    marginTop: 16
+  },
+  text2: {
+    ...textStyles.body1,
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0,
+    marginTop: 12
+  },
+  text3: {
+    textAlign: "right",
+    ...textStyles.body1,
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0
+  },
+  text4: {
+    textAlign: "center",
+    ...textStyles.body1,
+    alignItems: "flex-start",
+    flex: 0,
+    width: 80
+  },
+  text5: { ...textStyles.body1, alignItems: "flex-start", flex: 0 },
+  text6: { ...textStyles.body1, alignItems: "flex-start", flex: 0 },
+  text7: {
+    textAlign: "center",
+    ...textStyles.body1,
+    alignItems: "flex-start",
+    flex: 0
+  },
+  text8: {
+    textAlign: "center",
+    ...textStyles.body1,
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0
+  },
+  text9: { ...textStyles.body1, alignItems: "flex-start", flex: 0 },
+  text10: {
+    textAlign: "center",
+    ...textStyles.body1,
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0
+  },
+  image1: { alignItems: "flex-start", width: 100, height: 100 }
 })

--- a/examples/generated/test/react-native/style/TextStyleConditional.js
+++ b/examples/generated/test/react-native/style/TextStyleConditional.js
@@ -24,6 +24,18 @@ export default class TextStyleConditional extends React.Component {
 };
 
 let styles = StyleSheet.create({
-  view: { alignItems: "flex-start", alignSelf: "stretch", flex: 0 },
-  text: { ...textStyles.headline, alignItems: "flex-start", flex: 0 }
+  view: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  text: {
+    ...textStyles.headline,
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  }
 })

--- a/examples/generated/test/react-native/style/TextStyleConditional.js
+++ b/examples/generated/test/react-native/style/TextStyleConditional.js
@@ -24,6 +24,6 @@ export default class TextStyleConditional extends React.Component {
 };
 
 let styles = StyleSheet.create({
-  view: { alignSelf: "stretch" },
-  text: { ...textStyles.headline }
+  view: { alignItems: "flex-start", alignSelf: "stretch", flex: 0 },
+  text: { ...textStyles.headline, alignItems: "flex-start", flex: 0 }
 })

--- a/examples/generated/test/react-native/style/TextStylesTest.js
+++ b/examples/generated/test/react-native/style/TextStylesTest.js
@@ -46,15 +46,15 @@ export default class TextStylesTest extends React.Component {
 };
 
 let styles = StyleSheet.create({
-  view: { alignSelf: "stretch" },
-  text: { ...textStyles.display4 },
-  text1: { ...textStyles.display3 },
-  text2: { ...textStyles.display2 },
-  text3: { ...textStyles.display1 },
-  text4: { ...textStyles.headline },
-  text5: { ...textStyles.subheading2 },
-  text6: { ...textStyles.subheading1 },
-  text7: { ...textStyles.body2 },
-  text8: { ...textStyles.body1 },
-  text9: { ...textStyles.caption }
+  view: { alignItems: "flex-start", alignSelf: "stretch", flex: 0 },
+  text: { ...textStyles.display4, alignItems: "flex-start", flex: 0 },
+  text1: { ...textStyles.display3, alignItems: "flex-start", flex: 0 },
+  text2: { ...textStyles.display2, alignItems: "flex-start", flex: 0 },
+  text3: { ...textStyles.display1, alignItems: "flex-start", flex: 0 },
+  text4: { ...textStyles.headline, alignItems: "flex-start", flex: 0 },
+  text5: { ...textStyles.subheading2, alignItems: "flex-start", flex: 0 },
+  text6: { ...textStyles.subheading1, alignItems: "flex-start", flex: 0 },
+  text7: { ...textStyles.body2, alignItems: "flex-start", flex: 0 },
+  text8: { ...textStyles.body1, alignItems: "flex-start", flex: 0 },
+  text9: { ...textStyles.caption, alignItems: "flex-start", flex: 0 }
 })

--- a/examples/generated/test/react-native/style/TextStylesTest.js
+++ b/examples/generated/test/react-native/style/TextStylesTest.js
@@ -46,15 +46,81 @@ export default class TextStylesTest extends React.Component {
 };
 
 let styles = StyleSheet.create({
-  view: { alignItems: "flex-start", alignSelf: "stretch", flex: 0 },
-  text: { ...textStyles.display4, alignItems: "flex-start", flex: 0 },
-  text1: { ...textStyles.display3, alignItems: "flex-start", flex: 0 },
-  text2: { ...textStyles.display2, alignItems: "flex-start", flex: 0 },
-  text3: { ...textStyles.display1, alignItems: "flex-start", flex: 0 },
-  text4: { ...textStyles.headline, alignItems: "flex-start", flex: 0 },
-  text5: { ...textStyles.subheading2, alignItems: "flex-start", flex: 0 },
-  text6: { ...textStyles.subheading1, alignItems: "flex-start", flex: 0 },
-  text7: { ...textStyles.body2, alignItems: "flex-start", flex: 0 },
-  text8: { ...textStyles.body1, alignItems: "flex-start", flex: 0 },
-  text9: { ...textStyles.caption, alignItems: "flex-start", flex: 0 }
+  view: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  text: {
+    ...textStyles.display4,
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  text1: {
+    ...textStyles.display3,
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  text2: {
+    ...textStyles.display2,
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  text3: {
+    ...textStyles.display1,
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  text4: {
+    ...textStyles.headline,
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  text5: {
+    ...textStyles.subheading2,
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  text6: {
+    ...textStyles.subheading1,
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  text7: {
+    ...textStyles.body2,
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  text8: {
+    ...textStyles.body1,
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  text9: {
+    ...textStyles.caption,
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  }
 })

--- a/examples/generated/test/react-native/textstyles.js
+++ b/examples/generated/test/react-native/textstyles.js
@@ -2,77 +2,77 @@ import colors from "./colors"
 
 export default {
   display4: {
-    family: "Arial",
+    fontFamily: "Arial",
     fontWeight: "300",
     fontSize: 112,
     lineHeight: 120,
     color: colors.grey900
   },
   display3: {
-    family: "Arial",
+    fontFamily: "Arial",
     fontWeight: "400",
     fontSize: 56,
     lineHeight: 60,
     color: colors.grey900
   },
   display2: {
-    family: "Arial",
+    fontFamily: "Arial",
     fontWeight: "400",
     fontSize: 45,
     lineHeight: 48,
     color: colors.grey900
   },
   display1: {
-    family: "Arial",
+    fontFamily: "Arial",
     fontWeight: "400",
     fontSize: 34,
     lineHeight: 40,
     color: colors.grey900
   },
   headline: {
-    family: "Arial",
+    fontFamily: "Arial",
     fontWeight: "400",
     fontSize: 24,
     lineHeight: 32,
     color: colors.grey900
   },
   subheading2: {
-    family: "Arial",
+    fontFamily: "Arial",
     fontWeight: "400",
     fontSize: 16,
     lineHeight: 28,
     color: colors.grey900
   },
   subheading1: {
-    family: "Arial",
+    fontFamily: "Arial",
     fontWeight: "400",
     fontSize: 16,
     lineHeight: 24,
     color: colors.grey900
   },
   body2: {
-    family: "Arial",
+    fontFamily: "Arial",
     fontWeight: "500",
     fontSize: 14,
     lineHeight: 24,
     color: colors.grey900
   },
   body1: {
-    family: "Arial",
+    fontFamily: "Arial",
     fontWeight: "400",
     fontSize: 14,
     lineHeight: 20,
     color: colors.grey900
   },
   caption: {
-    family: "Arial",
+    fontFamily: "Arial",
     fontWeight: "400",
     fontSize: 12,
     lineHeight: 15,
     color: colors.grey900
   },
   button: {
-    family: "Arial",
+    fontFamily: "Arial",
     fontWeight: "500",
     fontSize: 14,
     lineHeight: 18,

--- a/examples/generated/test/sketchJs/components/ComponentParameterInstance.js
+++ b/examples/generated/test/sketchJs/components/ComponentParameterInstance.js
@@ -23,6 +23,10 @@ export default class ComponentParameterInstance extends React.Component {
 };
 
 let styles = StyleSheet.create({
-  view: { alignSelf: "stretch" },
-  componentParameterTemplate: {}
+  view: { alignItems: "flex-start", alignSelf: "stretch", flex: 0 },
+  componentParameterTemplate: {
+    alignItems: "stretch",
+    flex: 0,
+    flexDirection: "column"
+  }
 })

--- a/examples/generated/test/sketchJs/components/ComponentParameterInstance.js
+++ b/examples/generated/test/sketchJs/components/ComponentParameterInstance.js
@@ -11,22 +11,25 @@ export default class ComponentParameterInstance extends React.Component {
 
     return (
       <View style={[ styles.view, {} ]}>
-        <ComponentParameterTemplate
-          style={[ styles.componentParameterTemplate, {} ]}
-          subtitleComponent={{"parameters":{"text":"Subtitle","textStyle":"subheading2"},"type":"Lona:Text"}}
-          titleComponent={{"parameters":{"text":"Title","textStyle":"headline"},"type":"Lona:Text"}}
+        <View style={[ styles.componentParameterTemplate, {} ]}>
+          <ComponentParameterTemplate
+            subtitleComponent={{"parameters":{"text":"Subtitle","textStyle":"subheading2"},"type":"Lona:Text"}}
+            titleComponent={{"parameters":{"text":"Title","textStyle":"headline"},"type":"Lona:Text"}}
 
-        />
+          />
+        </View>
       </View>
     );
   }
 };
 
 let styles = StyleSheet.create({
-  view: { alignItems: "flex-start", alignSelf: "stretch", flex: 0 },
-  componentParameterTemplate: {
-    alignItems: "stretch",
+  view: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
     flex: 0,
-    flexDirection: "column"
-  }
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  componentParameterTemplate: { alignItems: "stretch", flexDirection: "column" }
 })

--- a/examples/generated/test/sketchJs/components/NestedBottomLeftLayout.js
+++ b/examples/generated/test/sketchJs/components/NestedBottomLeftLayout.js
@@ -3,19 +3,19 @@ import { View, StyleSheet, TextStyles } from "@mathieudutour/react-sketchapp"
 
 import colors from "../colors"
 import textStyles from "../textStyles"
-import ComponentParameterTemplate from "./ComponentParameterTemplate"
+import LocalAsset from "../images/LocalAsset"
 
-export default class ComponentParameterInstance extends React.Component {
+export default class NestedBottomLeftLayout extends React.Component {
   render() {
 
 
     return (
       <View style={[ styles.view, {} ]}>
-        <ComponentParameterTemplate
-          subtitleComponent={{"parameters":{"text":"Subtitle","textStyle":"subheading2"},"type":"Lona:Text"}}
-          titleComponent={{"parameters":{"text":"Title","textStyle":"headline"},"type":"Lona:Text"}}
-
-        />
+        <View style={[ styles.view1, {} ]}>
+          <View style={[ styles.localAsset, {} ]}>
+            <LocalAsset />
+          </View>
+        </View>
       </View>
     );
   }
@@ -29,8 +29,16 @@ let styles = StyleSheet.create({
     flexDirection: "column",
     justifyContent: "flex-start"
   },
-  componentParameterTemplate: {
-    alignItems: "flex-start",
+  view1: {
+    alignItems: "flex-end",
+    backgroundColor: colors.red100,
+    flexDirection: "row",
+    justifyContent: "flex-start",
+    width: 150,
+    height: 150
+  },
+  localAsset: {
+    alignItems: "flex-end",
     alignSelf: "stretch",
     flex: 1,
     flexDirection: "row",

--- a/examples/generated/test/sketchJs/components/NestedButtons.js
+++ b/examples/generated/test/sketchJs/components/NestedButtons.js
@@ -11,9 +11,13 @@ export default class NestedButtons extends React.Component {
 
     return (
       <View style={[ styles.view, {} ]}>
-        <Button style={[ styles.button, {} ]} label={"Button 1"} />
+        <View style={[ styles.button, {} ]}>
+          <Button label={"Button 1"} />
+        </View>
         <View style={[ styles.view1, {} ]} />
-        <Button style={[ styles.button2, {} ]} label={"Button 2"} />
+        <View style={[ styles.button2, {} ]}>
+          <Button label={"Button 2"} />
+        </View>
       </View>
     );
   }
@@ -24,12 +28,20 @@ let styles = StyleSheet.create({
     alignItems: "flex-start",
     alignSelf: "stretch",
     flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     paddingTop: 24,
     paddingRight: 24,
     paddingBottom: 24,
     paddingLeft: 24
   },
-  button: { alignItems: "stretch", flex: 0, flexDirection: "column" },
-  view1: { alignItems: "flex-start", alignSelf: "stretch", height: 8 },
-  button2: { alignItems: "stretch", flex: 0, flexDirection: "column" }
+  button: { alignItems: "stretch", flexDirection: "column" },
+  view1: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    height: 8
+  },
+  button2: { alignItems: "stretch", flexDirection: "column" }
 })

--- a/examples/generated/test/sketchJs/components/NestedButtons.js
+++ b/examples/generated/test/sketchJs/components/NestedButtons.js
@@ -11,13 +11,9 @@ export default class NestedButtons extends React.Component {
 
     return (
       <View style={[ styles.view, {} ]}>
-        <View style={[ styles.button, {} ]}>
-          <Button label={"Button 1"} />
-        </View>
+        <Button label={"Button 1"} />
         <View style={[ styles.view1, {} ]} />
-        <View style={[ styles.button2, {} ]}>
-          <Button label={"Button 2"} />
-        </View>
+        <Button label={"Button 2"} />
       </View>
     );
   }
@@ -35,7 +31,13 @@ let styles = StyleSheet.create({
     paddingBottom: 24,
     paddingLeft: 24
   },
-  button: { alignItems: "stretch", flexDirection: "column" },
+  button: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  },
   view1: {
     alignItems: "flex-start",
     alignSelf: "stretch",
@@ -43,5 +45,11 @@ let styles = StyleSheet.create({
     justifyContent: "flex-start",
     height: 8
   },
-  button2: { alignItems: "stretch", flexDirection: "column" }
+  button2: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  }
 })

--- a/examples/generated/test/sketchJs/components/NestedButtons.js
+++ b/examples/generated/test/sketchJs/components/NestedButtons.js
@@ -21,13 +21,15 @@ export default class NestedButtons extends React.Component {
 
 let styles = StyleSheet.create({
   view: {
+    alignItems: "flex-start",
     alignSelf: "stretch",
+    flex: 0,
     paddingTop: 24,
     paddingRight: 24,
     paddingBottom: 24,
     paddingLeft: 24
   },
-  button: {},
-  view1: { alignSelf: "stretch", height: 8 },
-  button2: {}
+  button: { alignItems: "stretch", flex: 0, flexDirection: "column" },
+  view1: { alignItems: "flex-start", alignSelf: "stretch", height: 8 },
+  button2: { alignItems: "stretch", flex: 0, flexDirection: "column" }
 })

--- a/examples/generated/test/sketchJs/components/NestedComponent.js
+++ b/examples/generated/test/sketchJs/components/NestedComponent.js
@@ -35,15 +35,31 @@ export default class NestedComponent extends React.Component {
 
 let styles = StyleSheet.create({
   view: {
+    alignItems: "flex-start",
     alignSelf: "stretch",
+    flex: 0,
     paddingTop: 10,
     paddingRight: 10,
     paddingBottom: 10,
     paddingLeft: 10
   },
-  text: { ...TextStyles.get("subheading2"), marginBottom: 8 },
-  fitContentParentSecondaryChildren: {},
-  text1: { marginTop: 12 },
-  localAsset: {},
-  text2: {}
+  text: {
+    ...TextStyles.get("subheading2"),
+    alignItems: "flex-start",
+    flex: 0,
+    marginBottom: 8
+  },
+  fitContentParentSecondaryChildren: {
+    alignItems: "stretch",
+    flex: 0,
+    flexDirection: "column"
+  },
+  text1: {
+    ...TextStyles.get("body1"),
+    alignItems: "flex-start",
+    flex: 0,
+    marginTop: 12
+  },
+  localAsset: { alignItems: "stretch", flex: 0, flexDirection: "column" },
+  text2: { ...TextStyles.get("body1"), alignItems: "flex-start", flex: 0 }
 })

--- a/examples/generated/test/sketchJs/components/NestedComponent.js
+++ b/examples/generated/test/sketchJs/components/NestedComponent.js
@@ -17,14 +17,15 @@ export default class NestedComponent extends React.Component {
         <Text style={[ styles.text, {} ]}>
           {"Example nested component"}
         </Text>
-        <FitContentParentSecondaryChildren
-          style={[ styles.fitContentParentSecondaryChildren, {} ]}
-
-        />
+        <View style={[ styles.fitContentParentSecondaryChildren, {} ]}>
+          <FitContentParentSecondaryChildren />
+        </View>
         <Text style={[ styles.text1, {} ]}>
           {"Text below"}
         </Text>
-        <LocalAsset style={[ styles.localAsset, {} ]} />
+        <View style={[ styles.localAsset, {} ]}>
+          <LocalAsset />
+        </View>
         <Text style={[ styles.text2, {} ]}>
           {"Very bottom"}
         </Text>
@@ -38,6 +39,8 @@ let styles = StyleSheet.create({
     alignItems: "flex-start",
     alignSelf: "stretch",
     flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     paddingTop: 10,
     paddingRight: 10,
     paddingBottom: 10,
@@ -47,19 +50,28 @@ let styles = StyleSheet.create({
     ...TextStyles.get("subheading2"),
     alignItems: "flex-start",
     flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     marginBottom: 8
   },
   fitContentParentSecondaryChildren: {
     alignItems: "stretch",
-    flex: 0,
     flexDirection: "column"
   },
   text1: {
     ...TextStyles.get("body1"),
     alignItems: "flex-start",
     flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     marginTop: 12
   },
-  localAsset: { alignItems: "stretch", flex: 0, flexDirection: "column" },
-  text2: { ...TextStyles.get("body1"), alignItems: "flex-start", flex: 0 }
+  localAsset: { alignItems: "stretch", flexDirection: "column" },
+  text2: {
+    ...TextStyles.get("body1"),
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  }
 })

--- a/examples/generated/test/sketchJs/components/NestedLayout.js
+++ b/examples/generated/test/sketchJs/components/NestedLayout.js
@@ -1,0 +1,427 @@
+import React from "react"
+import { View, StyleSheet, TextStyles } from "@mathieudutour/react-sketchapp"
+
+import colors from "../colors"
+import textStyles from "../textStyles"
+import LocalAsset from "../images/LocalAsset"
+
+export default class NestedLayout extends React.Component {
+  render() {
+
+
+    return (
+      <View style={[ styles.view, {} ]}>
+        <View style={[ styles.topRow, {} ]}>
+          <View style={[ styles.column1, {} ]}>
+            <View style={[ styles.view1, {} ]}>
+              <LocalAsset />
+            </View>
+            <View style={[ styles.view2, {} ]}>
+              <LocalAsset />
+            </View>
+            <View style={[ styles.view3, {} ]}>
+              <LocalAsset />
+            </View>
+          </View>
+          <View style={[ styles.column2, {} ]}>
+            <View style={[ styles.view4, {} ]}>
+              <LocalAsset />
+            </View>
+            <View style={[ styles.view5, {} ]}>
+              <LocalAsset />
+            </View>
+            <View style={[ styles.view6, {} ]}>
+              <LocalAsset />
+            </View>
+          </View>
+          <View style={[ styles.column3, {} ]}>
+            <View style={[ styles.view7, {} ]}>
+              <LocalAsset />
+            </View>
+            <View style={[ styles.view8, {} ]}>
+              <LocalAsset />
+            </View>
+            <View style={[ styles.view9, {} ]}>
+              <LocalAsset />
+            </View>
+          </View>
+        </View>
+        <View style={[ styles.bottomRow, {} ]}>
+          <View style={[ styles.column4, {} ]}>
+            <View style={[ styles.view10, {} ]}>
+              <View style={[ styles.localAsset10, {} ]}>
+                <LocalAsset />
+              </View>
+            </View>
+            <View style={[ styles.view11, {} ]}>
+              <View style={[ styles.localAsset11, {} ]}>
+                <LocalAsset />
+              </View>
+            </View>
+            <View style={[ styles.view12, {} ]}>
+              <View style={[ styles.localAsset12, {} ]}>
+                <LocalAsset />
+              </View>
+            </View>
+          </View>
+          <View style={[ styles.column5, {} ]}>
+            <View style={[ styles.view13, {} ]}>
+              <View style={[ styles.localAsset13, {} ]}>
+                <LocalAsset />
+              </View>
+            </View>
+            <View style={[ styles.view14, {} ]}>
+              <View style={[ styles.localAsset14, {} ]}>
+                <LocalAsset />
+              </View>
+            </View>
+            <View style={[ styles.view15, {} ]}>
+              <View style={[ styles.localAsset15, {} ]}>
+                <LocalAsset />
+              </View>
+            </View>
+          </View>
+          <View style={[ styles.column6, {} ]}>
+            <View style={[ styles.view16, {} ]}>
+              <View style={[ styles.localAsset16, {} ]}>
+                <LocalAsset />
+              </View>
+            </View>
+            <View style={[ styles.view17, {} ]}>
+              <View style={[ styles.localAsset17, {} ]}>
+                <LocalAsset />
+              </View>
+            </View>
+            <View style={[ styles.view18, {} ]}>
+              <View style={[ styles.localAsset18, {} ]}>
+                <LocalAsset />
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    );
+  }
+};
+
+let styles = StyleSheet.create({
+  view: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  topRow: {
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  },
+  bottomRow: {
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  },
+  column1: {
+    alignItems: "flex-start",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: 150
+  },
+  column2: {
+    alignItems: "flex-start",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: 150
+  },
+  column3: {
+    alignItems: "flex-start",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: 150
+  },
+  view1: {
+    alignItems: "flex-start",
+    backgroundColor: colors.grey50,
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: 150,
+    height: 150
+  },
+  view2: {
+    alignItems: "flex-start",
+    backgroundColor: "transparent",
+    flexDirection: "column",
+    justifyContent: "center",
+    width: 150,
+    height: 150
+  },
+  view3: {
+    alignItems: "flex-start",
+    backgroundColor: colors.grey50,
+    flexDirection: "column",
+    justifyContent: "flex-end",
+    width: 150,
+    height: 150
+  },
+  localAsset: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  },
+  localAsset2: {
+    alignItems: "center",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  },
+  localAsset3: {
+    alignItems: "flex-end",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  },
+  view4: {
+    alignItems: "center",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: 150,
+    height: 150
+  },
+  view5: {
+    alignItems: "center",
+    backgroundColor: colors.grey50,
+    flexDirection: "column",
+    justifyContent: "center",
+    width: 150,
+    height: 150
+  },
+  view6: {
+    alignItems: "center",
+    flexDirection: "column",
+    justifyContent: "flex-end",
+    width: 150,
+    height: 150
+  },
+  localAsset4: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "center"
+  },
+  localAsset5: {
+    alignItems: "center",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "center"
+  },
+  localAsset6: {
+    alignItems: "flex-end",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "center"
+  },
+  view7: {
+    alignItems: "flex-end",
+    backgroundColor: colors.grey50,
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: 150,
+    height: 150
+  },
+  view8: {
+    alignItems: "flex-end",
+    flexDirection: "column",
+    justifyContent: "center",
+    width: 150,
+    height: 150
+  },
+  view9: {
+    alignItems: "flex-end",
+    backgroundColor: colors.grey50,
+    flexDirection: "column",
+    justifyContent: "flex-end",
+    width: 150,
+    height: 150
+  },
+  localAsset7: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "flex-end"
+  },
+  localAsset8: {
+    alignItems: "center",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "flex-end"
+  },
+  localAsset9: {
+    alignItems: "flex-end",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "flex-end"
+  },
+  column4: {
+    alignItems: "flex-start",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: 150
+  },
+  column5: {
+    alignItems: "flex-start",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: 150
+  },
+  column6: {
+    alignItems: "flex-start",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: 150
+  },
+  view10: {
+    alignItems: "flex-start",
+    backgroundColor: colors.grey50,
+    flexDirection: "row",
+    justifyContent: "flex-start",
+    width: 150,
+    height: 150
+  },
+  view11: {
+    alignItems: "center",
+    backgroundColor: "transparent",
+    flexDirection: "row",
+    justifyContent: "flex-start",
+    width: 150,
+    height: 150
+  },
+  view12: {
+    alignItems: "flex-end",
+    backgroundColor: colors.grey50,
+    flexDirection: "row",
+    justifyContent: "flex-start",
+    width: 150,
+    height: 150
+  },
+  localAsset10: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  },
+  localAsset11: {
+    alignItems: "center",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  },
+  localAsset12: {
+    alignItems: "flex-end",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  },
+  view13: {
+    alignItems: "flex-start",
+    flexDirection: "row",
+    justifyContent: "center",
+    width: 150,
+    height: 150
+  },
+  view14: {
+    alignItems: "center",
+    backgroundColor: colors.grey50,
+    flexDirection: "row",
+    justifyContent: "center",
+    width: 150,
+    height: 150
+  },
+  view15: {
+    alignItems: "flex-end",
+    flexDirection: "row",
+    justifyContent: "center",
+    width: 150,
+    height: 150
+  },
+  localAsset13: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "center"
+  },
+  localAsset14: {
+    alignItems: "center",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "center"
+  },
+  localAsset15: {
+    alignItems: "flex-end",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "center"
+  },
+  view16: {
+    alignItems: "flex-start",
+    backgroundColor: colors.grey50,
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    width: 150,
+    height: 150
+  },
+  view17: {
+    alignItems: "center",
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    width: 150,
+    height: 150
+  },
+  view18: {
+    alignItems: "flex-end",
+    backgroundColor: colors.grey50,
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    width: 150,
+    height: 150
+  },
+  localAsset16: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "flex-end"
+  },
+  localAsset17: {
+    alignItems: "center",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "flex-end"
+  },
+  localAsset18: {
+    alignItems: "flex-end",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "flex-end"
+  }
+})

--- a/examples/generated/test/sketchJs/images/LocalAsset.js
+++ b/examples/generated/test/sketchJs/images/LocalAsset.js
@@ -22,10 +22,17 @@ export default class LocalAsset extends React.Component {
 };
 
 let styles = StyleSheet.create({
-  view: { alignItems: "flex-start", alignSelf: "stretch", flex: 0 },
+  view: {
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
   image: {
     alignItems: "flex-start",
     backgroundColor: "#D8D8D8",
+    flexDirection: "column",
+    justifyContent: "flex-start",
     width: 100,
     height: 100
   }

--- a/examples/generated/test/sketchJs/images/LocalAsset.js
+++ b/examples/generated/test/sketchJs/images/LocalAsset.js
@@ -22,6 +22,11 @@ export default class LocalAsset extends React.Component {
 };
 
 let styles = StyleSheet.create({
-  view: { alignSelf: "stretch" },
-  image: { backgroundColor: "#D8D8D8", width: 100, height: 100 }
+  view: { alignItems: "flex-start", alignSelf: "stretch", flex: 0 },
+  image: {
+    alignItems: "flex-start",
+    backgroundColor: "#D8D8D8",
+    width: 100,
+    height: 100
+  }
 })

--- a/examples/generated/test/sketchJs/images/LocalAsset.js
+++ b/examples/generated/test/sketchJs/images/LocalAsset.js
@@ -24,6 +24,7 @@ export default class LocalAsset extends React.Component {
 let styles = StyleSheet.create({
   view: {
     alignItems: "flex-start",
+    backgroundColor: colors.red400,
     flex: 0,
     flexDirection: "column",
     justifyContent: "flex-start"

--- a/examples/generated/test/sketchJs/interactivity/Button.js
+++ b/examples/generated/test/sketchJs/interactivity/Button.js
@@ -44,10 +44,18 @@ let styles = StyleSheet.create({
     alignItems: "flex-start",
     backgroundColor: colors.blue100,
     flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     paddingTop: 12,
     paddingRight: 16,
     paddingBottom: 12,
     paddingLeft: 16
   },
-  text: { ...TextStyles.get("button"), alignItems: "flex-start", flex: 0 }
+  text: {
+    ...TextStyles.get("button"),
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  }
 })

--- a/examples/generated/test/sketchJs/interactivity/Button.js
+++ b/examples/generated/test/sketchJs/interactivity/Button.js
@@ -41,11 +41,13 @@ export default class Button extends React.Component {
 
 let styles = StyleSheet.create({
   view: {
+    alignItems: "flex-start",
     backgroundColor: colors.blue100,
+    flex: 0,
     paddingTop: 12,
     paddingRight: 16,
     paddingBottom: 12,
     paddingLeft: 16
   },
-  text: { ...TextStyles.get("button") }
+  text: { ...TextStyles.get("button"), alignItems: "flex-start", flex: 0 }
 })

--- a/examples/generated/test/sketchJs/interactivity/PressableRootView.js
+++ b/examples/generated/test/sketchJs/interactivity/PressableRootView.js
@@ -62,13 +62,24 @@ export default class PressableRootView extends React.Component {
 
 let styles = StyleSheet.create({
   outer: {
+    alignItems: "flex-start",
     alignSelf: "stretch",
     backgroundColor: colors.grey50,
+    flex: 0,
     paddingTop: 24,
     paddingRight: 24,
     paddingBottom: 24,
     paddingLeft: 24
   },
-  inner: { backgroundColor: colors.blue500, width: 100, height: 100 },
-  innerText: { ...TextStyles.get("headline") }
+  inner: {
+    alignItems: "flex-start",
+    backgroundColor: colors.blue500,
+    width: 100,
+    height: 100
+  },
+  innerText: {
+    ...TextStyles.get("headline"),
+    alignItems: "flex-start",
+    flex: 0
+  }
 })

--- a/examples/generated/test/sketchJs/interactivity/PressableRootView.js
+++ b/examples/generated/test/sketchJs/interactivity/PressableRootView.js
@@ -66,6 +66,8 @@ let styles = StyleSheet.create({
     alignSelf: "stretch",
     backgroundColor: colors.grey50,
     flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     paddingTop: 24,
     paddingRight: 24,
     paddingBottom: 24,
@@ -74,12 +76,16 @@ let styles = StyleSheet.create({
   inner: {
     alignItems: "flex-start",
     backgroundColor: colors.blue500,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     width: 100,
     height: 100
   },
   innerText: {
     ...TextStyles.get("headline"),
     alignItems: "flex-start",
-    flex: 0
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
   }
 })

--- a/examples/generated/test/sketchJs/layouts/FitContentParentSecondaryChildren.js
+++ b/examples/generated/test/sketchJs/layouts/FitContentParentSecondaryChildren.js
@@ -20,15 +20,32 @@ export default class FitContentParentSecondaryChildren extends React.Component {
 
 let styles = StyleSheet.create({
   container: {
+    alignItems: "flex-start",
     alignSelf: "stretch",
     backgroundColor: colors.bluegrey50,
+    flex: 0,
     flexDirection: "row",
     paddingTop: 24,
     paddingRight: 24,
     paddingBottom: 24,
     paddingLeft: 24
   },
-  view1: { backgroundColor: colors.blue500, width: 60, height: 60 },
-  view3: { backgroundColor: colors.lightblue500, width: 100, height: 120 },
-  view2: { backgroundColor: colors.cyan500, width: 100, height: 180 }
+  view1: {
+    alignItems: "flex-start",
+    backgroundColor: colors.blue500,
+    width: 60,
+    height: 60
+  },
+  view3: {
+    alignItems: "flex-start",
+    backgroundColor: colors.lightblue500,
+    width: 100,
+    height: 120
+  },
+  view2: {
+    alignItems: "flex-start",
+    backgroundColor: colors.cyan500,
+    width: 100,
+    height: 180
+  }
 })

--- a/examples/generated/test/sketchJs/layouts/FitContentParentSecondaryChildren.js
+++ b/examples/generated/test/sketchJs/layouts/FitContentParentSecondaryChildren.js
@@ -25,6 +25,7 @@ let styles = StyleSheet.create({
     backgroundColor: colors.bluegrey50,
     flex: 0,
     flexDirection: "row",
+    justifyContent: "flex-start",
     paddingTop: 24,
     paddingRight: 24,
     paddingBottom: 24,
@@ -33,18 +34,24 @@ let styles = StyleSheet.create({
   view1: {
     alignItems: "flex-start",
     backgroundColor: colors.blue500,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     width: 60,
     height: 60
   },
   view3: {
     alignItems: "flex-start",
     backgroundColor: colors.lightblue500,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     width: 100,
     height: 120
   },
   view2: {
     alignItems: "flex-start",
     backgroundColor: colors.cyan500,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     width: 100,
     height: 180
   }

--- a/examples/generated/test/sketchJs/layouts/FixedParentFillAndFitChildren.js
+++ b/examples/generated/test/sketchJs/layouts/FixedParentFillAndFitChildren.js
@@ -23,6 +23,7 @@ export default class FixedParentFillAndFitChildren extends React.Component {
 
 let styles = StyleSheet.create({
   view: {
+    alignItems: "flex-start",
     alignSelf: "stretch",
     paddingTop: 24,
     paddingRight: 24,
@@ -31,21 +32,39 @@ let styles = StyleSheet.create({
     height: 600
   },
   view1: {
+    alignItems: "flex-start",
     alignSelf: "stretch",
     backgroundColor: colors.red50,
+    flex: 0,
     flexDirection: "row",
     paddingTop: 24,
     paddingRight: 24,
     paddingBottom: 24,
     paddingLeft: 24
   },
-  view4: { backgroundColor: colors.red200, width: 60, height: 100 },
+  view2: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    backgroundColor: colors.indigo100,
+    flex: 1
+  },
+  view3: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    backgroundColor: colors.teal100,
+    flex: 1
+  },
+  view4: {
+    alignItems: "flex-start",
+    backgroundColor: colors.red200,
+    width: 60,
+    height: 100
+  },
   view5: {
+    alignItems: "flex-start",
     backgroundColor: colors.deeporange200,
     marginLeft: 12,
     width: 60,
     height: 60
-  },
-  view2: { alignSelf: "stretch", backgroundColor: colors.indigo100, flex: 1 },
-  view3: { alignSelf: "stretch", backgroundColor: colors.teal100, flex: 1 }
+  }
 })

--- a/examples/generated/test/sketchJs/layouts/FixedParentFillAndFitChildren.js
+++ b/examples/generated/test/sketchJs/layouts/FixedParentFillAndFitChildren.js
@@ -25,6 +25,8 @@ let styles = StyleSheet.create({
   view: {
     alignItems: "flex-start",
     alignSelf: "stretch",
+    flexDirection: "column",
+    justifyContent: "flex-start",
     paddingTop: 24,
     paddingRight: 24,
     paddingBottom: 24,
@@ -37,6 +39,7 @@ let styles = StyleSheet.create({
     backgroundColor: colors.red50,
     flex: 0,
     flexDirection: "row",
+    justifyContent: "flex-start",
     paddingTop: 24,
     paddingRight: 24,
     paddingBottom: 24,
@@ -46,23 +49,31 @@ let styles = StyleSheet.create({
     alignItems: "flex-start",
     alignSelf: "stretch",
     backgroundColor: colors.indigo100,
-    flex: 1
+    flex: 1,
+    flexDirection: "column",
+    justifyContent: "flex-start"
   },
   view3: {
     alignItems: "flex-start",
     alignSelf: "stretch",
     backgroundColor: colors.teal100,
-    flex: 1
+    flex: 1,
+    flexDirection: "column",
+    justifyContent: "flex-start"
   },
   view4: {
     alignItems: "flex-start",
     backgroundColor: colors.red200,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     width: 60,
     height: 100
   },
   view5: {
     alignItems: "flex-start",
     backgroundColor: colors.deeporange200,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     marginLeft: 12,
     width: 60,
     height: 60

--- a/examples/generated/test/sketchJs/layouts/FixedParentFitChild.js
+++ b/examples/generated/test/sketchJs/layouts/FixedParentFitChild.js
@@ -21,6 +21,7 @@ export default class FixedParentFitChild extends React.Component {
 
 let styles = StyleSheet.create({
   view: {
+    alignItems: "flex-start",
     alignSelf: "stretch",
     backgroundColor: colors.bluegrey100,
     paddingTop: 24,
@@ -30,16 +31,24 @@ let styles = StyleSheet.create({
     height: 600
   },
   view1: {
+    alignItems: "flex-start",
     alignSelf: "stretch",
     backgroundColor: colors.red50,
+    flex: 0,
     flexDirection: "row",
     paddingTop: 24,
     paddingRight: 24,
     paddingBottom: 24,
     paddingLeft: 24
   },
-  view4: { backgroundColor: colors.red200, width: 60, height: 100 },
+  view4: {
+    alignItems: "flex-start",
+    backgroundColor: colors.red200,
+    width: 60,
+    height: 100
+  },
   view5: {
+    alignItems: "flex-start",
     backgroundColor: colors.deeporange200,
     marginLeft: 12,
     width: 60,

--- a/examples/generated/test/sketchJs/layouts/FixedParentFitChild.js
+++ b/examples/generated/test/sketchJs/layouts/FixedParentFitChild.js
@@ -24,6 +24,8 @@ let styles = StyleSheet.create({
     alignItems: "flex-start",
     alignSelf: "stretch",
     backgroundColor: colors.bluegrey100,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     paddingTop: 24,
     paddingRight: 24,
     paddingBottom: 24,
@@ -36,6 +38,7 @@ let styles = StyleSheet.create({
     backgroundColor: colors.red50,
     flex: 0,
     flexDirection: "row",
+    justifyContent: "flex-start",
     paddingTop: 24,
     paddingRight: 24,
     paddingBottom: 24,
@@ -44,12 +47,16 @@ let styles = StyleSheet.create({
   view4: {
     alignItems: "flex-start",
     backgroundColor: colors.red200,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     width: 60,
     height: 100
   },
   view5: {
     alignItems: "flex-start",
     backgroundColor: colors.deeporange200,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     marginLeft: 12,
     width: 60,
     height: 60

--- a/examples/generated/test/sketchJs/layouts/MultipleFlexText.js
+++ b/examples/generated/test/sketchJs/layouts/MultipleFlexText.js
@@ -4,27 +4,27 @@ import { Text, View, StyleSheet, TextStyles } from
 
 import colors from "../colors"
 import textStyles from "../textStyles"
-import FitContentParentSecondaryChildren from
-  "../layouts/FitContentParentSecondaryChildren"
-import LocalAsset from "../images/LocalAsset"
 
-export default class NestedComponent extends React.Component {
+export default class MultipleFlexText extends React.Component {
   render() {
 
 
     return (
       <View style={[ styles.view, {} ]}>
-        <Text style={[ styles.text, {} ]}>
-          {"Example nested component"}
-        </Text>
-        <FitContentParentSecondaryChildren />
-        <Text style={[ styles.text1, {} ]}>
-          {"Text below"}
-        </Text>
-        <LocalAsset />
-        <Text style={[ styles.text2, {} ]}>
-          {"Very bottom"}
-        </Text>
+        <View style={[ styles.view1, {} ]}>
+          <View style={[ styles.view3, {} ]}>
+            <Text style={[ styles.text, {} ]}>
+              {"Some long text (currently LS lays out incorrectly)"}
+            </Text>
+          </View>
+        </View>
+        <View style={[ styles.view2, {} ]}>
+          <View style={[ styles.view4, {} ]}>
+            <Text style={[ styles.text1, {} ]}>
+              {"Short"}
+            </Text>
+          </View>
+        </View>
       </View>
     );
   }
@@ -35,46 +35,51 @@ let styles = StyleSheet.create({
     alignItems: "flex-start",
     alignSelf: "stretch",
     flex: 0,
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    paddingTop: 10,
-    paddingRight: 10,
-    paddingBottom: 10,
-    paddingLeft: 10
+    flexDirection: "row",
+    justifyContent: "flex-start"
   },
-  text: {
-    ...TextStyles.get("subheading2"),
+  view1: {
     alignItems: "flex-start",
-    flex: 0,
+    backgroundColor: colors.red50,
+    flex: 1,
     flexDirection: "column",
     justifyContent: "flex-start",
-    marginBottom: 8
+    height: 100
   },
-  fitContentParentSecondaryChildren: {
+  view2: {
+    alignItems: "flex-start",
+    backgroundColor: colors.blue50,
+    flex: 1,
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    height: 100
+  },
+  view3: {
     alignItems: "flex-start",
     alignSelf: "stretch",
     flex: 1,
-    flexDirection: "row",
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  text: {
+    ...TextStyles.get("body1"),
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  view4: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "column",
     justifyContent: "flex-start"
   },
   text1: {
     ...TextStyles.get("body1"),
     alignItems: "flex-start",
-    flex: 0,
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    marginTop: 12
-  },
-  localAsset: {
-    alignItems: "flex-start",
     alignSelf: "stretch",
-    flex: 1,
-    flexDirection: "row",
-    justifyContent: "flex-start"
-  },
-  text2: {
-    ...TextStyles.get("body1"),
-    alignItems: "flex-start",
     flex: 0,
     flexDirection: "column",
     justifyContent: "flex-start"

--- a/examples/generated/test/sketchJs/layouts/PrimaryAxis.js
+++ b/examples/generated/test/sketchJs/layouts/PrimaryAxis.js
@@ -28,6 +28,8 @@ let styles = StyleSheet.create({
   view: {
     alignItems: "flex-start",
     alignSelf: "stretch",
+    flexDirection: "column",
+    justifyContent: "flex-start",
     paddingTop: 24,
     paddingRight: 24,
     paddingBottom: 24,
@@ -37,6 +39,8 @@ let styles = StyleSheet.create({
   fixed: {
     alignItems: "flex-start",
     backgroundColor: "#D8D8D8",
+    flexDirection: "column",
+    justifyContent: "flex-start",
     marginBottom: 24,
     width: 100,
     height: 100
@@ -45,6 +49,8 @@ let styles = StyleSheet.create({
     alignItems: "flex-start",
     backgroundColor: "#D8D8D8",
     flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     marginBottom: 24,
     width: 100
   },
@@ -52,13 +58,23 @@ let styles = StyleSheet.create({
     alignItems: "flex-start",
     backgroundColor: colors.cyan500,
     flex: 1,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     width: 100
   },
   fill2: {
     alignItems: "flex-start",
     backgroundColor: colors.blue500,
     flex: 1,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     width: 100
   },
-  text: { ...TextStyles.get("body1"), alignItems: "flex-start", flex: 0 }
+  text: {
+    ...TextStyles.get("body1"),
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  }
 })

--- a/examples/generated/test/sketchJs/layouts/PrimaryAxis.js
+++ b/examples/generated/test/sketchJs/layouts/PrimaryAxis.js
@@ -26,6 +26,7 @@ export default class PrimaryAxis extends React.Component {
 
 let styles = StyleSheet.create({
   view: {
+    alignItems: "flex-start",
     alignSelf: "stretch",
     paddingTop: 24,
     paddingRight: 24,
@@ -34,13 +35,30 @@ let styles = StyleSheet.create({
     height: 500
   },
   fixed: {
+    alignItems: "flex-start",
     backgroundColor: "#D8D8D8",
     marginBottom: 24,
     width: 100,
     height: 100
   },
-  fit: { backgroundColor: "#D8D8D8", marginBottom: 24, width: 100 },
-  text: {},
-  fill1: { backgroundColor: colors.cyan500, flex: 1, width: 100 },
-  fill2: { backgroundColor: colors.blue500, flex: 1, width: 100 }
+  fit: {
+    alignItems: "flex-start",
+    backgroundColor: "#D8D8D8",
+    flex: 0,
+    marginBottom: 24,
+    width: 100
+  },
+  fill1: {
+    alignItems: "flex-start",
+    backgroundColor: colors.cyan500,
+    flex: 1,
+    width: 100
+  },
+  fill2: {
+    alignItems: "flex-start",
+    backgroundColor: colors.blue500,
+    flex: 1,
+    width: 100
+  },
+  text: { ...TextStyles.get("body1"), alignItems: "flex-start", flex: 0 }
 })

--- a/examples/generated/test/sketchJs/layouts/SecondaryAxis.js
+++ b/examples/generated/test/sketchJs/layouts/SecondaryAxis.js
@@ -25,19 +25,23 @@ export default class SecondaryAxis extends React.Component {
 
 let styles = StyleSheet.create({
   container: {
+    alignItems: "flex-start",
     alignSelf: "stretch",
+    flex: 0,
     paddingTop: 24,
     paddingRight: 24,
     paddingBottom: 24,
     paddingLeft: 24
   },
   fixed: {
+    alignItems: "flex-start",
     backgroundColor: "#D8D8D8",
     marginBottom: 24,
     width: 100,
     height: 100
   },
   fit: {
+    alignItems: "flex-start",
     backgroundColor: "#D8D8D8",
     marginBottom: 24,
     paddingTop: 12,
@@ -46,6 +50,11 @@ let styles = StyleSheet.create({
     paddingLeft: 12,
     height: 100
   },
-  text: {},
-  fill: { alignSelf: "stretch", backgroundColor: "#D8D8D8", height: 100 }
+  fill: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    backgroundColor: "#D8D8D8",
+    height: 100
+  },
+  text: { ...TextStyles.get("body1"), alignItems: "flex-start", flex: 0 }
 })

--- a/examples/generated/test/sketchJs/layouts/SecondaryAxis.js
+++ b/examples/generated/test/sketchJs/layouts/SecondaryAxis.js
@@ -28,6 +28,8 @@ let styles = StyleSheet.create({
     alignItems: "flex-start",
     alignSelf: "stretch",
     flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     paddingTop: 24,
     paddingRight: 24,
     paddingBottom: 24,
@@ -36,6 +38,8 @@ let styles = StyleSheet.create({
   fixed: {
     alignItems: "flex-start",
     backgroundColor: "#D8D8D8",
+    flexDirection: "column",
+    justifyContent: "flex-start",
     marginBottom: 24,
     width: 100,
     height: 100
@@ -43,6 +47,8 @@ let styles = StyleSheet.create({
   fit: {
     alignItems: "flex-start",
     backgroundColor: "#D8D8D8",
+    flexDirection: "column",
+    justifyContent: "flex-start",
     marginBottom: 24,
     paddingTop: 12,
     paddingRight: 12,
@@ -54,7 +60,15 @@ let styles = StyleSheet.create({
     alignItems: "flex-start",
     alignSelf: "stretch",
     backgroundColor: "#D8D8D8",
+    flexDirection: "column",
+    justifyContent: "flex-start",
     height: 100
   },
-  text: { ...TextStyles.get("body1"), alignItems: "flex-start", flex: 0 }
+  text: {
+    ...TextStyles.get("body1"),
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  }
 })

--- a/examples/generated/test/sketchJs/logic/Assign.js
+++ b/examples/generated/test/sketchJs/logic/Assign.js
@@ -21,4 +21,7 @@ export default class Assign extends React.Component {
   }
 };
 
-let styles = StyleSheet.create({ view: { alignSelf: "stretch" }, text: {} })
+let styles = StyleSheet.create({
+  view: { alignItems: "flex-start", alignSelf: "stretch", flex: 0 },
+  text: { ...TextStyles.get("body1"), alignItems: "flex-start", flex: 0 }
+})

--- a/examples/generated/test/sketchJs/logic/Assign.js
+++ b/examples/generated/test/sketchJs/logic/Assign.js
@@ -22,6 +22,18 @@ export default class Assign extends React.Component {
 };
 
 let styles = StyleSheet.create({
-  view: { alignItems: "flex-start", alignSelf: "stretch", flex: 0 },
-  text: { ...TextStyles.get("body1"), alignItems: "flex-start", flex: 0 }
+  view: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  text: {
+    ...TextStyles.get("body1"),
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  }
 })

--- a/examples/generated/test/sketchJs/logic/If.js
+++ b/examples/generated/test/sketchJs/logic/If.js
@@ -23,5 +23,11 @@ export default class If extends React.Component {
 };
 
 let styles = StyleSheet.create({
-  view: { alignItems: "flex-start", alignSelf: "stretch", flex: 0 }
+  view: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  }
 })

--- a/examples/generated/test/sketchJs/logic/If.js
+++ b/examples/generated/test/sketchJs/logic/If.js
@@ -22,4 +22,6 @@ export default class If extends React.Component {
   }
 };
 
-let styles = StyleSheet.create({ view: { alignSelf: "stretch" } })
+let styles = StyleSheet.create({
+  view: { alignItems: "flex-start", alignSelf: "stretch", flex: 0 }
+})

--- a/examples/generated/test/sketchJs/style/BorderWidthColor.js
+++ b/examples/generated/test/sketchJs/style/BorderWidthColor.js
@@ -17,8 +17,9 @@ export default class BorderWidthColor extends React.Component {
 };
 
 let styles = StyleSheet.create({
-  view: { alignSelf: "stretch" },
+  view: { alignItems: "flex-start", alignSelf: "stretch", flex: 0 },
   view1: {
+    alignItems: "flex-start",
     borderRadius: 10,
     borderWidth: 20,
     borderColor: colors.blue300,

--- a/examples/generated/test/sketchJs/style/BorderWidthColor.js
+++ b/examples/generated/test/sketchJs/style/BorderWidthColor.js
@@ -17,9 +17,17 @@ export default class BorderWidthColor extends React.Component {
 };
 
 let styles = StyleSheet.create({
-  view: { alignItems: "flex-start", alignSelf: "stretch", flex: 0 },
+  view: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
   view1: {
     alignItems: "flex-start",
+    flexDirection: "column",
+    justifyContent: "flex-start",
     borderRadius: 10,
     borderWidth: 20,
     borderColor: colors.blue300,

--- a/examples/generated/test/sketchJs/style/BoxModelConditional.js
+++ b/examples/generated/test/sketchJs/style/BoxModelConditional.js
@@ -43,11 +43,18 @@ export default class BoxModelConditional extends React.Component {
 
 let styles = StyleSheet.create({
   outer: {
+    alignItems: "flex-start",
     alignSelf: "stretch",
+    flex: 0,
     paddingTop: 4,
     paddingRight: 4,
     paddingBottom: 4,
     paddingLeft: 4
   },
-  inner: { backgroundColor: "#D8D8D8", width: 60, height: 60 }
+  inner: {
+    alignItems: "flex-start",
+    backgroundColor: "#D8D8D8",
+    width: 60,
+    height: 60
+  }
 })

--- a/examples/generated/test/sketchJs/style/BoxModelConditional.js
+++ b/examples/generated/test/sketchJs/style/BoxModelConditional.js
@@ -46,6 +46,8 @@ let styles = StyleSheet.create({
     alignItems: "flex-start",
     alignSelf: "stretch",
     flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     paddingTop: 4,
     paddingRight: 4,
     paddingBottom: 4,
@@ -54,6 +56,8 @@ let styles = StyleSheet.create({
   inner: {
     alignItems: "flex-start",
     backgroundColor: "#D8D8D8",
+    flexDirection: "column",
+    justifyContent: "flex-start",
     width: 60,
     height: 60
   }

--- a/examples/generated/test/sketchJs/style/TextAlignment.js
+++ b/examples/generated/test/sketchJs/style/TextAlignment.js
@@ -77,6 +77,8 @@ let styles = StyleSheet.create({
     alignItems: "flex-start",
     alignSelf: "stretch",
     flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     paddingTop: 10,
     paddingRight: 10,
     paddingBottom: 10,
@@ -87,12 +89,15 @@ let styles = StyleSheet.create({
     alignSelf: "stretch",
     backgroundColor: colors.indigo50,
     flex: 0,
+    flexDirection: "column",
     justifyContent: "center"
   },
   view3: {
     alignItems: "center",
     backgroundColor: "#D8D8D8",
     flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     paddingRight: 12,
     paddingLeft: 12
   },
@@ -100,6 +105,8 @@ let styles = StyleSheet.create({
     alignItems: "center",
     backgroundColor: "#D8D8D8",
     flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     paddingRight: 12,
     paddingLeft: 12,
     width: 400
@@ -108,6 +115,8 @@ let styles = StyleSheet.create({
     alignItems: "flex-start",
     backgroundColor: "#D8D8D8",
     flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     paddingRight: 12,
     paddingLeft: 12
   },
@@ -115,6 +124,8 @@ let styles = StyleSheet.create({
     alignItems: "flex-start",
     backgroundColor: "#D8D8D8",
     flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     paddingRight: 12,
     paddingLeft: 12,
     width: 400
@@ -123,16 +134,32 @@ let styles = StyleSheet.create({
     alignItems: "flex-end",
     alignSelf: "stretch",
     backgroundColor: "#D8D8D8",
-    flex: 0
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
   },
-  image: { alignItems: "flex-start", width: 100, height: 100 },
-  view2: { alignItems: "flex-start", backgroundColor: "#D8D8D8", flex: 0 },
+  image: {
+    alignItems: "flex-start",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: 100,
+    height: 100
+  },
+  view2: {
+    alignItems: "flex-start",
+    backgroundColor: "#D8D8D8",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
   text: {
     textAlign: "center",
     ...TextStyles.get("display1"),
     alignItems: "flex-start",
     alignSelf: "stretch",
     flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     marginTop: 16
   },
   text1: {
@@ -140,6 +167,8 @@ let styles = StyleSheet.create({
     ...TextStyles.get("subheading2"),
     alignItems: "flex-start",
     flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     marginTop: 16
   },
   text2: {
@@ -147,6 +176,8 @@ let styles = StyleSheet.create({
     alignItems: "flex-start",
     alignSelf: "stretch",
     flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     marginTop: 12
   },
   text3: {
@@ -154,37 +185,71 @@ let styles = StyleSheet.create({
     ...TextStyles.get("body1"),
     alignItems: "flex-start",
     alignSelf: "stretch",
-    flex: 0
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
   },
   text4: {
     textAlign: "center",
     ...TextStyles.get("body1"),
     alignItems: "flex-start",
     flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
     width: 80
   },
-  text5: { ...TextStyles.get("body1"), alignItems: "flex-start", flex: 0 },
-  text6: { ...TextStyles.get("body1"), alignItems: "flex-start", flex: 0 },
+  text5: {
+    ...TextStyles.get("body1"),
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  text6: {
+    ...TextStyles.get("body1"),
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
   text7: {
     textAlign: "center",
     ...TextStyles.get("body1"),
     alignItems: "flex-start",
-    flex: 0
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
   },
   text8: {
     textAlign: "center",
     ...TextStyles.get("body1"),
     alignItems: "flex-start",
     alignSelf: "stretch",
-    flex: 0
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
   },
-  text9: { ...TextStyles.get("body1"), alignItems: "flex-start", flex: 0 },
+  text9: {
+    ...TextStyles.get("body1"),
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
   text10: {
     textAlign: "center",
     ...TextStyles.get("body1"),
     alignItems: "flex-start",
     alignSelf: "stretch",
-    flex: 0
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
   },
-  image1: { alignItems: "flex-start", width: 100, height: 100 }
+  image1: {
+    alignItems: "flex-start",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: 100,
+    height: 100
+  }
 })

--- a/examples/generated/test/sketchJs/style/TextAlignment.js
+++ b/examples/generated/test/sketchJs/style/TextAlignment.js
@@ -76,6 +76,7 @@ let styles = StyleSheet.create({
   view: {
     alignItems: "flex-start",
     alignSelf: "stretch",
+    flex: 0,
     paddingTop: 10,
     paddingRight: 10,
     paddingBottom: 10,
@@ -85,54 +86,105 @@ let styles = StyleSheet.create({
     alignItems: "center",
     alignSelf: "stretch",
     backgroundColor: colors.indigo50,
+    flex: 0,
     justifyContent: "center"
   },
-  image: { width: 100, height: 100 },
-  view2: { backgroundColor: "#D8D8D8" },
+  view3: {
+    alignItems: "center",
+    backgroundColor: "#D8D8D8",
+    flex: 0,
+    paddingRight: 12,
+    paddingLeft: 12
+  },
+  view4: {
+    alignItems: "center",
+    backgroundColor: "#D8D8D8",
+    flex: 0,
+    paddingRight: 12,
+    paddingLeft: 12,
+    width: 400
+  },
+  view5: {
+    alignItems: "flex-start",
+    backgroundColor: "#D8D8D8",
+    flex: 0,
+    paddingRight: 12,
+    paddingLeft: 12
+  },
+  view6: {
+    alignItems: "flex-start",
+    backgroundColor: "#D8D8D8",
+    flex: 0,
+    paddingRight: 12,
+    paddingLeft: 12,
+    width: 400
+  },
+  rightAlignmentContainer: {
+    alignItems: "flex-end",
+    alignSelf: "stretch",
+    backgroundColor: "#D8D8D8",
+    flex: 0
+  },
+  image: { alignItems: "flex-start", width: 100, height: 100 },
+  view2: { alignItems: "flex-start", backgroundColor: "#D8D8D8", flex: 0 },
   text: {
     textAlign: "center",
     ...TextStyles.get("display1"),
+    alignItems: "flex-start",
     alignSelf: "stretch",
+    flex: 0,
     marginTop: 16
   },
   text1: {
     textAlign: "center",
     ...TextStyles.get("subheading2"),
+    alignItems: "flex-start",
+    flex: 0,
     marginTop: 16
   },
-  text2: { alignSelf: "stretch", marginTop: 12 },
-  text3: { textAlign: "right", alignSelf: "stretch" },
-  text4: { textAlign: "center", width: 80 },
-  view3: {
-    alignItems: "center",
-    backgroundColor: "#D8D8D8",
-    paddingRight: 12,
-    paddingLeft: 12
-  },
-  text5: {},
-  view4: {
-    alignItems: "center",
-    backgroundColor: "#D8D8D8",
-    paddingRight: 12,
-    paddingLeft: 12,
-    width: 400
-  },
-  text6: {},
-  view5: { backgroundColor: "#D8D8D8", paddingRight: 12, paddingLeft: 12 },
-  text7: { textAlign: "center" },
-  view6: {
-    backgroundColor: "#D8D8D8",
-    paddingRight: 12,
-    paddingLeft: 12,
-    width: 400
-  },
-  text8: { textAlign: "center", alignSelf: "stretch" },
-  rightAlignmentContainer: {
-    alignItems: "flex-end",
+  text2: {
+    ...TextStyles.get("body1"),
+    alignItems: "flex-start",
     alignSelf: "stretch",
-    backgroundColor: "#D8D8D8"
+    flex: 0,
+    marginTop: 12
   },
-  text9: {},
-  text10: { textAlign: "center", alignSelf: "stretch" },
-  image1: { width: 100, height: 100 }
+  text3: {
+    textAlign: "right",
+    ...TextStyles.get("body1"),
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0
+  },
+  text4: {
+    textAlign: "center",
+    ...TextStyles.get("body1"),
+    alignItems: "flex-start",
+    flex: 0,
+    width: 80
+  },
+  text5: { ...TextStyles.get("body1"), alignItems: "flex-start", flex: 0 },
+  text6: { ...TextStyles.get("body1"), alignItems: "flex-start", flex: 0 },
+  text7: {
+    textAlign: "center",
+    ...TextStyles.get("body1"),
+    alignItems: "flex-start",
+    flex: 0
+  },
+  text8: {
+    textAlign: "center",
+    ...TextStyles.get("body1"),
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0
+  },
+  text9: { ...TextStyles.get("body1"), alignItems: "flex-start", flex: 0 },
+  text10: {
+    textAlign: "center",
+    ...TextStyles.get("body1"),
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0
+  },
+  image1: { alignItems: "flex-start", width: 100, height: 100 }
 })

--- a/examples/generated/test/sketchJs/style/TextStyleConditional.js
+++ b/examples/generated/test/sketchJs/style/TextStyleConditional.js
@@ -25,6 +25,6 @@ export default class TextStyleConditional extends React.Component {
 };
 
 let styles = StyleSheet.create({
-  view: { alignSelf: "stretch" },
-  text: { ...TextStyles.get("headline") }
+  view: { alignItems: "flex-start", alignSelf: "stretch", flex: 0 },
+  text: { ...TextStyles.get("headline"), alignItems: "flex-start", flex: 0 }
 })

--- a/examples/generated/test/sketchJs/style/TextStyleConditional.js
+++ b/examples/generated/test/sketchJs/style/TextStyleConditional.js
@@ -25,6 +25,18 @@ export default class TextStyleConditional extends React.Component {
 };
 
 let styles = StyleSheet.create({
-  view: { alignItems: "flex-start", alignSelf: "stretch", flex: 0 },
-  text: { ...TextStyles.get("headline"), alignItems: "flex-start", flex: 0 }
+  view: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  text: {
+    ...TextStyles.get("headline"),
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  }
 })

--- a/examples/generated/test/sketchJs/style/TextStylesTest.js
+++ b/examples/generated/test/sketchJs/style/TextStylesTest.js
@@ -47,15 +47,23 @@ export default class TextStylesTest extends React.Component {
 };
 
 let styles = StyleSheet.create({
-  view: { alignSelf: "stretch" },
-  text: { ...TextStyles.get("display4") },
-  text1: { ...TextStyles.get("display3") },
-  text2: { ...TextStyles.get("display2") },
-  text3: { ...TextStyles.get("display1") },
-  text4: { ...TextStyles.get("headline") },
-  text5: { ...TextStyles.get("subheading2") },
-  text6: { ...TextStyles.get("subheading1") },
-  text7: { ...TextStyles.get("body2") },
-  text8: { ...TextStyles.get("body1") },
-  text9: { ...TextStyles.get("caption") }
+  view: { alignItems: "flex-start", alignSelf: "stretch", flex: 0 },
+  text: { ...TextStyles.get("display4"), alignItems: "flex-start", flex: 0 },
+  text1: { ...TextStyles.get("display3"), alignItems: "flex-start", flex: 0 },
+  text2: { ...TextStyles.get("display2"), alignItems: "flex-start", flex: 0 },
+  text3: { ...TextStyles.get("display1"), alignItems: "flex-start", flex: 0 },
+  text4: { ...TextStyles.get("headline"), alignItems: "flex-start", flex: 0 },
+  text5: {
+    ...TextStyles.get("subheading2"),
+    alignItems: "flex-start",
+    flex: 0
+  },
+  text6: {
+    ...TextStyles.get("subheading1"),
+    alignItems: "flex-start",
+    flex: 0
+  },
+  text7: { ...TextStyles.get("body2"), alignItems: "flex-start", flex: 0 },
+  text8: { ...TextStyles.get("body1"), alignItems: "flex-start", flex: 0 },
+  text9: { ...TextStyles.get("caption"), alignItems: "flex-start", flex: 0 }
 })

--- a/examples/generated/test/sketchJs/style/TextStylesTest.js
+++ b/examples/generated/test/sketchJs/style/TextStylesTest.js
@@ -47,23 +47,81 @@ export default class TextStylesTest extends React.Component {
 };
 
 let styles = StyleSheet.create({
-  view: { alignItems: "flex-start", alignSelf: "stretch", flex: 0 },
-  text: { ...TextStyles.get("display4"), alignItems: "flex-start", flex: 0 },
-  text1: { ...TextStyles.get("display3"), alignItems: "flex-start", flex: 0 },
-  text2: { ...TextStyles.get("display2"), alignItems: "flex-start", flex: 0 },
-  text3: { ...TextStyles.get("display1"), alignItems: "flex-start", flex: 0 },
-  text4: { ...TextStyles.get("headline"), alignItems: "flex-start", flex: 0 },
+  view: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  text: {
+    ...TextStyles.get("display4"),
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  text1: {
+    ...TextStyles.get("display3"),
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  text2: {
+    ...TextStyles.get("display2"),
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  text3: {
+    ...TextStyles.get("display1"),
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  text4: {
+    ...TextStyles.get("headline"),
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
   text5: {
     ...TextStyles.get("subheading2"),
     alignItems: "flex-start",
-    flex: 0
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
   },
   text6: {
     ...TextStyles.get("subheading1"),
     alignItems: "flex-start",
-    flex: 0
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
   },
-  text7: { ...TextStyles.get("body2"), alignItems: "flex-start", flex: 0 },
-  text8: { ...TextStyles.get("body1"), alignItems: "flex-start", flex: 0 },
-  text9: { ...TextStyles.get("caption"), alignItems: "flex-start", flex: 0 }
+  text7: {
+    ...TextStyles.get("body2"),
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  text8: {
+    ...TextStyles.get("body1"),
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  text9: {
+    ...TextStyles.get("caption"),
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  }
 })

--- a/examples/generated/test/sketchJs/textStyles.js
+++ b/examples/generated/test/sketchJs/textStyles.js
@@ -2,77 +2,77 @@ import colors from "./colors"
 
 export default {
   display4: {
-    family: "Arial",
+    fontFamily: "Arial",
     fontWeight: "300",
     fontSize: 112,
     lineHeight: 120,
     color: colors.grey900
   },
   display3: {
-    family: "Arial",
+    fontFamily: "Arial",
     fontWeight: "400",
     fontSize: 56,
     lineHeight: 60,
     color: colors.grey900
   },
   display2: {
-    family: "Arial",
+    fontFamily: "Arial",
     fontWeight: "400",
     fontSize: 45,
     lineHeight: 48,
     color: colors.grey900
   },
   display1: {
-    family: "Arial",
+    fontFamily: "Arial",
     fontWeight: "400",
     fontSize: 34,
     lineHeight: 40,
     color: colors.grey900
   },
   headline: {
-    family: "Arial",
+    fontFamily: "Arial",
     fontWeight: "400",
     fontSize: 24,
     lineHeight: 32,
     color: colors.grey900
   },
   subheading2: {
-    family: "Arial",
+    fontFamily: "Arial",
     fontWeight: "400",
     fontSize: 16,
     lineHeight: 28,
     color: colors.grey900
   },
   subheading1: {
-    family: "Arial",
+    fontFamily: "Arial",
     fontWeight: "400",
     fontSize: 16,
     lineHeight: 24,
     color: colors.grey900
   },
   body2: {
-    family: "Arial",
+    fontFamily: "Arial",
     fontWeight: "500",
     fontSize: 14,
     lineHeight: 24,
     color: colors.grey900
   },
   body1: {
-    family: "Arial",
+    fontFamily: "Arial",
     fontWeight: "400",
     fontSize: 14,
     lineHeight: 20,
     color: colors.grey900
   },
   caption: {
-    family: "Arial",
+    fontFamily: "Arial",
     fontWeight: "400",
     fontSize: 12,
     lineHeight: 15,
     color: colors.grey900
   },
   button: {
-    family: "Arial",
+    fontFamily: "Arial",
     fontWeight: "500",
     fontSize: 14,
     lineHeight: 18,

--- a/examples/generated/test/swift/components/NestedBottomLeftLayout.swift
+++ b/examples/generated/test/swift/components/NestedBottomLeftLayout.swift
@@ -1,0 +1,64 @@
+import UIKit
+import Foundation
+
+// MARK: - NestedBottomLeftLayout
+
+public class NestedBottomLeftLayout: UIView {
+
+  // MARK: Lifecycle
+
+  public init() {
+    super.init(frame: .zero)
+
+    setUpViews()
+    setUpConstraints()
+
+    update()
+  }
+
+  public required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: Private
+
+  private var view1View = UIView(frame: .zero)
+  private var localAssetView = LocalAsset()
+
+  private func setUpViews() {
+    addSubview(view1View)
+    view1View.addSubview(localAssetView)
+
+    view1View.backgroundColor = Colors.red100
+  }
+
+  private func setUpConstraints() {
+    translatesAutoresizingMaskIntoConstraints = false
+    view1View.translatesAutoresizingMaskIntoConstraints = false
+    localAssetView.translatesAutoresizingMaskIntoConstraints = false
+
+    let view1ViewTopAnchorConstraint = view1View.topAnchor.constraint(equalTo: topAnchor)
+    let view1ViewBottomAnchorConstraint = view1View.bottomAnchor.constraint(equalTo: bottomAnchor)
+    let view1ViewLeadingAnchorConstraint = view1View.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let view1ViewHeightAnchorConstraint = view1View.heightAnchor.constraint(equalToConstant: 150)
+    let view1ViewWidthAnchorConstraint = view1View.widthAnchor.constraint(equalToConstant: 150)
+    let localAssetViewLeadingAnchorConstraint = localAssetView
+      .leadingAnchor
+      .constraint(equalTo: view1View.leadingAnchor)
+    let localAssetViewTopAnchorConstraint = localAssetView.topAnchor.constraint(equalTo: view1View.topAnchor)
+    let localAssetViewBottomAnchorConstraint = localAssetView.bottomAnchor.constraint(equalTo: view1View.bottomAnchor)
+
+    NSLayoutConstraint.activate([
+      view1ViewTopAnchorConstraint,
+      view1ViewBottomAnchorConstraint,
+      view1ViewLeadingAnchorConstraint,
+      view1ViewHeightAnchorConstraint,
+      view1ViewWidthAnchorConstraint,
+      localAssetViewLeadingAnchorConstraint,
+      localAssetViewTopAnchorConstraint,
+      localAssetViewBottomAnchorConstraint
+    ])
+  }
+
+  private func update() {}
+}

--- a/examples/generated/test/swift/components/NestedComponent.swift
+++ b/examples/generated/test/swift/components/NestedComponent.swift
@@ -85,7 +85,7 @@ public class NestedComponent: UIView {
       .constraint(equalTo: leadingAnchor, constant: 10)
     let localAssetViewTrailingAnchorConstraint = localAssetView
       .trailingAnchor
-      .constraint(equalTo: trailingAnchor, constant: -10)
+      .constraint(lessThanOrEqualTo: trailingAnchor, constant: -10)
     let text2ViewBottomAnchorConstraint = text2View.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -10)
     let text2ViewTopAnchorConstraint = text2View.topAnchor.constraint(equalTo: localAssetView.bottomAnchor)
     let text2ViewLeadingAnchorConstraint = text2View.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10)

--- a/examples/generated/test/swift/components/NestedLayout.swift
+++ b/examples/generated/test/swift/components/NestedLayout.swift
@@ -1,0 +1,644 @@
+import UIKit
+import Foundation
+
+// MARK: - NestedLayout
+
+public class NestedLayout: UIView {
+
+  // MARK: Lifecycle
+
+  public init() {
+    super.init(frame: .zero)
+
+    setUpViews()
+    setUpConstraints()
+
+    update()
+  }
+
+  public required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: Private
+
+  private var topRowView = UIView(frame: .zero)
+  private var column1View = UIView(frame: .zero)
+  private var view1View = UIView(frame: .zero)
+  private var localAssetView = LocalAsset()
+  private var view2View = UIView(frame: .zero)
+  private var localAsset2View = LocalAsset()
+  private var view3View = UIView(frame: .zero)
+  private var localAsset3View = LocalAsset()
+  private var column2View = UIView(frame: .zero)
+  private var view4View = UIView(frame: .zero)
+  private var localAsset4View = LocalAsset()
+  private var view5View = UIView(frame: .zero)
+  private var localAsset5View = LocalAsset()
+  private var view6View = UIView(frame: .zero)
+  private var localAsset6View = LocalAsset()
+  private var column3View = UIView(frame: .zero)
+  private var view7View = UIView(frame: .zero)
+  private var localAsset7View = LocalAsset()
+  private var view8View = UIView(frame: .zero)
+  private var localAsset8View = LocalAsset()
+  private var view9View = UIView(frame: .zero)
+  private var localAsset9View = LocalAsset()
+  private var bottomRowView = UIView(frame: .zero)
+  private var column4View = UIView(frame: .zero)
+  private var view10View = UIView(frame: .zero)
+  private var localAsset10View = LocalAsset()
+  private var view11View = UIView(frame: .zero)
+  private var localAsset11View = LocalAsset()
+  private var view12View = UIView(frame: .zero)
+  private var localAsset12View = LocalAsset()
+  private var column5View = UIView(frame: .zero)
+  private var view13View = UIView(frame: .zero)
+  private var localAsset13View = LocalAsset()
+  private var view14View = UIView(frame: .zero)
+  private var localAsset14View = LocalAsset()
+  private var view15View = UIView(frame: .zero)
+  private var localAsset15View = LocalAsset()
+  private var column6View = UIView(frame: .zero)
+  private var view16View = UIView(frame: .zero)
+  private var localAsset16View = LocalAsset()
+  private var view17View = UIView(frame: .zero)
+  private var localAsset17View = LocalAsset()
+  private var view18View = UIView(frame: .zero)
+  private var localAsset18View = LocalAsset()
+
+  private func setUpViews() {
+    addSubview(topRowView)
+    addSubview(bottomRowView)
+    topRowView.addSubview(column1View)
+    topRowView.addSubview(column2View)
+    topRowView.addSubview(column3View)
+    column1View.addSubview(view1View)
+    column1View.addSubview(view2View)
+    column1View.addSubview(view3View)
+    view1View.addSubview(localAssetView)
+    view2View.addSubview(localAsset2View)
+    view3View.addSubview(localAsset3View)
+    column2View.addSubview(view4View)
+    column2View.addSubview(view5View)
+    column2View.addSubview(view6View)
+    view4View.addSubview(localAsset4View)
+    view5View.addSubview(localAsset5View)
+    view6View.addSubview(localAsset6View)
+    column3View.addSubview(view7View)
+    column3View.addSubview(view8View)
+    column3View.addSubview(view9View)
+    view7View.addSubview(localAsset7View)
+    view8View.addSubview(localAsset8View)
+    view9View.addSubview(localAsset9View)
+    bottomRowView.addSubview(column4View)
+    bottomRowView.addSubview(column5View)
+    bottomRowView.addSubview(column6View)
+    column4View.addSubview(view10View)
+    column4View.addSubview(view11View)
+    column4View.addSubview(view12View)
+    view10View.addSubview(localAsset10View)
+    view11View.addSubview(localAsset11View)
+    view12View.addSubview(localAsset12View)
+    column5View.addSubview(view13View)
+    column5View.addSubview(view14View)
+    column5View.addSubview(view15View)
+    view13View.addSubview(localAsset13View)
+    view14View.addSubview(localAsset14View)
+    view15View.addSubview(localAsset15View)
+    column6View.addSubview(view16View)
+    column6View.addSubview(view17View)
+    column6View.addSubview(view18View)
+    view16View.addSubview(localAsset16View)
+    view17View.addSubview(localAsset17View)
+    view18View.addSubview(localAsset18View)
+
+    view1View.backgroundColor = Colors.grey50
+    view2View.backgroundColor = #colorLiteral(red: 0, green: 0, blue: 0, alpha: 0)
+    view3View.backgroundColor = Colors.grey50
+    view5View.backgroundColor = Colors.grey50
+    view7View.backgroundColor = Colors.grey50
+    view9View.backgroundColor = Colors.grey50
+    view10View.backgroundColor = Colors.grey50
+    view11View.backgroundColor = #colorLiteral(red: 0, green: 0, blue: 0, alpha: 0)
+    view12View.backgroundColor = Colors.grey50
+    view14View.backgroundColor = Colors.grey50
+    view16View.backgroundColor = Colors.grey50
+    view18View.backgroundColor = Colors.grey50
+  }
+
+  private func setUpConstraints() {
+    translatesAutoresizingMaskIntoConstraints = false
+    topRowView.translatesAutoresizingMaskIntoConstraints = false
+    bottomRowView.translatesAutoresizingMaskIntoConstraints = false
+    column1View.translatesAutoresizingMaskIntoConstraints = false
+    column2View.translatesAutoresizingMaskIntoConstraints = false
+    column3View.translatesAutoresizingMaskIntoConstraints = false
+    view1View.translatesAutoresizingMaskIntoConstraints = false
+    view2View.translatesAutoresizingMaskIntoConstraints = false
+    view3View.translatesAutoresizingMaskIntoConstraints = false
+    localAssetView.translatesAutoresizingMaskIntoConstraints = false
+    localAsset2View.translatesAutoresizingMaskIntoConstraints = false
+    localAsset3View.translatesAutoresizingMaskIntoConstraints = false
+    view4View.translatesAutoresizingMaskIntoConstraints = false
+    view5View.translatesAutoresizingMaskIntoConstraints = false
+    view6View.translatesAutoresizingMaskIntoConstraints = false
+    localAsset4View.translatesAutoresizingMaskIntoConstraints = false
+    localAsset5View.translatesAutoresizingMaskIntoConstraints = false
+    localAsset6View.translatesAutoresizingMaskIntoConstraints = false
+    view7View.translatesAutoresizingMaskIntoConstraints = false
+    view8View.translatesAutoresizingMaskIntoConstraints = false
+    view9View.translatesAutoresizingMaskIntoConstraints = false
+    localAsset7View.translatesAutoresizingMaskIntoConstraints = false
+    localAsset8View.translatesAutoresizingMaskIntoConstraints = false
+    localAsset9View.translatesAutoresizingMaskIntoConstraints = false
+    column4View.translatesAutoresizingMaskIntoConstraints = false
+    column5View.translatesAutoresizingMaskIntoConstraints = false
+    column6View.translatesAutoresizingMaskIntoConstraints = false
+    view10View.translatesAutoresizingMaskIntoConstraints = false
+    view11View.translatesAutoresizingMaskIntoConstraints = false
+    view12View.translatesAutoresizingMaskIntoConstraints = false
+    localAsset10View.translatesAutoresizingMaskIntoConstraints = false
+    localAsset11View.translatesAutoresizingMaskIntoConstraints = false
+    localAsset12View.translatesAutoresizingMaskIntoConstraints = false
+    view13View.translatesAutoresizingMaskIntoConstraints = false
+    view14View.translatesAutoresizingMaskIntoConstraints = false
+    view15View.translatesAutoresizingMaskIntoConstraints = false
+    localAsset13View.translatesAutoresizingMaskIntoConstraints = false
+    localAsset14View.translatesAutoresizingMaskIntoConstraints = false
+    localAsset15View.translatesAutoresizingMaskIntoConstraints = false
+    view16View.translatesAutoresizingMaskIntoConstraints = false
+    view17View.translatesAutoresizingMaskIntoConstraints = false
+    view18View.translatesAutoresizingMaskIntoConstraints = false
+    localAsset16View.translatesAutoresizingMaskIntoConstraints = false
+    localAsset17View.translatesAutoresizingMaskIntoConstraints = false
+    localAsset18View.translatesAutoresizingMaskIntoConstraints = false
+
+    let topRowViewTopAnchorConstraint = topRowView.topAnchor.constraint(equalTo: topAnchor)
+    let topRowViewLeadingAnchorConstraint = topRowView.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let topRowViewTrailingAnchorConstraint = topRowView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor)
+    let bottomRowViewBottomAnchorConstraint = bottomRowView.bottomAnchor.constraint(equalTo: bottomAnchor)
+    let bottomRowViewTopAnchorConstraint = bottomRowView.topAnchor.constraint(equalTo: topRowView.bottomAnchor)
+    let bottomRowViewLeadingAnchorConstraint = bottomRowView.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let bottomRowViewTrailingAnchorConstraint = bottomRowView
+      .trailingAnchor
+      .constraint(lessThanOrEqualTo: trailingAnchor)
+    let column1ViewHeightAnchorParentConstraint = column1View
+      .heightAnchor
+      .constraint(lessThanOrEqualTo: topRowView.heightAnchor)
+    let column2ViewHeightAnchorParentConstraint = column2View
+      .heightAnchor
+      .constraint(lessThanOrEqualTo: topRowView.heightAnchor)
+    let column3ViewHeightAnchorParentConstraint = column3View
+      .heightAnchor
+      .constraint(lessThanOrEqualTo: topRowView.heightAnchor)
+    let column1ViewLeadingAnchorConstraint = column1View.leadingAnchor.constraint(equalTo: topRowView.leadingAnchor)
+    let column1ViewTopAnchorConstraint = column1View.topAnchor.constraint(equalTo: topRowView.topAnchor)
+    let column1ViewBottomAnchorConstraint = column1View.bottomAnchor.constraint(equalTo: topRowView.bottomAnchor)
+    let column2ViewLeadingAnchorConstraint = column2View.leadingAnchor.constraint(equalTo: column1View.trailingAnchor)
+    let column2ViewTopAnchorConstraint = column2View.topAnchor.constraint(equalTo: topRowView.topAnchor)
+    let column2ViewBottomAnchorConstraint = column2View.bottomAnchor.constraint(equalTo: topRowView.bottomAnchor)
+    let column3ViewTrailingAnchorConstraint = column3View.trailingAnchor.constraint(equalTo: topRowView.trailingAnchor)
+    let column3ViewLeadingAnchorConstraint = column3View.leadingAnchor.constraint(equalTo: column2View.trailingAnchor)
+    let column3ViewTopAnchorConstraint = column3View.topAnchor.constraint(equalTo: topRowView.topAnchor)
+    let column3ViewBottomAnchorConstraint = column3View.bottomAnchor.constraint(equalTo: topRowView.bottomAnchor)
+    let column4ViewHeightAnchorParentConstraint = column4View
+      .heightAnchor
+      .constraint(lessThanOrEqualTo: bottomRowView.heightAnchor)
+    let column5ViewHeightAnchorParentConstraint = column5View
+      .heightAnchor
+      .constraint(lessThanOrEqualTo: bottomRowView.heightAnchor)
+    let column6ViewHeightAnchorParentConstraint = column6View
+      .heightAnchor
+      .constraint(lessThanOrEqualTo: bottomRowView.heightAnchor)
+    let column4ViewLeadingAnchorConstraint = column4View.leadingAnchor.constraint(equalTo: bottomRowView.leadingAnchor)
+    let column4ViewTopAnchorConstraint = column4View.topAnchor.constraint(equalTo: bottomRowView.topAnchor)
+    let column4ViewBottomAnchorConstraint = column4View.bottomAnchor.constraint(equalTo: bottomRowView.bottomAnchor)
+    let column5ViewLeadingAnchorConstraint = column5View.leadingAnchor.constraint(equalTo: column4View.trailingAnchor)
+    let column5ViewTopAnchorConstraint = column5View.topAnchor.constraint(equalTo: bottomRowView.topAnchor)
+    let column5ViewBottomAnchorConstraint = column5View.bottomAnchor.constraint(equalTo: bottomRowView.bottomAnchor)
+    let column6ViewTrailingAnchorConstraint = column6View
+      .trailingAnchor
+      .constraint(equalTo: bottomRowView.trailingAnchor)
+    let column6ViewLeadingAnchorConstraint = column6View.leadingAnchor.constraint(equalTo: column5View.trailingAnchor)
+    let column6ViewTopAnchorConstraint = column6View.topAnchor.constraint(equalTo: bottomRowView.topAnchor)
+    let column6ViewBottomAnchorConstraint = column6View.bottomAnchor.constraint(equalTo: bottomRowView.bottomAnchor)
+    let column1ViewWidthAnchorConstraint = column1View.widthAnchor.constraint(equalToConstant: 150)
+    let view1ViewTopAnchorConstraint = view1View.topAnchor.constraint(equalTo: column1View.topAnchor)
+    let view1ViewLeadingAnchorConstraint = view1View.leadingAnchor.constraint(equalTo: column1View.leadingAnchor)
+    let view2ViewTopAnchorConstraint = view2View.topAnchor.constraint(equalTo: view1View.bottomAnchor)
+    let view2ViewLeadingAnchorConstraint = view2View.leadingAnchor.constraint(equalTo: column1View.leadingAnchor)
+    let view3ViewBottomAnchorConstraint = view3View.bottomAnchor.constraint(equalTo: column1View.bottomAnchor)
+    let view3ViewTopAnchorConstraint = view3View.topAnchor.constraint(equalTo: view2View.bottomAnchor)
+    let view3ViewLeadingAnchorConstraint = view3View.leadingAnchor.constraint(equalTo: column1View.leadingAnchor)
+    let column2ViewWidthAnchorConstraint = column2View.widthAnchor.constraint(equalToConstant: 150)
+    let view4ViewTopAnchorConstraint = view4View.topAnchor.constraint(equalTo: column2View.topAnchor)
+    let view4ViewLeadingAnchorConstraint = view4View.leadingAnchor.constraint(equalTo: column2View.leadingAnchor)
+    let view5ViewTopAnchorConstraint = view5View.topAnchor.constraint(equalTo: view4View.bottomAnchor)
+    let view5ViewLeadingAnchorConstraint = view5View.leadingAnchor.constraint(equalTo: column2View.leadingAnchor)
+    let view6ViewBottomAnchorConstraint = view6View.bottomAnchor.constraint(equalTo: column2View.bottomAnchor)
+    let view6ViewTopAnchorConstraint = view6View.topAnchor.constraint(equalTo: view5View.bottomAnchor)
+    let view6ViewLeadingAnchorConstraint = view6View.leadingAnchor.constraint(equalTo: column2View.leadingAnchor)
+    let column3ViewWidthAnchorConstraint = column3View.widthAnchor.constraint(equalToConstant: 150)
+    let view7ViewTopAnchorConstraint = view7View.topAnchor.constraint(equalTo: column3View.topAnchor)
+    let view7ViewLeadingAnchorConstraint = view7View.leadingAnchor.constraint(equalTo: column3View.leadingAnchor)
+    let view8ViewTopAnchorConstraint = view8View.topAnchor.constraint(equalTo: view7View.bottomAnchor)
+    let view8ViewLeadingAnchorConstraint = view8View.leadingAnchor.constraint(equalTo: column3View.leadingAnchor)
+    let view9ViewBottomAnchorConstraint = view9View.bottomAnchor.constraint(equalTo: column3View.bottomAnchor)
+    let view9ViewTopAnchorConstraint = view9View.topAnchor.constraint(equalTo: view8View.bottomAnchor)
+    let view9ViewLeadingAnchorConstraint = view9View.leadingAnchor.constraint(equalTo: column3View.leadingAnchor)
+    let view1ViewHeightAnchorConstraint = view1View.heightAnchor.constraint(equalToConstant: 150)
+    let view1ViewWidthAnchorConstraint = view1View.widthAnchor.constraint(equalToConstant: 150)
+    let localAssetViewTopAnchorConstraint = localAssetView.topAnchor.constraint(equalTo: view1View.topAnchor)
+    let localAssetViewLeadingAnchorConstraint = localAssetView
+      .leadingAnchor
+      .constraint(equalTo: view1View.leadingAnchor)
+    let localAssetViewTrailingAnchorConstraint = localAssetView
+      .trailingAnchor
+      .constraint(equalTo: view1View.trailingAnchor)
+    let view2ViewHeightAnchorConstraint = view2View.heightAnchor.constraint(equalToConstant: 150)
+    let view2ViewWidthAnchorConstraint = view2View.widthAnchor.constraint(equalToConstant: 150)
+    let localAsset2ViewTopAnchorConstraint = localAsset2View.topAnchor.constraint(equalTo: view2View.topAnchor)
+    let localAsset2ViewLeadingAnchorConstraint = localAsset2View
+      .leadingAnchor
+      .constraint(equalTo: view2View.leadingAnchor)
+    let localAsset2ViewTrailingAnchorConstraint = localAsset2View
+      .trailingAnchor
+      .constraint(equalTo: view2View.trailingAnchor)
+    let view3ViewHeightAnchorConstraint = view3View.heightAnchor.constraint(equalToConstant: 150)
+    let view3ViewWidthAnchorConstraint = view3View.widthAnchor.constraint(equalToConstant: 150)
+    let localAsset3ViewTopAnchorConstraint = localAsset3View.topAnchor.constraint(equalTo: view3View.topAnchor)
+    let localAsset3ViewLeadingAnchorConstraint = localAsset3View
+      .leadingAnchor
+      .constraint(equalTo: view3View.leadingAnchor)
+    let localAsset3ViewTrailingAnchorConstraint = localAsset3View
+      .trailingAnchor
+      .constraint(equalTo: view3View.trailingAnchor)
+    let view4ViewHeightAnchorConstraint = view4View.heightAnchor.constraint(equalToConstant: 150)
+    let view4ViewWidthAnchorConstraint = view4View.widthAnchor.constraint(equalToConstant: 150)
+    let localAsset4ViewTopAnchorConstraint = localAsset4View.topAnchor.constraint(equalTo: view4View.topAnchor)
+    let localAsset4ViewLeadingAnchorConstraint = localAsset4View
+      .leadingAnchor
+      .constraint(equalTo: view4View.leadingAnchor)
+    let localAsset4ViewCenterXAnchorConstraint = localAsset4View
+      .centerXAnchor
+      .constraint(equalTo: view4View.centerXAnchor)
+    let localAsset4ViewTrailingAnchorConstraint = localAsset4View
+      .trailingAnchor
+      .constraint(equalTo: view4View.trailingAnchor)
+    let view5ViewHeightAnchorConstraint = view5View.heightAnchor.constraint(equalToConstant: 150)
+    let view5ViewWidthAnchorConstraint = view5View.widthAnchor.constraint(equalToConstant: 150)
+    let localAsset5ViewTopAnchorConstraint = localAsset5View.topAnchor.constraint(equalTo: view5View.topAnchor)
+    let localAsset5ViewLeadingAnchorConstraint = localAsset5View
+      .leadingAnchor
+      .constraint(equalTo: view5View.leadingAnchor)
+    let localAsset5ViewCenterXAnchorConstraint = localAsset5View
+      .centerXAnchor
+      .constraint(equalTo: view5View.centerXAnchor)
+    let localAsset5ViewTrailingAnchorConstraint = localAsset5View
+      .trailingAnchor
+      .constraint(equalTo: view5View.trailingAnchor)
+    let view6ViewHeightAnchorConstraint = view6View.heightAnchor.constraint(equalToConstant: 150)
+    let view6ViewWidthAnchorConstraint = view6View.widthAnchor.constraint(equalToConstant: 150)
+    let localAsset6ViewTopAnchorConstraint = localAsset6View.topAnchor.constraint(equalTo: view6View.topAnchor)
+    let localAsset6ViewLeadingAnchorConstraint = localAsset6View
+      .leadingAnchor
+      .constraint(equalTo: view6View.leadingAnchor)
+    let localAsset6ViewCenterXAnchorConstraint = localAsset6View
+      .centerXAnchor
+      .constraint(equalTo: view6View.centerXAnchor)
+    let localAsset6ViewTrailingAnchorConstraint = localAsset6View
+      .trailingAnchor
+      .constraint(equalTo: view6View.trailingAnchor)
+    let view7ViewHeightAnchorConstraint = view7View.heightAnchor.constraint(equalToConstant: 150)
+    let view7ViewWidthAnchorConstraint = view7View.widthAnchor.constraint(equalToConstant: 150)
+    let localAsset7ViewTopAnchorConstraint = localAsset7View.topAnchor.constraint(equalTo: view7View.topAnchor)
+    let localAsset7ViewLeadingAnchorConstraint = localAsset7View
+      .leadingAnchor
+      .constraint(equalTo: view7View.leadingAnchor)
+    let localAsset7ViewTrailingAnchorConstraint = localAsset7View
+      .trailingAnchor
+      .constraint(equalTo: view7View.trailingAnchor)
+    let view8ViewHeightAnchorConstraint = view8View.heightAnchor.constraint(equalToConstant: 150)
+    let view8ViewWidthAnchorConstraint = view8View.widthAnchor.constraint(equalToConstant: 150)
+    let localAsset8ViewTopAnchorConstraint = localAsset8View.topAnchor.constraint(equalTo: view8View.topAnchor)
+    let localAsset8ViewLeadingAnchorConstraint = localAsset8View
+      .leadingAnchor
+      .constraint(equalTo: view8View.leadingAnchor)
+    let localAsset8ViewTrailingAnchorConstraint = localAsset8View
+      .trailingAnchor
+      .constraint(equalTo: view8View.trailingAnchor)
+    let view9ViewHeightAnchorConstraint = view9View.heightAnchor.constraint(equalToConstant: 150)
+    let view9ViewWidthAnchorConstraint = view9View.widthAnchor.constraint(equalToConstant: 150)
+    let localAsset9ViewTopAnchorConstraint = localAsset9View.topAnchor.constraint(equalTo: view9View.topAnchor)
+    let localAsset9ViewLeadingAnchorConstraint = localAsset9View
+      .leadingAnchor
+      .constraint(equalTo: view9View.leadingAnchor)
+    let localAsset9ViewTrailingAnchorConstraint = localAsset9View
+      .trailingAnchor
+      .constraint(equalTo: view9View.trailingAnchor)
+    let column4ViewWidthAnchorConstraint = column4View.widthAnchor.constraint(equalToConstant: 150)
+    let view10ViewTopAnchorConstraint = view10View.topAnchor.constraint(equalTo: column4View.topAnchor)
+    let view10ViewLeadingAnchorConstraint = view10View.leadingAnchor.constraint(equalTo: column4View.leadingAnchor)
+    let view11ViewTopAnchorConstraint = view11View.topAnchor.constraint(equalTo: view10View.bottomAnchor)
+    let view11ViewLeadingAnchorConstraint = view11View.leadingAnchor.constraint(equalTo: column4View.leadingAnchor)
+    let view12ViewBottomAnchorConstraint = view12View.bottomAnchor.constraint(equalTo: column4View.bottomAnchor)
+    let view12ViewTopAnchorConstraint = view12View.topAnchor.constraint(equalTo: view11View.bottomAnchor)
+    let view12ViewLeadingAnchorConstraint = view12View.leadingAnchor.constraint(equalTo: column4View.leadingAnchor)
+    let column5ViewWidthAnchorConstraint = column5View.widthAnchor.constraint(equalToConstant: 150)
+    let view13ViewTopAnchorConstraint = view13View.topAnchor.constraint(equalTo: column5View.topAnchor)
+    let view13ViewLeadingAnchorConstraint = view13View.leadingAnchor.constraint(equalTo: column5View.leadingAnchor)
+    let view14ViewTopAnchorConstraint = view14View.topAnchor.constraint(equalTo: view13View.bottomAnchor)
+    let view14ViewLeadingAnchorConstraint = view14View.leadingAnchor.constraint(equalTo: column5View.leadingAnchor)
+    let view15ViewBottomAnchorConstraint = view15View.bottomAnchor.constraint(equalTo: column5View.bottomAnchor)
+    let view15ViewTopAnchorConstraint = view15View.topAnchor.constraint(equalTo: view14View.bottomAnchor)
+    let view15ViewLeadingAnchorConstraint = view15View.leadingAnchor.constraint(equalTo: column5View.leadingAnchor)
+    let column6ViewWidthAnchorConstraint = column6View.widthAnchor.constraint(equalToConstant: 150)
+    let view16ViewTopAnchorConstraint = view16View.topAnchor.constraint(equalTo: column6View.topAnchor)
+    let view16ViewLeadingAnchorConstraint = view16View.leadingAnchor.constraint(equalTo: column6View.leadingAnchor)
+    let view17ViewTopAnchorConstraint = view17View.topAnchor.constraint(equalTo: view16View.bottomAnchor)
+    let view17ViewLeadingAnchorConstraint = view17View.leadingAnchor.constraint(equalTo: column6View.leadingAnchor)
+    let view18ViewBottomAnchorConstraint = view18View.bottomAnchor.constraint(equalTo: column6View.bottomAnchor)
+    let view18ViewTopAnchorConstraint = view18View.topAnchor.constraint(equalTo: view17View.bottomAnchor)
+    let view18ViewLeadingAnchorConstraint = view18View.leadingAnchor.constraint(equalTo: column6View.leadingAnchor)
+    let view10ViewHeightAnchorConstraint = view10View.heightAnchor.constraint(equalToConstant: 150)
+    let view10ViewWidthAnchorConstraint = view10View.widthAnchor.constraint(equalToConstant: 150)
+    let localAsset10ViewLeadingAnchorConstraint = localAsset10View
+      .leadingAnchor
+      .constraint(equalTo: view10View.leadingAnchor)
+    let localAsset10ViewTopAnchorConstraint = localAsset10View.topAnchor.constraint(equalTo: view10View.topAnchor)
+    let localAsset10ViewBottomAnchorConstraint = localAsset10View
+      .bottomAnchor
+      .constraint(equalTo: view10View.bottomAnchor)
+    let view11ViewHeightAnchorConstraint = view11View.heightAnchor.constraint(equalToConstant: 150)
+    let view11ViewWidthAnchorConstraint = view11View.widthAnchor.constraint(equalToConstant: 150)
+    let localAsset11ViewLeadingAnchorConstraint = localAsset11View
+      .leadingAnchor
+      .constraint(equalTo: view11View.leadingAnchor)
+    let localAsset11ViewTopAnchorConstraint = localAsset11View.topAnchor.constraint(equalTo: view11View.topAnchor)
+    let localAsset11ViewCenterYAnchorConstraint = localAsset11View
+      .centerYAnchor
+      .constraint(equalTo: view11View.centerYAnchor)
+    let localAsset11ViewBottomAnchorConstraint = localAsset11View
+      .bottomAnchor
+      .constraint(equalTo: view11View.bottomAnchor)
+    let view12ViewHeightAnchorConstraint = view12View.heightAnchor.constraint(equalToConstant: 150)
+    let view12ViewWidthAnchorConstraint = view12View.widthAnchor.constraint(equalToConstant: 150)
+    let localAsset12ViewLeadingAnchorConstraint = localAsset12View
+      .leadingAnchor
+      .constraint(equalTo: view12View.leadingAnchor)
+    let localAsset12ViewTopAnchorConstraint = localAsset12View.topAnchor.constraint(equalTo: view12View.topAnchor)
+    let localAsset12ViewBottomAnchorConstraint = localAsset12View
+      .bottomAnchor
+      .constraint(equalTo: view12View.bottomAnchor)
+    let view13ViewHeightAnchorConstraint = view13View.heightAnchor.constraint(equalToConstant: 150)
+    let view13ViewWidthAnchorConstraint = view13View.widthAnchor.constraint(equalToConstant: 150)
+    let localAsset13ViewLeadingAnchorConstraint = localAsset13View
+      .leadingAnchor
+      .constraint(equalTo: view13View.leadingAnchor)
+    let localAsset13ViewTopAnchorConstraint = localAsset13View.topAnchor.constraint(equalTo: view13View.topAnchor)
+    let localAsset13ViewBottomAnchorConstraint = localAsset13View
+      .bottomAnchor
+      .constraint(equalTo: view13View.bottomAnchor)
+    let view14ViewHeightAnchorConstraint = view14View.heightAnchor.constraint(equalToConstant: 150)
+    let view14ViewWidthAnchorConstraint = view14View.widthAnchor.constraint(equalToConstant: 150)
+    let localAsset14ViewLeadingAnchorConstraint = localAsset14View
+      .leadingAnchor
+      .constraint(equalTo: view14View.leadingAnchor)
+    let localAsset14ViewTopAnchorConstraint = localAsset14View.topAnchor.constraint(equalTo: view14View.topAnchor)
+    let localAsset14ViewCenterYAnchorConstraint = localAsset14View
+      .centerYAnchor
+      .constraint(equalTo: view14View.centerYAnchor)
+    let localAsset14ViewBottomAnchorConstraint = localAsset14View
+      .bottomAnchor
+      .constraint(equalTo: view14View.bottomAnchor)
+    let view15ViewHeightAnchorConstraint = view15View.heightAnchor.constraint(equalToConstant: 150)
+    let view15ViewWidthAnchorConstraint = view15View.widthAnchor.constraint(equalToConstant: 150)
+    let localAsset15ViewLeadingAnchorConstraint = localAsset15View
+      .leadingAnchor
+      .constraint(equalTo: view15View.leadingAnchor)
+    let localAsset15ViewTopAnchorConstraint = localAsset15View.topAnchor.constraint(equalTo: view15View.topAnchor)
+    let localAsset15ViewBottomAnchorConstraint = localAsset15View
+      .bottomAnchor
+      .constraint(equalTo: view15View.bottomAnchor)
+    let view16ViewHeightAnchorConstraint = view16View.heightAnchor.constraint(equalToConstant: 150)
+    let view16ViewWidthAnchorConstraint = view16View.widthAnchor.constraint(equalToConstant: 150)
+    let localAsset16ViewLeadingAnchorConstraint = localAsset16View
+      .leadingAnchor
+      .constraint(equalTo: view16View.leadingAnchor)
+    let localAsset16ViewTopAnchorConstraint = localAsset16View.topAnchor.constraint(equalTo: view16View.topAnchor)
+    let localAsset16ViewBottomAnchorConstraint = localAsset16View
+      .bottomAnchor
+      .constraint(equalTo: view16View.bottomAnchor)
+    let view17ViewHeightAnchorConstraint = view17View.heightAnchor.constraint(equalToConstant: 150)
+    let view17ViewWidthAnchorConstraint = view17View.widthAnchor.constraint(equalToConstant: 150)
+    let localAsset17ViewLeadingAnchorConstraint = localAsset17View
+      .leadingAnchor
+      .constraint(equalTo: view17View.leadingAnchor)
+    let localAsset17ViewTopAnchorConstraint = localAsset17View.topAnchor.constraint(equalTo: view17View.topAnchor)
+    let localAsset17ViewCenterYAnchorConstraint = localAsset17View
+      .centerYAnchor
+      .constraint(equalTo: view17View.centerYAnchor)
+    let localAsset17ViewBottomAnchorConstraint = localAsset17View
+      .bottomAnchor
+      .constraint(equalTo: view17View.bottomAnchor)
+    let view18ViewHeightAnchorConstraint = view18View.heightAnchor.constraint(equalToConstant: 150)
+    let view18ViewWidthAnchorConstraint = view18View.widthAnchor.constraint(equalToConstant: 150)
+    let localAsset18ViewLeadingAnchorConstraint = localAsset18View
+      .leadingAnchor
+      .constraint(equalTo: view18View.leadingAnchor)
+    let localAsset18ViewTopAnchorConstraint = localAsset18View.topAnchor.constraint(equalTo: view18View.topAnchor)
+    let localAsset18ViewBottomAnchorConstraint = localAsset18View
+      .bottomAnchor
+      .constraint(equalTo: view18View.bottomAnchor)
+
+    column1ViewHeightAnchorParentConstraint.priority = UILayoutPriority.defaultLow
+    column2ViewHeightAnchorParentConstraint.priority = UILayoutPriority.defaultLow
+    column3ViewHeightAnchorParentConstraint.priority = UILayoutPriority.defaultLow
+    column4ViewHeightAnchorParentConstraint.priority = UILayoutPriority.defaultLow
+    column5ViewHeightAnchorParentConstraint.priority = UILayoutPriority.defaultLow
+    column6ViewHeightAnchorParentConstraint.priority = UILayoutPriority.defaultLow
+
+    NSLayoutConstraint.activate([
+      topRowViewTopAnchorConstraint,
+      topRowViewLeadingAnchorConstraint,
+      topRowViewTrailingAnchorConstraint,
+      bottomRowViewBottomAnchorConstraint,
+      bottomRowViewTopAnchorConstraint,
+      bottomRowViewLeadingAnchorConstraint,
+      bottomRowViewTrailingAnchorConstraint,
+      column1ViewHeightAnchorParentConstraint,
+      column2ViewHeightAnchorParentConstraint,
+      column3ViewHeightAnchorParentConstraint,
+      column1ViewLeadingAnchorConstraint,
+      column1ViewTopAnchorConstraint,
+      column1ViewBottomAnchorConstraint,
+      column2ViewLeadingAnchorConstraint,
+      column2ViewTopAnchorConstraint,
+      column2ViewBottomAnchorConstraint,
+      column3ViewTrailingAnchorConstraint,
+      column3ViewLeadingAnchorConstraint,
+      column3ViewTopAnchorConstraint,
+      column3ViewBottomAnchorConstraint,
+      column4ViewHeightAnchorParentConstraint,
+      column5ViewHeightAnchorParentConstraint,
+      column6ViewHeightAnchorParentConstraint,
+      column4ViewLeadingAnchorConstraint,
+      column4ViewTopAnchorConstraint,
+      column4ViewBottomAnchorConstraint,
+      column5ViewLeadingAnchorConstraint,
+      column5ViewTopAnchorConstraint,
+      column5ViewBottomAnchorConstraint,
+      column6ViewTrailingAnchorConstraint,
+      column6ViewLeadingAnchorConstraint,
+      column6ViewTopAnchorConstraint,
+      column6ViewBottomAnchorConstraint,
+      column1ViewWidthAnchorConstraint,
+      view1ViewTopAnchorConstraint,
+      view1ViewLeadingAnchorConstraint,
+      view2ViewTopAnchorConstraint,
+      view2ViewLeadingAnchorConstraint,
+      view3ViewBottomAnchorConstraint,
+      view3ViewTopAnchorConstraint,
+      view3ViewLeadingAnchorConstraint,
+      column2ViewWidthAnchorConstraint,
+      view4ViewTopAnchorConstraint,
+      view4ViewLeadingAnchorConstraint,
+      view5ViewTopAnchorConstraint,
+      view5ViewLeadingAnchorConstraint,
+      view6ViewBottomAnchorConstraint,
+      view6ViewTopAnchorConstraint,
+      view6ViewLeadingAnchorConstraint,
+      column3ViewWidthAnchorConstraint,
+      view7ViewTopAnchorConstraint,
+      view7ViewLeadingAnchorConstraint,
+      view8ViewTopAnchorConstraint,
+      view8ViewLeadingAnchorConstraint,
+      view9ViewBottomAnchorConstraint,
+      view9ViewTopAnchorConstraint,
+      view9ViewLeadingAnchorConstraint,
+      view1ViewHeightAnchorConstraint,
+      view1ViewWidthAnchorConstraint,
+      localAssetViewTopAnchorConstraint,
+      localAssetViewLeadingAnchorConstraint,
+      localAssetViewTrailingAnchorConstraint,
+      view2ViewHeightAnchorConstraint,
+      view2ViewWidthAnchorConstraint,
+      localAsset2ViewTopAnchorConstraint,
+      localAsset2ViewLeadingAnchorConstraint,
+      localAsset2ViewTrailingAnchorConstraint,
+      view3ViewHeightAnchorConstraint,
+      view3ViewWidthAnchorConstraint,
+      localAsset3ViewTopAnchorConstraint,
+      localAsset3ViewLeadingAnchorConstraint,
+      localAsset3ViewTrailingAnchorConstraint,
+      view4ViewHeightAnchorConstraint,
+      view4ViewWidthAnchorConstraint,
+      localAsset4ViewTopAnchorConstraint,
+      localAsset4ViewLeadingAnchorConstraint,
+      localAsset4ViewCenterXAnchorConstraint,
+      localAsset4ViewTrailingAnchorConstraint,
+      view5ViewHeightAnchorConstraint,
+      view5ViewWidthAnchorConstraint,
+      localAsset5ViewTopAnchorConstraint,
+      localAsset5ViewLeadingAnchorConstraint,
+      localAsset5ViewCenterXAnchorConstraint,
+      localAsset5ViewTrailingAnchorConstraint,
+      view6ViewHeightAnchorConstraint,
+      view6ViewWidthAnchorConstraint,
+      localAsset6ViewTopAnchorConstraint,
+      localAsset6ViewLeadingAnchorConstraint,
+      localAsset6ViewCenterXAnchorConstraint,
+      localAsset6ViewTrailingAnchorConstraint,
+      view7ViewHeightAnchorConstraint,
+      view7ViewWidthAnchorConstraint,
+      localAsset7ViewTopAnchorConstraint,
+      localAsset7ViewLeadingAnchorConstraint,
+      localAsset7ViewTrailingAnchorConstraint,
+      view8ViewHeightAnchorConstraint,
+      view8ViewWidthAnchorConstraint,
+      localAsset8ViewTopAnchorConstraint,
+      localAsset8ViewLeadingAnchorConstraint,
+      localAsset8ViewTrailingAnchorConstraint,
+      view9ViewHeightAnchorConstraint,
+      view9ViewWidthAnchorConstraint,
+      localAsset9ViewTopAnchorConstraint,
+      localAsset9ViewLeadingAnchorConstraint,
+      localAsset9ViewTrailingAnchorConstraint,
+      column4ViewWidthAnchorConstraint,
+      view10ViewTopAnchorConstraint,
+      view10ViewLeadingAnchorConstraint,
+      view11ViewTopAnchorConstraint,
+      view11ViewLeadingAnchorConstraint,
+      view12ViewBottomAnchorConstraint,
+      view12ViewTopAnchorConstraint,
+      view12ViewLeadingAnchorConstraint,
+      column5ViewWidthAnchorConstraint,
+      view13ViewTopAnchorConstraint,
+      view13ViewLeadingAnchorConstraint,
+      view14ViewTopAnchorConstraint,
+      view14ViewLeadingAnchorConstraint,
+      view15ViewBottomAnchorConstraint,
+      view15ViewTopAnchorConstraint,
+      view15ViewLeadingAnchorConstraint,
+      column6ViewWidthAnchorConstraint,
+      view16ViewTopAnchorConstraint,
+      view16ViewLeadingAnchorConstraint,
+      view17ViewTopAnchorConstraint,
+      view17ViewLeadingAnchorConstraint,
+      view18ViewBottomAnchorConstraint,
+      view18ViewTopAnchorConstraint,
+      view18ViewLeadingAnchorConstraint,
+      view10ViewHeightAnchorConstraint,
+      view10ViewWidthAnchorConstraint,
+      localAsset10ViewLeadingAnchorConstraint,
+      localAsset10ViewTopAnchorConstraint,
+      localAsset10ViewBottomAnchorConstraint,
+      view11ViewHeightAnchorConstraint,
+      view11ViewWidthAnchorConstraint,
+      localAsset11ViewLeadingAnchorConstraint,
+      localAsset11ViewTopAnchorConstraint,
+      localAsset11ViewCenterYAnchorConstraint,
+      localAsset11ViewBottomAnchorConstraint,
+      view12ViewHeightAnchorConstraint,
+      view12ViewWidthAnchorConstraint,
+      localAsset12ViewLeadingAnchorConstraint,
+      localAsset12ViewTopAnchorConstraint,
+      localAsset12ViewBottomAnchorConstraint,
+      view13ViewHeightAnchorConstraint,
+      view13ViewWidthAnchorConstraint,
+      localAsset13ViewLeadingAnchorConstraint,
+      localAsset13ViewTopAnchorConstraint,
+      localAsset13ViewBottomAnchorConstraint,
+      view14ViewHeightAnchorConstraint,
+      view14ViewWidthAnchorConstraint,
+      localAsset14ViewLeadingAnchorConstraint,
+      localAsset14ViewTopAnchorConstraint,
+      localAsset14ViewCenterYAnchorConstraint,
+      localAsset14ViewBottomAnchorConstraint,
+      view15ViewHeightAnchorConstraint,
+      view15ViewWidthAnchorConstraint,
+      localAsset15ViewLeadingAnchorConstraint,
+      localAsset15ViewTopAnchorConstraint,
+      localAsset15ViewBottomAnchorConstraint,
+      view16ViewHeightAnchorConstraint,
+      view16ViewWidthAnchorConstraint,
+      localAsset16ViewLeadingAnchorConstraint,
+      localAsset16ViewTopAnchorConstraint,
+      localAsset16ViewBottomAnchorConstraint,
+      view17ViewHeightAnchorConstraint,
+      view17ViewWidthAnchorConstraint,
+      localAsset17ViewLeadingAnchorConstraint,
+      localAsset17ViewTopAnchorConstraint,
+      localAsset17ViewCenterYAnchorConstraint,
+      localAsset17ViewBottomAnchorConstraint,
+      view18ViewHeightAnchorConstraint,
+      view18ViewWidthAnchorConstraint,
+      localAsset18ViewLeadingAnchorConstraint,
+      localAsset18ViewTopAnchorConstraint,
+      localAsset18ViewBottomAnchorConstraint
+    ])
+  }
+
+  private func update() {}
+}

--- a/examples/generated/test/swift/images/LocalAsset.swift
+++ b/examples/generated/test/swift/images/LocalAsset.swift
@@ -35,13 +35,17 @@ public class LocalAsset: UIView {
     translatesAutoresizingMaskIntoConstraints = false
     imageView.translatesAutoresizingMaskIntoConstraints = false
 
+    let imageViewWidthAnchorParentConstraint = imageView.widthAnchor.constraint(lessThanOrEqualTo: widthAnchor)
     let imageViewTopAnchorConstraint = imageView.topAnchor.constraint(equalTo: topAnchor)
     let imageViewBottomAnchorConstraint = imageView.bottomAnchor.constraint(equalTo: bottomAnchor)
     let imageViewLeadingAnchorConstraint = imageView.leadingAnchor.constraint(equalTo: leadingAnchor)
     let imageViewHeightAnchorConstraint = imageView.heightAnchor.constraint(equalToConstant: 100)
     let imageViewWidthAnchorConstraint = imageView.widthAnchor.constraint(equalToConstant: 100)
 
+    imageViewWidthAnchorParentConstraint.priority = UILayoutPriority.defaultLow
+
     NSLayoutConstraint.activate([
+      imageViewWidthAnchorParentConstraint,
       imageViewTopAnchorConstraint,
       imageViewBottomAnchorConstraint,
       imageViewLeadingAnchorConstraint,

--- a/examples/generated/test/swift/images/LocalAsset.swift
+++ b/examples/generated/test/swift/images/LocalAsset.swift
@@ -27,6 +27,7 @@ public class LocalAsset: UIView {
   private func setUpViews() {
     addSubview(imageView)
 
+    backgroundColor = Colors.red400
     imageView.image = #imageLiteral(resourceName: "icon_128x128")
     imageView.backgroundColor = #colorLiteral(red: 0.847058823529, green: 0.847058823529, blue: 0.847058823529, alpha: 1)
   }

--- a/examples/generated/test/swift/layouts/MultipleFlexText.swift
+++ b/examples/generated/test/swift/layouts/MultipleFlexText.swift
@@ -1,0 +1,120 @@
+import UIKit
+import Foundation
+
+// MARK: - MultipleFlexText
+
+public class MultipleFlexText: UIView {
+
+  // MARK: Lifecycle
+
+  public init() {
+    super.init(frame: .zero)
+
+    setUpViews()
+    setUpConstraints()
+
+    update()
+  }
+
+  public required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: Private
+
+  private var view1View = UIView(frame: .zero)
+  private var view3View = UIView(frame: .zero)
+  private var textView = UILabel()
+  private var view2View = UIView(frame: .zero)
+  private var view4View = UIView(frame: .zero)
+  private var text1View = UILabel()
+
+  private var textViewTextStyle = TextStyles.body1
+  private var text1ViewTextStyle = TextStyles.body1
+
+  private func setUpViews() {
+    textView.numberOfLines = 0
+    text1View.numberOfLines = 0
+
+    addSubview(view1View)
+    addSubview(view2View)
+    view1View.addSubview(view3View)
+    view3View.addSubview(textView)
+    view2View.addSubview(view4View)
+    view4View.addSubview(text1View)
+
+    view1View.backgroundColor = Colors.red50
+    textView.attributedText = textViewTextStyle.apply(to: "Some long text (currently LS lays out incorrectly)")
+    view2View.backgroundColor = Colors.blue50
+    text1View.attributedText = text1ViewTextStyle.apply(to: "Short")
+  }
+
+  private func setUpConstraints() {
+    translatesAutoresizingMaskIntoConstraints = false
+    view1View.translatesAutoresizingMaskIntoConstraints = false
+    view2View.translatesAutoresizingMaskIntoConstraints = false
+    view3View.translatesAutoresizingMaskIntoConstraints = false
+    textView.translatesAutoresizingMaskIntoConstraints = false
+    view4View.translatesAutoresizingMaskIntoConstraints = false
+    text1View.translatesAutoresizingMaskIntoConstraints = false
+
+    let view1ViewView2ViewWidthAnchorSiblingConstraint = view1View
+      .widthAnchor
+      .constraint(equalTo: view2View.widthAnchor)
+    let view1ViewHeightAnchorParentConstraint = view1View.heightAnchor.constraint(lessThanOrEqualTo: heightAnchor)
+    let view2ViewHeightAnchorParentConstraint = view2View.heightAnchor.constraint(lessThanOrEqualTo: heightAnchor)
+    let view1ViewLeadingAnchorConstraint = view1View.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let view1ViewTopAnchorConstraint = view1View.topAnchor.constraint(equalTo: topAnchor)
+    let view2ViewTrailingAnchorConstraint = view2View.trailingAnchor.constraint(equalTo: trailingAnchor)
+    let view2ViewLeadingAnchorConstraint = view2View.leadingAnchor.constraint(equalTo: view1View.trailingAnchor)
+    let view2ViewTopAnchorConstraint = view2View.topAnchor.constraint(equalTo: topAnchor)
+    let view1ViewHeightAnchorConstraint = view1View.heightAnchor.constraint(equalToConstant: 100)
+    let view3ViewTopAnchorConstraint = view3View.topAnchor.constraint(equalTo: view1View.topAnchor)
+    let view3ViewBottomAnchorConstraint = view3View.bottomAnchor.constraint(equalTo: view1View.bottomAnchor)
+    let view3ViewLeadingAnchorConstraint = view3View.leadingAnchor.constraint(equalTo: view1View.leadingAnchor)
+    let view3ViewTrailingAnchorConstraint = view3View.trailingAnchor.constraint(equalTo: view1View.trailingAnchor)
+    let view2ViewHeightAnchorConstraint = view2View.heightAnchor.constraint(equalToConstant: 100)
+    let view4ViewTopAnchorConstraint = view4View.topAnchor.constraint(equalTo: view2View.topAnchor)
+    let view4ViewBottomAnchorConstraint = view4View.bottomAnchor.constraint(equalTo: view2View.bottomAnchor)
+    let view4ViewLeadingAnchorConstraint = view4View.leadingAnchor.constraint(equalTo: view2View.leadingAnchor)
+    let view4ViewTrailingAnchorConstraint = view4View.trailingAnchor.constraint(equalTo: view2View.trailingAnchor)
+    let textViewTopAnchorConstraint = textView.topAnchor.constraint(equalTo: view3View.topAnchor)
+    let textViewLeadingAnchorConstraint = textView.leadingAnchor.constraint(equalTo: view3View.leadingAnchor)
+    let textViewTrailingAnchorConstraint = textView.trailingAnchor.constraint(equalTo: view3View.trailingAnchor)
+    let text1ViewTopAnchorConstraint = text1View.topAnchor.constraint(equalTo: view4View.topAnchor)
+    let text1ViewLeadingAnchorConstraint = text1View.leadingAnchor.constraint(equalTo: view4View.leadingAnchor)
+    let text1ViewTrailingAnchorConstraint = text1View.trailingAnchor.constraint(equalTo: view4View.trailingAnchor)
+
+    view1ViewHeightAnchorParentConstraint.priority = UILayoutPriority.defaultLow
+    view2ViewHeightAnchorParentConstraint.priority = UILayoutPriority.defaultLow
+
+    NSLayoutConstraint.activate([
+      view1ViewView2ViewWidthAnchorSiblingConstraint,
+      view1ViewHeightAnchorParentConstraint,
+      view2ViewHeightAnchorParentConstraint,
+      view1ViewLeadingAnchorConstraint,
+      view1ViewTopAnchorConstraint,
+      view2ViewTrailingAnchorConstraint,
+      view2ViewLeadingAnchorConstraint,
+      view2ViewTopAnchorConstraint,
+      view1ViewHeightAnchorConstraint,
+      view3ViewTopAnchorConstraint,
+      view3ViewBottomAnchorConstraint,
+      view3ViewLeadingAnchorConstraint,
+      view3ViewTrailingAnchorConstraint,
+      view2ViewHeightAnchorConstraint,
+      view4ViewTopAnchorConstraint,
+      view4ViewBottomAnchorConstraint,
+      view4ViewLeadingAnchorConstraint,
+      view4ViewTrailingAnchorConstraint,
+      textViewTopAnchorConstraint,
+      textViewLeadingAnchorConstraint,
+      textViewTrailingAnchorConstraint,
+      text1ViewTopAnchorConstraint,
+      text1ViewLeadingAnchorConstraint,
+      text1ViewTrailingAnchorConstraint
+    ])
+  }
+
+  private func update() {}
+}

--- a/examples/test/components/NestedBottomLeftLayout.component
+++ b/examples/test/components/NestedBottomLeftLayout.component
@@ -37,7 +37,7 @@
         "id" : "View 1",
         "params" : {
           "alignItems" : "flex-end",
-          "backgroundColor" : "blue100",
+          "backgroundColor" : "red100",
           "flexDirection" : "row",
           "height" : 150,
           "justifyContent" : "flex-start",

--- a/examples/test/components/NestedBottomLeftLayout.component
+++ b/examples/test/components/NestedBottomLeftLayout.component
@@ -1,0 +1,55 @@
+{
+  "devices" : [
+    {
+      "height" : 100,
+      "heightMode" : "At Least",
+      "name" : "iPhone SE",
+      "width" : 320
+    }
+  ],
+  "examples" : [
+    {
+      "id" : "Default",
+      "name" : "Default",
+      "params" : {
+
+      }
+    }
+  ],
+  "logic" : [
+
+  ],
+  "params" : [
+
+  ],
+  "root" : {
+    "children" : [
+      {
+        "children" : [
+          {
+            "id" : "LocalAsset",
+            "params" : {
+
+            },
+            "type" : "LocalAsset"
+          }
+        ],
+        "id" : "View 1",
+        "params" : {
+          "alignItems" : "flex-end",
+          "backgroundColor" : "blue100",
+          "flexDirection" : "row",
+          "height" : 150,
+          "justifyContent" : "flex-start",
+          "width" : 150
+        },
+        "type" : "Lona:View"
+      }
+    ],
+    "id" : "View",
+    "params" : {
+      "alignSelf" : "stretch"
+    },
+    "type" : "Lona:View"
+  }
+}

--- a/examples/test/components/NestedComponent.component
+++ b/examples/test/components/NestedComponent.component
@@ -1,77 +1,27 @@
 {
-  "root" : {
-    "id" : "View",
-    "type" : "Lona:View",
-    "params" : {
-      "paddingTop" : 10,
-      "alignSelf" : "stretch",
-      "paddingBottom" : 10,
-      "paddingLeft" : 10,
-      "paddingRight" : 10
-    },
-    "children" : [
-      {
-        "id" : "Text",
-        "type" : "Lona:Text",
-        "params" : {
-          "text" : "Example nested component",
-          "font" : "subheading2",
-          "marginBottom" : 8
-        }
-      },
-      {
-        "id" : "FitContentParentSecondaryChildren",
-        "type" : "FitContentParentSecondaryChildren",
-        "params" : {
-
-        }
-      },
-      {
-        "id" : "Text 1",
-        "type" : "Lona:Text",
-        "params" : {
-          "text" : "Text below",
-          "marginTop" : 12
-        }
-      },
-      {
-        "id" : "LocalAsset",
-        "type" : "LocalAsset",
-        "params" : {
-
-        }
-      },
-      {
-        "id" : "Text 2",
-        "type" : "Lona:Text",
-        "params" : {
-          "text" : "Very bottom"
-        }
-      }
-    ]
-  },
   "devices" : [
     {
-      "name" : "iPhone SE",
       "height" : 100,
       "heightMode" : "At Least",
+      "name" : "iPhone SE",
       "width" : 320
     },
     {
-      "name" : "iPhone 7",
       "height" : 100,
       "heightMode" : "At Least",
+      "name" : "iPhone 7",
       "width" : 375
     },
     {
-      "name" : "iPhone 7+",
       "height" : 100,
       "heightMode" : "At Least",
+      "name" : "iPhone 7+",
       "width" : 414
     }
   ],
   "examples" : [
     {
+      "id" : "Default",
       "name" : "Default",
       "params" : {
 
@@ -83,5 +33,56 @@
   ],
   "params" : [
 
-  ]
+  ],
+  "root" : {
+    "children" : [
+      {
+        "id" : "Text",
+        "params" : {
+          "font" : "subheading2",
+          "marginBottom" : 8,
+          "text" : "Example nested component"
+        },
+        "type" : "Lona:Text"
+      },
+      {
+        "id" : "FitContentParentSecondaryChildren",
+        "params" : {
+
+        },
+        "type" : "FitContentParentSecondaryChildren"
+      },
+      {
+        "id" : "Text 1",
+        "params" : {
+          "marginTop" : 12,
+          "text" : "Text below"
+        },
+        "type" : "Lona:Text"
+      },
+      {
+        "id" : "LocalAsset",
+        "params" : {
+
+        },
+        "type" : "LocalAsset"
+      },
+      {
+        "id" : "Text 2",
+        "params" : {
+          "text" : "Very bottom"
+        },
+        "type" : "Lona:Text"
+      }
+    ],
+    "id" : "View",
+    "params" : {
+      "alignSelf" : "stretch",
+      "paddingBottom" : 10,
+      "paddingLeft" : 10,
+      "paddingRight" : 10,
+      "paddingTop" : 10
+    },
+    "type" : "Lona:View"
+  }
 }

--- a/examples/test/components/NestedLayout.component
+++ b/examples/test/components/NestedLayout.component
@@ -1,0 +1,459 @@
+{
+  "devices" : [
+    {
+      "height" : 900,
+      "heightMode" : "At Least",
+      "name" : "iPhone SE",
+      "width" : 450
+    }
+  ],
+  "examples" : [
+    {
+      "id" : "Default",
+      "name" : "Default",
+      "params" : {
+
+      }
+    }
+  ],
+  "logic" : [
+
+  ],
+  "params" : [
+
+  ],
+  "root" : {
+    "children" : [
+      {
+        "children" : [
+          {
+            "children" : [
+              {
+                "children" : [
+                  {
+                    "id" : "LocalAsset",
+                    "params" : {
+
+                    },
+                    "type" : "LocalAsset"
+                  }
+                ],
+                "id" : "View 1",
+                "params" : {
+                  "backgroundColor" : "grey50",
+                  "height" : 150,
+                  "width" : 150
+                },
+                "type" : "Lona:View"
+              },
+              {
+                "children" : [
+                  {
+                    "id" : "LocalAsset2",
+                    "params" : {
+
+                    },
+                    "type" : "LocalAsset"
+                  }
+                ],
+                "id" : "View 2",
+                "params" : {
+                  "backgroundColor" : "transparent",
+                  "height" : 150,
+                  "justifyContent" : "center",
+                  "width" : 150
+                },
+                "type" : "Lona:View"
+              },
+              {
+                "children" : [
+                  {
+                    "id" : "LocalAsset3",
+                    "params" : {
+
+                    },
+                    "type" : "LocalAsset"
+                  }
+                ],
+                "id" : "View 3",
+                "params" : {
+                  "backgroundColor" : "grey50",
+                  "height" : 150,
+                  "justifyContent" : "flex-end",
+                  "width" : 150
+                },
+                "type" : "Lona:View"
+              }
+            ],
+            "id" : "Column1",
+            "params" : {
+              "width" : 150
+            },
+            "type" : "Lona:View"
+          },
+          {
+            "children" : [
+              {
+                "children" : [
+                  {
+                    "id" : "LocalAsset4",
+                    "params" : {
+
+                    },
+                    "type" : "LocalAsset"
+                  }
+                ],
+                "id" : "View 4",
+                "params" : {
+                  "alignItems" : "center",
+                  "height" : 150,
+                  "width" : 150
+                },
+                "type" : "Lona:View"
+              },
+              {
+                "children" : [
+                  {
+                    "id" : "LocalAsset5",
+                    "params" : {
+
+                    },
+                    "type" : "LocalAsset"
+                  }
+                ],
+                "id" : "View 5",
+                "params" : {
+                  "alignItems" : "center",
+                  "backgroundColor" : "grey50",
+                  "height" : 150,
+                  "justifyContent" : "center",
+                  "width" : 150
+                },
+                "type" : "Lona:View"
+              },
+              {
+                "children" : [
+                  {
+                    "id" : "LocalAsset6",
+                    "params" : {
+
+                    },
+                    "type" : "LocalAsset"
+                  }
+                ],
+                "id" : "View 6",
+                "params" : {
+                  "alignItems" : "center",
+                  "height" : 150,
+                  "justifyContent" : "flex-end",
+                  "width" : 150
+                },
+                "type" : "Lona:View"
+              }
+            ],
+            "id" : "Column2",
+            "params" : {
+              "width" : 150
+            },
+            "type" : "Lona:View"
+          },
+          {
+            "children" : [
+              {
+                "children" : [
+                  {
+                    "id" : "LocalAsset7",
+                    "params" : {
+
+                    },
+                    "type" : "LocalAsset"
+                  }
+                ],
+                "id" : "View 7",
+                "params" : {
+                  "alignItems" : "flex-end",
+                  "backgroundColor" : "grey50",
+                  "height" : 150,
+                  "width" : 150
+                },
+                "type" : "Lona:View"
+              },
+              {
+                "children" : [
+                  {
+                    "id" : "LocalAsset8",
+                    "params" : {
+
+                    },
+                    "type" : "LocalAsset"
+                  }
+                ],
+                "id" : "View 8",
+                "params" : {
+                  "alignItems" : "flex-end",
+                  "height" : 150,
+                  "justifyContent" : "center",
+                  "width" : 150
+                },
+                "type" : "Lona:View"
+              },
+              {
+                "children" : [
+                  {
+                    "id" : "LocalAsset9",
+                    "params" : {
+
+                    },
+                    "type" : "LocalAsset"
+                  }
+                ],
+                "id" : "View 9",
+                "params" : {
+                  "alignItems" : "flex-end",
+                  "backgroundColor" : "grey50",
+                  "height" : 150,
+                  "justifyContent" : "flex-end",
+                  "width" : 150
+                },
+                "type" : "Lona:View"
+              }
+            ],
+            "id" : "Column3",
+            "params" : {
+              "width" : 150
+            },
+            "type" : "Lona:View"
+          }
+        ],
+        "id" : "TopRow",
+        "params" : {
+          "flexDirection" : "row"
+        },
+        "type" : "Lona:View"
+      },
+      {
+        "children" : [
+          {
+            "children" : [
+              {
+                "children" : [
+                  {
+                    "id" : "LocalAsset10",
+                    "params" : {
+
+                    },
+                    "type" : "LocalAsset"
+                  }
+                ],
+                "id" : "View 10",
+                "params" : {
+                  "backgroundColor" : "grey50",
+                  "flexDirection" : "row",
+                  "height" : 150,
+                  "width" : 150
+                },
+                "type" : "Lona:View"
+              },
+              {
+                "children" : [
+                  {
+                    "id" : "LocalAsset11",
+                    "params" : {
+
+                    },
+                    "type" : "LocalAsset"
+                  }
+                ],
+                "id" : "View 11",
+                "params" : {
+                  "alignItems" : "center",
+                  "backgroundColor" : "transparent",
+                  "flexDirection" : "row",
+                  "height" : 150,
+                  "justifyContent" : "flex-start",
+                  "width" : 150
+                },
+                "type" : "Lona:View"
+              },
+              {
+                "children" : [
+                  {
+                    "id" : "LocalAsset12",
+                    "params" : {
+
+                    },
+                    "type" : "LocalAsset"
+                  }
+                ],
+                "id" : "View 12",
+                "params" : {
+                  "alignItems" : "flex-end",
+                  "backgroundColor" : "grey50",
+                  "flexDirection" : "row",
+                  "height" : 150,
+                  "justifyContent" : "flex-start",
+                  "width" : 150
+                },
+                "type" : "Lona:View"
+              }
+            ],
+            "id" : "Column4",
+            "params" : {
+              "width" : 150
+            },
+            "type" : "Lona:View"
+          },
+          {
+            "children" : [
+              {
+                "children" : [
+                  {
+                    "id" : "LocalAsset13",
+                    "params" : {
+
+                    },
+                    "type" : "LocalAsset"
+                  }
+                ],
+                "id" : "View 13",
+                "params" : {
+                  "flexDirection" : "row",
+                  "height" : 150,
+                  "justifyContent" : "center",
+                  "width" : 150
+                },
+                "type" : "Lona:View"
+              },
+              {
+                "children" : [
+                  {
+                    "id" : "LocalAsset14",
+                    "params" : {
+
+                    },
+                    "type" : "LocalAsset"
+                  }
+                ],
+                "id" : "View 14",
+                "params" : {
+                  "alignItems" : "center",
+                  "backgroundColor" : "grey50",
+                  "flexDirection" : "row",
+                  "height" : 150,
+                  "justifyContent" : "center",
+                  "width" : 150
+                },
+                "type" : "Lona:View"
+              },
+              {
+                "children" : [
+                  {
+                    "id" : "LocalAsset15",
+                    "params" : {
+
+                    },
+                    "type" : "LocalAsset"
+                  }
+                ],
+                "id" : "View 15",
+                "params" : {
+                  "alignItems" : "flex-end",
+                  "flexDirection" : "row",
+                  "height" : 150,
+                  "justifyContent" : "center",
+                  "width" : 150
+                },
+                "type" : "Lona:View"
+              }
+            ],
+            "id" : "Column5",
+            "params" : {
+              "width" : 150
+            },
+            "type" : "Lona:View"
+          },
+          {
+            "children" : [
+              {
+                "children" : [
+                  {
+                    "id" : "LocalAsset16",
+                    "params" : {
+
+                    },
+                    "type" : "LocalAsset"
+                  }
+                ],
+                "id" : "View 16",
+                "params" : {
+                  "backgroundColor" : "grey50",
+                  "flexDirection" : "row",
+                  "height" : 150,
+                  "justifyContent" : "flex-end",
+                  "width" : 150
+                },
+                "type" : "Lona:View"
+              },
+              {
+                "children" : [
+                  {
+                    "id" : "LocalAsset17",
+                    "params" : {
+
+                    },
+                    "type" : "LocalAsset"
+                  }
+                ],
+                "id" : "View 17",
+                "params" : {
+                  "alignItems" : "center",
+                  "flexDirection" : "row",
+                  "height" : 150,
+                  "justifyContent" : "flex-end",
+                  "width" : 150
+                },
+                "type" : "Lona:View"
+              },
+              {
+                "children" : [
+                  {
+                    "id" : "LocalAsset18",
+                    "params" : {
+
+                    },
+                    "type" : "LocalAsset"
+                  }
+                ],
+                "id" : "View 18",
+                "params" : {
+                  "alignItems" : "flex-end",
+                  "backgroundColor" : "grey50",
+                  "flexDirection" : "row",
+                  "height" : 150,
+                  "justifyContent" : "flex-end",
+                  "width" : 150
+                },
+                "type" : "Lona:View"
+              }
+            ],
+            "id" : "Column6",
+            "params" : {
+              "width" : 150
+            },
+            "type" : "Lona:View"
+          }
+        ],
+        "id" : "BottomRow",
+        "params" : {
+          "flexDirection" : "row"
+        },
+        "type" : "Lona:View"
+      }
+    ],
+    "id" : "View",
+    "params" : {
+      "alignSelf" : "stretch"
+    },
+    "type" : "Lona:View"
+  }
+}

--- a/examples/test/images/LocalAsset.component
+++ b/examples/test/images/LocalAsset.component
@@ -49,7 +49,7 @@
     ],
     "id" : "View",
     "params" : {
-
+      "backgroundColor" : "red400"
     },
     "type" : "Lona:View"
   }

--- a/examples/test/images/LocalAsset.component
+++ b/examples/test/images/LocalAsset.component
@@ -21,6 +21,7 @@
   ],
   "examples" : [
     {
+      "id" : "Default",
       "name" : "Default",
       "params" : {
 
@@ -48,7 +49,7 @@
     ],
     "id" : "View",
     "params" : {
-      "alignSelf" : "stretch"
+
     },
     "type" : "Lona:View"
   }

--- a/examples/test/layouts/MultipleFlexText.component
+++ b/examples/test/layouts/MultipleFlexText.component
@@ -1,0 +1,105 @@
+{
+  "devices" : [
+    {
+      "height" : 100,
+      "heightMode" : "At Least",
+      "name" : "iPhone SE",
+      "width" : 320
+    },
+    {
+      "height" : 100,
+      "heightMode" : "At Least",
+      "name" : "iPhone 7",
+      "width" : 375
+    },
+    {
+      "height" : 100,
+      "heightMode" : "At Least",
+      "name" : "iPhone 7+",
+      "width" : 414
+    }
+  ],
+  "examples" : [
+    {
+      "id" : "Default",
+      "name" : "Default",
+      "params" : {
+
+      }
+    }
+  ],
+  "logic" : [
+
+  ],
+  "params" : [
+
+  ],
+  "root" : {
+    "children" : [
+      {
+        "children" : [
+          {
+            "children" : [
+              {
+                "id" : "Text",
+                "params" : {
+                  "alignSelf" : "stretch",
+                  "text" : "Some long text (currently LS lays out incorrectly)"
+                },
+                "type" : "Lona:Text"
+              }
+            ],
+            "id" : "View 3",
+            "params" : {
+              "alignSelf" : "stretch",
+              "flex" : 1
+            },
+            "type" : "Lona:View"
+          }
+        ],
+        "id" : "View 1",
+        "params" : {
+          "backgroundColor" : "red50",
+          "flex" : 1,
+          "height" : 100
+        },
+        "type" : "Lona:View"
+      },
+      {
+        "children" : [
+          {
+            "children" : [
+              {
+                "id" : "Text 1",
+                "params" : {
+                  "alignSelf" : "stretch",
+                  "text" : "Short"
+                },
+                "type" : "Lona:Text"
+              }
+            ],
+            "id" : "View 4",
+            "params" : {
+              "alignSelf" : "stretch",
+              "flex" : 1
+            },
+            "type" : "Lona:View"
+          }
+        ],
+        "id" : "View 2",
+        "params" : {
+          "backgroundColor" : "blue50",
+          "flex" : 1,
+          "height" : 100
+        },
+        "type" : "Lona:View"
+      }
+    ],
+    "id" : "View",
+    "params" : {
+      "alignSelf" : "stretch",
+      "flexDirection" : "row"
+    },
+    "type" : "Lona:View"
+  }
+}

--- a/studio/LonaStudio/Models/CSLayer.swift
+++ b/studio/LonaStudio/Models/CSLayer.swift
@@ -515,6 +515,7 @@ class CSLayer: CSDataDeserializable, CSDataSerializable, DataNode, NSCopying {
     }
 
     static let defaultParameterValue: [String: CSData] = [
+        "alignItems": CSData.String("flex-start"),
         "borderRadius": CSData.Number(0),
         "flex": CSData.Number(0),
         "flexDirection": CSData.String("column"),


### PR DESCRIPTION
## What

Components now expect their parent to use the platform default layout.

DOM:
```
display: flex
flex-direction: row
alignItems: flex-start
```

RN:
```
flex-direction: column
alignItems: stretch
```

This also fixes nested component layouts for React DOM.

## Why

Easier for consumers to use Lona components.

## Testing Plan

- [X] Tested this change locally
- [X] Checked that existing features work

@outdooricon 