### PR TITLE
Add shadows for reactDom

### DIFF
--- a/compiler/core/package.json
+++ b/compiler/core/package.json
@@ -4,7 +4,11 @@
   "description": "Lona cross-platform code compiler",
   "main": "build/index.js",
   "bin": "./build/index.js",
-  "files": ["build/index.js", "static", "README.md"],
+  "files": [
+    "build/index.js",
+    "static",
+    "README.md"
+  ],
   "scripts": {
     "build": "bsb -make-world",
     "start": "bsb -make-world -w",
@@ -12,20 +16,24 @@
     "bundle": "npm run clean && npm run build && webpack",
     "format": "bsrefmt --parse=re --print=re --in-place src/**/*.re",
     "prepublishOnly": "yarn clean && yarn build && yarn bundle",
-    "snapshotJsDom":
-      "node src/main.bs.js workspace js ../../examples/test ../../examples/generated/test/react-dom --framework=reactdom",
-    "snapshotJsNative":
-      "node src/main.bs.js workspace js ../../examples/test ../../examples/generated/test/react-native --framework=reactnative",
-    "snapshotSketch":
-      "node src/main.bs.js workspace js ../../examples/test ../../examples/generated/test/sketchJs --framework=reactsketchapp",
-    "snapshotSwift":
-      "node src/main.bs.js workspace swift ../../examples/test ../../examples/generated/test/swift",
-    "snapshotAppkit":
-      "node src/main.bs.js workspace swift ../../examples/test ../../examples/generated/test/appkit --framework=appkit",
-    "snapshot":
-      "yarn snapshotSwift && yarn snapshotAppkit && yarn snapshotJsDom && yarn snapshotJsNative && yarn snapshotSketch"
+    "snapshotJsDom": "node src/main.bs.js workspace js ../../examples/test ../../examples/generated/test/react-dom --framework=reactdom",
+    "snapshotJsDom:watch": "nodemon --exec \"yarn snapshotJsDom\"",
+    "snapshotJsNative": "node src/main.bs.js workspace js ../../examples/test ../../examples/generated/test/react-native --framework=reactnative",
+    "snapshotJsNative:watch": "nodemon --exec \"yarn snapshotJsNative\"",
+    "snapshotSketch": "node src/main.bs.js workspace js ../../examples/test ../../examples/generated/test/sketchJs --framework=reactsketchapp",
+    "snapshotSketch:watch": "nodemon --exec \"yarn snapshotSketch\"",
+    "snapshotSwift": "node src/main.bs.js workspace swift ../../examples/test ../../examples/generated/test/swift",
+    "snapshotSwift:watch": "nodemon --exec \"yarn snapshotSwift\"",
+    "snapshotAppkit": "node src/main.bs.js workspace swift ../../examples/test ../../examples/generated/test/appkit --framework=appkit",
+    "snapshotAppkit:watch": "nodemon --exec \"yarn snapshotAppkit\"",
+    "snapshot": "yarn snapshotSwift && yarn snapshotAppkit && yarn snapshotJsDom && yarn snapshotJsNative && yarn snapshotSketch",
+    "snapshot:watch": "nodemon --exec \"yarn snapshot\""
   },
-  "keywords": ["lona", "compiler", "react"],
+  "keywords": [
+    "lona",
+    "compiler",
+    "react"
+  ],
   "author": "Devin Abbott <devinabbott@gmail.com>",
   "license": "MIT",
   "repository": {
@@ -37,8 +45,8 @@
   },
   "homepage": "https://github.com/airbnb/Lona",
   "devDependencies": {
-    "bs-glob": "reasonml-community/bs-glob",
     "@glennsl/bs-json": "*",
+    "bs-glob": "reasonml-community/bs-glob",
     "bs-node": "github:buckletypes/bs-node",
     "bs-platform": "^4.0.5",
     "copy-webpack-plugin": "^4.5.1",
@@ -47,6 +55,7 @@
     "get-stdin": "^5.0.1",
     "lodash.camelcase": "^4.3.0",
     "lodash.upperfirst": "^4.3.1",
+    "nodemon": "^1.18.4",
     "prettier": "dabbott/prettier#28eebd6d150746b91f581e18bef8352e2bae5623",
     "webpack": "^3.10.0"
   },

--- a/compiler/core/src/core/layer.re
+++ b/compiler/core/src/core/layer.re
@@ -57,7 +57,7 @@ let getParameterCategory = (x: ParameterKey.t) =>
   | BorderRadius => Style
   | BorderWidth => Style
   | TextAlign => Style
-  /* | Shadow => Style */
+  | Shadow => Style
   /* Props */
   | NumberOfLines => Prop
   | Text => Prop

--- a/compiler/core/src/javaScript/javaScriptComponent.re
+++ b/compiler/core/src/javaScript/javaScriptComponent.re
@@ -81,6 +81,10 @@ let createStyleAttributePropertyAST =
     JavaScriptAst.SpreadElement(
       JavaScriptLogic.logicValueToJavaScriptAST(config, value),
     )
+  | ParameterKey.Shadow =>
+    JavaScriptAst.SpreadElement(
+      JavaScriptLogic.logicValueToJavaScriptAST(config, value),
+    )
   | _ =>
     JavaScriptAst.Property({
       key: Identifier([key |> styleNameKey]),
@@ -462,6 +466,7 @@ let generate =
       options: JavaScriptOptions.options,
       componentName,
       colorsFilePath,
+      shadowsFilePath,
       textStylesFilePath,
       config: Config.t,
       getComponent,
@@ -522,6 +527,10 @@ let generate =
             ImportDeclaration({
               source: colorsFilePath |> Js.String.replace(".json", ""),
               specifiers: [ImportDefaultSpecifier("colors")],
+            }),
+            ImportDeclaration({
+              source: shadowsFilePath |> Js.String.replace(".json", ""),
+              specifiers: [ImportDefaultSpecifier("shadows")],
             }),
             ImportDeclaration({
               source: textStylesFilePath |> Js.String.replace(".json", ""),

--- a/compiler/core/src/javaScript/javaScriptLogic.re
+++ b/compiler/core/src/javaScript/javaScriptLogic.re
@@ -13,6 +13,14 @@ let logicValueToJavaScriptAST = (config: Config.t, x: Logic.logicValue) =>
       | Some(color) => Ast.Identifier(["colors", color.id])
       | None => Literal(lonaValue)
       };
+    | Reference("Shadow")
+    | Named("Shadow", _) =>
+      let shadowStyles = config.shadowsFile.contents;
+      let data = Json.Decode.string(lonaValue.data);
+      switch (Shadow.find(shadowStyles.styles, data)) {
+      | Some(shadowStyle) => Ast.Identifier(["shadows", shadowStyle.id])
+      | None => Literal(lonaValue)
+      };
     | Reference("TextStyle")
     | Named("TextStyle", _) =>
       let textStyles = config.textStylesFile.contents;

--- a/compiler/core/src/javaScript/javaScriptShadow.re
+++ b/compiler/core/src/javaScript/javaScriptShadow.re
@@ -1,0 +1,67 @@
+open JavaScriptAst;
+
+let renderReactDom = (colors: list(Color.t), shadowsFile: Shadow.file) => {
+  let shadowObject = (shadow: Shadow.t) => {
+    let dropShadowString =
+      "drop-shadow("
+      ++ string_of_int(int_of_float(shadow.x))
+      ++ "px "
+      ++ string_of_int(int_of_float(shadow.y))
+      ++ "px "
+      ++ string_of_int(int_of_float(shadow.blur))
+      ++ "px ";
+
+    let filterValue =
+      switch (Color.find(colors, shadow.color)) {
+      | Some(color) =>
+        BinaryExpression({
+          left:
+            BinaryExpression({
+              left: Literal(LonaValue.string(dropShadowString)),
+              operator: Plus,
+              right: Identifier(["colors", color.id]),
+            }),
+          operator: Plus,
+          right: Literal(LonaValue.string(");")),
+        })
+      | None =>
+        Literal(LonaValue.string(dropShadowString ++ shadow.color ++ ");"))
+      };
+
+    Property({
+      key: Identifier([shadow.id |> JavaScriptFormat.styleVariableName]),
+      value:
+        ObjectLiteral([
+          JavaScriptAst.Property({
+            key: Identifier(["filter"]),
+            value: filterValue,
+          }),
+        ]),
+    });
+  };
+
+  JavaScriptRender.toString(
+    Program([
+      ImportDeclaration({
+        source: "./colors",
+        specifiers: [ImportDefaultSpecifier("colors")],
+      }),
+      Empty,
+      ExportDefaultDeclaration(
+        ObjectLiteral(shadowsFile.styles |> List.map(shadowObject)),
+      ),
+      Empty,
+    ]),
+  );
+};
+
+let render =
+    (
+      javascriptOptions: JavaScriptOptions.options,
+      colors: list(Color.t),
+      shadowsFile: Shadow.file,
+    ) =>
+  switch (javascriptOptions.framework) {
+  | JavaScriptOptions.ReactDOM => renderReactDom(colors, shadowsFile)
+  | _ => ""
+  };

--- a/compiler/core/src/javaScript/javaScriptStyles.re
+++ b/compiler/core/src/javaScript/javaScriptStyles.re
@@ -19,6 +19,26 @@ let getTextStyleProperty =
     )
   );
 
+let getShadowProperty = (framework: JavaScriptOptions.framework, shadowId) =>
+  JavaScriptAst.(
+    SpreadElement(
+      switch (framework) {
+      | JavaScriptOptions.ReactSketchapp =>
+        CallExpression({
+          callee: Identifier(["Shadows", "get"]),
+          arguments: [
+            StringLiteral(shadowId |> JavaScriptFormat.styleVariableName),
+          ],
+        })
+      | _ =>
+        Identifier([
+          "shadows",
+          shadowId |> JavaScriptFormat.styleVariableName,
+        ])
+      },
+    )
+  );
+
 let getStyleProperty =
     (
       framework: JavaScriptOptions.framework,
@@ -36,6 +56,15 @@ let getStyleProperty =
     | Some(textStyleId) => getTextStyleProperty(framework, textStyleId)
     | None =>
       Js.log("TextStyle id must be a string");
+      raise(Not_found);
+    };
+  | Named("Shadow", _)
+  | Reference("Shadow") =>
+    let data = value.data |> Js.Json.decodeString;
+    switch (data) {
+    | Some(shadowId) => getShadowProperty(framework, shadowId)
+    | None =>
+      Js.log("Shadow id must be a string");
       raise(Not_found);
     };
   | Named("Color", _)

--- a/compiler/core/src/main.re
+++ b/compiler/core/src/main.re
@@ -116,6 +116,7 @@ let renderTextStyles = (target, colors, textStyles) =>
 let renderShadows = (target, colors, shadows) =>
   switch (target) {
   | Types.Swift => SwiftShadow.render(swiftOptions, colors, shadows)
+  | JavaScript => JavaScriptShadow.render(javaScriptOptions, colors, shadows)
   | _ => ""
   };
 
@@ -198,6 +199,11 @@ let convertComponent = (config: Config.t, filename: string) => {
       Node.Path.relative(
         ~from=Node.Path.dirname(filename),
         ~to_=config.colorsFile.path,
+        (),
+      ),
+      Node.Path.relative(
+        ~from=Node.Path.dirname(filename),
+        ~to_=config.shadowsFile.path,
         (),
       ),
       Node.Path.relative(
@@ -316,7 +322,7 @@ let convertWorkspace = (workspace, output) => {
     `utf8,
   );
 
-  if (target == Types.Swift) {
+  if (target == Types.Swift || target == Types.JavaScript) {
     let shadowsOutputPath =
       concat(
         toDirectory,

--- a/compiler/core/yarn.lock
+++ b/compiler/core/yarn.lock
@@ -82,6 +82,12 @@ align-text@^0.1.1, align-text@^0.1.3:
     longest "^1.0.1"
     repeat-string "^1.5.2"
 
+ansi-align@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-2.0.0.tgz#c36aeccba563b89ceb556f3690f0b1d9e3547f7f"
+  dependencies:
+    string-width "^2.0.0"
+
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
@@ -229,6 +235,18 @@ bluebird@^3.0.5, bluebird@^3.5.1:
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
+
+boxen@^1.2.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/boxen/-/boxen-1.3.0.tgz#55c6c39a8ba58d9c61ad22cd877532deb665a20b"
+  dependencies:
+    ansi-align "^2.0.0"
+    camelcase "^4.0.0"
+    chalk "^2.0.1"
+    cli-boxes "^1.0.0"
+    string-width "^2.0.0"
+    term-size "^1.2.0"
+    widest-line "^2.0.0"
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -379,13 +397,17 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
-camelcase@4.1.0, camelcase@^4.1.0:
+camelcase@4.1.0, camelcase@^4.0.0, camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
 camelcase@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
+
+capture-stack-trace@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz#a6c0bbe1f38f3aa0b92238ecb6ff42c344d4135d"
 
 center-align@^0.1.1:
   version "0.1.3"
@@ -412,7 +434,7 @@ chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.4.1:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   dependencies:
@@ -455,6 +477,10 @@ chownr@^1.0.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.1.tgz#54726b8b8fff4df053c42187e801fb4412df1494"
 
+ci-info@^1.5.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.6.0.tgz#2ca20dbb9ceb32d4524a683303313f0304b1e497"
+
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
@@ -474,6 +500,10 @@ class-utils@^0.3.5:
     define-property "^0.2.5"
     isobject "^3.0.0"
     static-extend "^0.1.1"
+
+cli-boxes@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-1.0.0.tgz#4fa917c3e59c94a004cd61f8ee509da651687143"
 
 cliui@^2.1.0:
   version "2.1.0"
@@ -545,6 +575,17 @@ concat-stream@^1.5.0:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
+configstore@^3.0.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/configstore/-/configstore-3.1.2.tgz#c6f25defaeef26df12dd33414b001fe81a543f8f"
+  dependencies:
+    dot-prop "^4.1.0"
+    graceful-fs "^4.1.2"
+    make-dir "^1.0.0"
+    unique-string "^1.0.0"
+    write-file-atomic "^2.0.0"
+    xdg-basedir "^3.0.0"
+
 console-browserify@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.1.0.tgz#f0241c45730a9fc6323b206dbf38edc741d0bb10"
@@ -607,6 +648,12 @@ create-ecdh@^4.0.0:
     bn.js "^4.1.0"
     elliptic "^6.0.0"
 
+create-error-class@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/create-error-class/-/create-error-class-3.0.2.tgz#06be7abef947a3f14a30fd610671d401bca8b7b6"
+  dependencies:
+    capture-stack-trace "^1.0.0"
+
 create-hash@^1.1.0, create-hash@^1.1.2:
   version "1.2.0"
   resolved "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
@@ -652,6 +699,10 @@ crypto-browserify@^3.11.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
+crypto-random-string@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
+
 csscolorparser@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/csscolorparser/-/csscolorparser-1.0.3.tgz#b34f391eea4da8f3e98231e2ccd8df9c041f171b"
@@ -679,6 +730,12 @@ debug@^2.1.2, debug@^2.2.0, debug@^2.3.3:
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
     ms "2.0.0"
+
+debug@^3.1.0:
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
+  dependencies:
+    ms "^2.1.1"
 
 decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
@@ -756,6 +813,20 @@ dir-glob@^2.0.0:
 domain-browser@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
+
+dot-prop@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.0.tgz#1f19e0c2e1aa0e32797c49799f2837ac6af69c57"
+  dependencies:
+    is-obj "^1.0.0"
+
+duplexer3@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
+
+duplexer@^0.1.1, duplexer@~0.1.1:
+  version "0.1.1"
+  resolved "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
 
 duplexify@^3.4.2, duplexify@^3.6.0:
   version "3.6.0"
@@ -918,6 +989,19 @@ event-emitter@~0.3.5:
     d "1"
     es5-ext "~0.10.14"
 
+event-stream@~3.3.0:
+  version "3.3.6"
+  resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.6.tgz#cac1230890e07e73ec9cacd038f60a5b66173eef"
+  dependencies:
+    duplexer "^0.1.1"
+    flatmap-stream "^0.1.0"
+    from "^0.1.7"
+    map-stream "0.0.7"
+    pause-stream "^0.0.11"
+    split "^1.0.1"
+    stream-combiner "^0.2.2"
+    through "^2.3.8"
+
 events@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
@@ -1028,6 +1112,10 @@ find-up@^2.0.0, find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
+flatmap-stream@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/flatmap-stream/-/flatmap-stream-0.1.1.tgz#d34f39ef3b9aa5a2fc225016bd3adf28ac5ae6ea"
+
 flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
@@ -1063,6 +1151,10 @@ from2@^2.1.0:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
+
+from@^0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"
 
 fs-extra@^5.0.0:
   version "5.0.0"
@@ -1149,6 +1241,12 @@ glob@^7.0.3, glob@^7.0.5, glob@^7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+global-dirs@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-0.1.1.tgz#b319c0dd4607f353f3be9cca4c72fc148c49f445"
+  dependencies:
+    ini "^1.3.4"
+
 globby@6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-6.1.0.tgz#f5a6d70e8395e21c858fb0489d64df02424d506c"
@@ -1169,6 +1267,22 @@ globby@^7.1.1:
     ignore "^3.3.5"
     pify "^3.0.0"
     slash "^1.0.0"
+
+got@^6.7.1:
+  version "6.7.1"
+  resolved "http://registry.npmjs.org/got/-/got-6.7.1.tgz#240cd05785a9a18e561dc1b44b41c763ef1e8db0"
+  dependencies:
+    create-error-class "^3.0.0"
+    duplexer3 "^0.1.4"
+    get-stream "^3.0.0"
+    is-redirect "^1.0.0"
+    is-retry-allowed "^1.0.0"
+    is-stream "^1.0.0"
+    lowercase-keys "^1.0.0"
+    safe-buffer "^5.0.1"
+    timed-out "^4.0.0"
+    unzip-response "^2.0.1"
+    url-parse-lax "^1.0.0"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.11"
@@ -1292,6 +1406,10 @@ iferr@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
 
+ignore-by-default@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/ignore-by-default/-/ignore-by-default-1.0.1.tgz#48ca6d72f6c6a3af00a9ad4ae6876be3889e2b09"
+
 ignore-walk@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.1.tgz#a83e62e7d272ac0e3b551aaa82831a19b69f82f8"
@@ -1305,6 +1423,10 @@ ignore@3.3.7:
 ignore@^3.3.5:
   version "3.3.10"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
+
+import-lazy@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -1333,7 +1455,7 @@ inherits@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
 
-ini@~1.3.0:
+ini@^1.3.4, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
 
@@ -1387,6 +1509,12 @@ is-builtin-module@^1.0.0:
   resolved "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz#540572d34f7ac3119f8f76c30cbc1b1e037affbe"
   dependencies:
     builtin-modules "^1.0.0"
+
+is-ci@^1.0.10:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.2.1.tgz#e3779c8ee17fccf428488f6e281187f2e632841c"
+  dependencies:
+    ci-info "^1.5.0"
 
 is-data-descriptor@^0.1.4:
   version "0.1.4"
@@ -1464,11 +1592,32 @@ is-hexadecimal@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.2.tgz#b6e710d7d07bb66b98cb8cece5c9b4921deeb835"
 
+is-installed-globally@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.1.0.tgz#0dfd98f5a9111716dd535dda6492f67bf3d25a80"
+  dependencies:
+    global-dirs "^0.1.0"
+    is-path-inside "^1.0.0"
+
+is-npm@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-1.0.0.tgz#f2fb63a65e4905b406c86072765a1a4dc793b9f4"
+
 is-number@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
   dependencies:
     kind-of "^3.0.2"
+
+is-obj@^1.0.0:
+  version "1.0.1"
+  resolved "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
+
+is-path-inside@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.1.tgz#8ef5b7de50437a3fdca6b4e865ef7aa55cb48036"
+  dependencies:
+    path-is-inside "^1.0.1"
 
 is-plain-obj@^1.1.0:
   version "1.1.0"
@@ -1480,7 +1629,15 @@ is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
-is-stream@^1.1.0:
+is-redirect@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24"
+
+is-retry-allowed@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
+
+is-stream@^1.0.0, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
@@ -1591,6 +1748,12 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
 
+latest-version@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-3.1.0.tgz#a205383fea322b33b5ae3b18abee0dc2f356ee15"
+  dependencies:
+    package-json "^4.0.0"
+
 lazy-cache@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
@@ -1666,6 +1829,10 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
+lowercase-keys@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
+
 lru-cache@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-3.2.0.tgz#71789b3b7f5399bec8565dda38aa30d2a097efee"
@@ -1688,6 +1855,10 @@ make-dir@^1.0.0:
 map-cache@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
+
+map-stream@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.0.7.tgz#8a1f07896d82b10926bd3744a2420009f88974a8"
 
 map-visit@^1.0.0:
   version "1.0.0"
@@ -1837,6 +2008,10 @@ ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
+ms@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
+
 nan@^2.9.2:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.11.0.tgz#574e360e4d954ab16966ec102c0c049fd961a099"
@@ -1916,12 +2091,33 @@ node-pre-gyp@^0.10.0:
     semver "^5.3.0"
     tar "^4"
 
+nodemon@^1.18.4:
+  version "1.18.4"
+  resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-1.18.4.tgz#873f65fdb53220eb166180cf106b1354ac5d714d"
+  dependencies:
+    chokidar "^2.0.2"
+    debug "^3.1.0"
+    ignore-by-default "^1.0.1"
+    minimatch "^3.0.4"
+    pstree.remy "^1.1.0"
+    semver "^5.5.0"
+    supports-color "^5.2.0"
+    touch "^3.1.0"
+    undefsafe "^2.0.2"
+    update-notifier "^2.3.0"
+
 nopt@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"
   dependencies:
     abbrev "1"
     osenv "^0.1.4"
+
+nopt@~1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-1.0.10.tgz#6ddd21bd2a31417b92727dd585f8a6f37608ebee"
+  dependencies:
+    abbrev "1"
 
 normalize-package-data@^2.3.2:
   version "2.4.0"
@@ -2052,6 +2248,15 @@ p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
 
+package-json@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/package-json/-/package-json-4.0.1.tgz#8869a0401253661c4c4ca3da6c2121ed555f5eed"
+  dependencies:
+    got "^6.7.1"
+    registry-auth-token "^3.0.1"
+    registry-url "^3.0.3"
+    semver "^5.1.0"
+
 pako@~1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.6.tgz#0101211baa70c4bca4a0f63f2206e97b7dfaf258"
@@ -2130,6 +2335,10 @@ path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
+path-is-inside@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
+
 path-key@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
@@ -2149,6 +2358,12 @@ path-type@^3.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
   dependencies:
     pify "^3.0.0"
+
+pause-stream@^0.0.11:
+  version "0.0.11"
+  resolved "http://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz#fe5a34b0cbce12b5aa6a2b403ee2e73b602f1445"
+  dependencies:
+    through "~2.3"
 
 pbkdf2@^3.0.3:
   version "3.0.16"
@@ -2237,6 +2452,10 @@ postcss@^6.0.3:
     source-map "^0.6.1"
     supports-color "^5.4.0"
 
+prepend-http@^1.0.1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
+
 prettier@dabbott/prettier#28eebd6d150746b91f581e18bef8352e2bae5623:
   version "1.10.2"
   resolved "https://codeload.github.com/dabbott/prettier/tar.gz/28eebd6d150746b91f581e18bef8352e2bae5623"
@@ -2302,9 +2521,21 @@ prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
 
+ps-tree@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/ps-tree/-/ps-tree-1.1.0.tgz#b421b24140d6203f1ed3c76996b4427b08e8c014"
+  dependencies:
+    event-stream "~3.3.0"
+
 pseudomap@^1.0.1, pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+
+pstree.remy@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pstree.remy/-/pstree.remy-1.1.0.tgz#f2af27265bd3e5b32bbfcc10e80bac55ba78688b"
+  dependencies:
+    ps-tree "^1.1.0"
 
 public-encrypt@^4.0.0:
   version "4.0.2"
@@ -2364,7 +2595,7 @@ randomfill@^1.0.3:
     randombytes "^2.0.5"
     safe-buffer "^5.1.0"
 
-rc@^1.2.7:
+rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   dependencies:
@@ -2429,6 +2660,19 @@ regex-not@^1.0.0, regex-not@^1.0.2:
   dependencies:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
+
+registry-auth-token@^3.0.1:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-3.3.2.tgz#851fd49038eecb586911115af845260eec983f20"
+  dependencies:
+    rc "^1.1.6"
+    safe-buffer "^5.0.1"
+
+registry-url@^3.0.3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/registry-url/-/registry-url-3.1.0.tgz#3d4ef870f73dde1d77f0cf9a381432444e174942"
+  dependencies:
+    rc "^1.0.1"
 
 remark-frontmatter@1.1.0:
   version "1.1.0"
@@ -2542,7 +2786,13 @@ sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
-"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0:
+semver-diff@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/semver-diff/-/semver-diff-2.1.0.tgz#4bbb8437c8d37e4b0cf1a68fd726ec6d645d6d36"
+  dependencies:
+    semver "^5.0.3"
+
+"semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.5.0:
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"
 
@@ -2601,7 +2851,7 @@ sigmund@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
 
-signal-exit@^3.0.0:
+signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
@@ -2694,6 +2944,12 @@ split-string@^3.0.1, split-string@^3.0.2:
   dependencies:
     extend-shallow "^3.0.0"
 
+split@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/split/-/split-1.0.1.tgz#605bd9be303aa59fb35f9229fbea0ddec9ea07d9"
+  dependencies:
+    through "2"
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
@@ -2722,6 +2978,13 @@ stream-browserify@^2.0.1:
     inherits "~2.0.1"
     readable-stream "^2.0.2"
 
+stream-combiner@^0.2.2:
+  version "0.2.2"
+  resolved "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz#aec8cbac177b56b6f4fa479ced8c1912cee52858"
+  dependencies:
+    duplexer "~0.1.1"
+    through "~2.3.4"
+
 stream-each@^1.1.0:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/stream-each/-/stream-each-1.2.3.tgz#ebe27a0c389b04fbcc233642952e10731afa9bae"
@@ -2743,7 +3006,7 @@ stream-shift@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
 
-string-width@2.1.1, "string-width@^1.0.2 || 2", string-width@^2.0.0:
+string-width@2.1.1, "string-width@^1.0.2 || 2", string-width@^2.0.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   dependencies:
@@ -2808,7 +3071,7 @@ supports-color@^4.0.0, supports-color@^4.2.1:
   dependencies:
     has-flag "^2.0.0"
 
-supports-color@^5.3.0, supports-color@^5.4.0:
+supports-color@^5.2.0, supports-color@^5.3.0, supports-color@^5.4.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   dependencies:
@@ -2830,12 +3093,26 @@ tar@^4:
     safe-buffer "^5.1.2"
     yallist "^3.0.2"
 
+term-size@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/term-size/-/term-size-1.2.0.tgz#458b83887f288fc56d6fffbfad262e26638efa69"
+  dependencies:
+    execa "^0.7.0"
+
 through2@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"
   dependencies:
     readable-stream "^2.1.5"
     xtend "~4.0.1"
+
+through@2, through@^2.3.8, through@~2.3, through@~2.3.4:
+  version "2.3.8"
+  resolved "http://registry.npmjs.org/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+
+timed-out@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
 
 timers-browserify@^2.0.4:
   version "2.0.10"
@@ -2868,6 +3145,12 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
+
+touch@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/touch/-/touch-3.1.0.tgz#fe365f5f75ec9ed4e56825e0bb76d24ab74af83b"
+  dependencies:
+    nopt "~1.0.10"
 
 trim-trailing-lines@^1.0.0:
   version "1.1.1"
@@ -2928,6 +3211,12 @@ uglifyjs-webpack-plugin@^0.4.6:
     uglify-js "^2.8.29"
     webpack-sources "^1.0.1"
 
+undefsafe@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/undefsafe/-/undefsafe-2.0.2.tgz#225f6b9e0337663e0d8e7cfd686fc2836ccace76"
+  dependencies:
+    debug "^2.2.0"
+
 unherit@^1.0.4:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/unherit/-/unherit-1.1.1.tgz#132748da3e88eab767e08fabfbb89c5e9d28628c"
@@ -2976,6 +3265,12 @@ unique-slug@^2.0.0:
   dependencies:
     imurmurhash "^0.1.4"
 
+unique-string@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-1.0.0.tgz#9e1057cca851abb93398f8b33ae187b99caec11a"
+  dependencies:
+    crypto-random-string "^1.0.0"
+
 unist-util-is@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-2.1.2.tgz#1193fa8f2bfbbb82150633f3a8d2eb9a1c1d55db"
@@ -3013,9 +3308,28 @@ unset-value@^1.0.0:
     has-value "^0.3.1"
     isobject "^3.0.0"
 
+unzip-response@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
+
 upath@^1.0.5:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.0.tgz#35256597e46a581db4793d0ce47fa9aebfc9fabd"
+
+update-notifier@^2.3.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-2.5.0.tgz#d0744593e13f161e406acb1d9408b72cad08aff6"
+  dependencies:
+    boxen "^1.2.1"
+    chalk "^2.0.1"
+    configstore "^3.0.0"
+    import-lazy "^2.1.0"
+    is-ci "^1.0.10"
+    is-installed-globally "^0.1.0"
+    is-npm "^1.0.0"
+    latest-version "^3.0.0"
+    semver-diff "^2.0.0"
+    xdg-basedir "^3.0.0"
 
 uri-js@^4.2.2:
   version "4.2.2"
@@ -3026,6 +3340,12 @@ uri-js@^4.2.2:
 urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
+
+url-parse-lax@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-1.0.0.tgz#7af8f303645e9bd79a272e7a14ac68bc0609da73"
+  dependencies:
+    prepend-http "^1.0.1"
 
 url@^0.11.0:
   version "0.11.0"
@@ -3144,6 +3464,12 @@ wide-align@^1.1.0:
   dependencies:
     string-width "^1.0.2 || 2"
 
+widest-line@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/widest-line/-/widest-line-2.0.0.tgz#0142a4e8a243f8882c0233aa0e0281aa76152273"
+  dependencies:
+    string-width "^2.1.1"
+
 window-size@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
@@ -3167,6 +3493,14 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
 
+write-file-atomic@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.3.0.tgz#1ff61575c2e2a4e8e510d6fa4e243cce183999ab"
+  dependencies:
+    graceful-fs "^4.1.11"
+    imurmurhash "^0.1.4"
+    signal-exit "^3.0.2"
+
 x-is-function@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/x-is-function/-/x-is-function-1.0.4.tgz#5d294dc3d268cbdd062580e0c5df77a391d1fa1e"
@@ -3174,6 +3508,10 @@ x-is-function@^1.0.4:
 x-is-string@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/x-is-string/-/x-is-string-0.1.0.tgz#474b50865af3a49a9c4657f05acd145458f77d82"
+
+xdg-basedir@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
 
 xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.1"

--- a/examples/generated/test/appkit/Shadows.swift
+++ b/examples/generated/test/appkit/Shadows.swift
@@ -3,7 +3,7 @@ import AppKit
 public enum Shadows {
   public static let elevation1 = NSShadow(color: #colorLiteral(red: 0, green: 0, blue: 0, alpha: 0.5), offset: NSSize(width: 0, height: -1), blur: 2)
   public static let elevation2 = NSShadow(color: #colorLiteral(red: 0, green: 0, blue: 0, alpha: 0.5), offset: NSSize(width: 0, height: -2), blur: 4)
-  public static let elevation3 = NSShadow(color: #colorLiteral(red: 0, green: 0, blue: 0, alpha: 0.5), offset: NSSize(width: 0, height: -3), blur: 9)
+  public static let elevation3 = NSShadow(color: Colors.grey900, offset: NSSize(width: 0, height: -3), blur: 9)
 }
 
 private extension NSShadow {

--- a/examples/generated/test/react-dom/components/ComponentParameterInstance.js
+++ b/examples/generated/test/react-dom/components/ComponentParameterInstance.js
@@ -2,6 +2,7 @@ import React from "react"
 import styled, { ThemeProvider } from "styled-components"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 import ComponentParameterTemplate from "./ComponentParameterTemplate"
 

--- a/examples/generated/test/react-dom/components/NestedBottomLeftLayout.js
+++ b/examples/generated/test/react-dom/components/NestedBottomLeftLayout.js
@@ -2,6 +2,7 @@ import React from "react"
 import styled, { ThemeProvider } from "styled-components"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 import LocalAsset from "../images/LocalAsset"
 

--- a/examples/generated/test/react-dom/components/NestedButtons.js
+++ b/examples/generated/test/react-dom/components/NestedButtons.js
@@ -2,6 +2,7 @@ import React from "react"
 import styled, { ThemeProvider } from "styled-components"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 import Button from "../interactivity/Button"
 

--- a/examples/generated/test/react-dom/components/NestedComponent.js
+++ b/examples/generated/test/react-dom/components/NestedComponent.js
@@ -2,6 +2,7 @@ import React from "react"
 import styled, { ThemeProvider } from "styled-components"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 import FitContentParentSecondaryChildren from
   "../layouts/FitContentParentSecondaryChildren"

--- a/examples/generated/test/react-dom/components/NestedLayout.js
+++ b/examples/generated/test/react-dom/components/NestedLayout.js
@@ -2,6 +2,7 @@ import React from "react"
 import styled, { ThemeProvider } from "styled-components"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 import LocalAsset from "../images/LocalAsset"
 

--- a/examples/generated/test/react-dom/images/LocalAsset.js
+++ b/examples/generated/test/react-dom/images/LocalAsset.js
@@ -2,6 +2,7 @@ import React from "react"
 import styled, { ThemeProvider } from "styled-components"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class LocalAsset extends React.Component {

--- a/examples/generated/test/react-dom/interactivity/Button.js
+++ b/examples/generated/test/react-dom/interactivity/Button.js
@@ -2,6 +2,7 @@ import React from "react"
 import styled, { ThemeProvider } from "styled-components"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class Button extends React.Component {

--- a/examples/generated/test/react-dom/interactivity/PressableRootView.js
+++ b/examples/generated/test/react-dom/interactivity/PressableRootView.js
@@ -2,6 +2,7 @@ import React from "react"
 import styled, { ThemeProvider } from "styled-components"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class PressableRootView extends React.Component {

--- a/examples/generated/test/react-dom/layouts/FitContentParentSecondaryChildren.js
+++ b/examples/generated/test/react-dom/layouts/FitContentParentSecondaryChildren.js
@@ -2,6 +2,7 @@ import React from "react"
 import styled, { ThemeProvider } from "styled-components"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class FitContentParentSecondaryChildren extends React.Component {

--- a/examples/generated/test/react-dom/layouts/FixedParentFillAndFitChildren.js
+++ b/examples/generated/test/react-dom/layouts/FixedParentFillAndFitChildren.js
@@ -2,6 +2,7 @@ import React from "react"
 import styled, { ThemeProvider } from "styled-components"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class FixedParentFillAndFitChildren extends React.Component {

--- a/examples/generated/test/react-dom/layouts/FixedParentFitChild.js
+++ b/examples/generated/test/react-dom/layouts/FixedParentFitChild.js
@@ -2,6 +2,7 @@ import React from "react"
 import styled, { ThemeProvider } from "styled-components"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class FixedParentFitChild extends React.Component {

--- a/examples/generated/test/react-dom/layouts/MultipleFlexText.js
+++ b/examples/generated/test/react-dom/layouts/MultipleFlexText.js
@@ -2,6 +2,7 @@ import React from "react"
 import styled, { ThemeProvider } from "styled-components"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class MultipleFlexText extends React.Component {

--- a/examples/generated/test/react-dom/layouts/PrimaryAxis.js
+++ b/examples/generated/test/react-dom/layouts/PrimaryAxis.js
@@ -2,6 +2,7 @@ import React from "react"
 import styled, { ThemeProvider } from "styled-components"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class PrimaryAxis extends React.Component {

--- a/examples/generated/test/react-dom/layouts/SecondaryAxis.js
+++ b/examples/generated/test/react-dom/layouts/SecondaryAxis.js
@@ -2,6 +2,7 @@ import React from "react"
 import styled, { ThemeProvider } from "styled-components"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class SecondaryAxis extends React.Component {

--- a/examples/generated/test/react-dom/logic/Assign.js
+++ b/examples/generated/test/react-dom/logic/Assign.js
@@ -2,6 +2,7 @@ import React from "react"
 import styled, { ThemeProvider } from "styled-components"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class Assign extends React.Component {

--- a/examples/generated/test/react-dom/logic/If.js
+++ b/examples/generated/test/react-dom/logic/If.js
@@ -2,6 +2,7 @@ import React from "react"
 import styled, { ThemeProvider } from "styled-components"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class If extends React.Component {

--- a/examples/generated/test/react-dom/shadows.js
+++ b/examples/generated/test/react-dom/shadows.js
@@ -1,0 +1,7 @@
+import colors from "./colors"
+
+export default {
+  elevation1: { filter: "drop-shadow(0px 1px 2px rgba(0,0,0,0.5));" },
+  elevation2: { filter: "drop-shadow(0px 2px 4px rgba(0,0,0,0.5));" },
+  elevation3: { filter: "drop-shadow(0px 3px 9px " + colors.grey900 + ");" }
+};

--- a/examples/generated/test/react-dom/style/BorderWidthColor.js
+++ b/examples/generated/test/react-dom/style/BorderWidthColor.js
@@ -2,6 +2,7 @@ import React from "react"
 import styled, { ThemeProvider } from "styled-components"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class BorderWidthColor extends React.Component {

--- a/examples/generated/test/react-dom/style/BoxModelConditional.js
+++ b/examples/generated/test/react-dom/style/BoxModelConditional.js
@@ -2,6 +2,7 @@ import React from "react"
 import styled, { ThemeProvider } from "styled-components"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class BoxModelConditional extends React.Component {

--- a/examples/generated/test/react-dom/style/ShadowsTest.js
+++ b/examples/generated/test/react-dom/style/ShadowsTest.js
@@ -1,0 +1,48 @@
+import React from "react"
+import styled, { ThemeProvider } from "styled-components"
+
+import colors from "../colors"
+import shadows from "../shadows"
+import textStyles from "../textStyles"
+
+export default class ShadowsTest extends React.Component {
+  render() {
+
+    let Inner$shadow
+    Inner$shadow = shadows.elevation2
+
+    if (this.props.largeShadow) {
+      Inner$shadow = shadows.elevation3
+    }
+    let theme = { "container": { "normal": {} }, "inner": { "normal": {} } }
+    return (
+      <ThemeProvider theme={theme}>
+        <div style={Object.assign({}, styles.container, {})}>
+          <div style={Object.assign({}, styles.inner, { ...Inner$shadow })} />
+        </div>
+      </ThemeProvider>
+    );
+  }
+};
+
+let styles = {
+  container: {
+    alignItems: "center",
+    display: "flex",
+    flex: "1 1 0%",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    paddingTop: "20px",
+    paddingBottom: "20px"
+  },
+  inner: {
+    alignItems: "flex-start",
+    backgroundColor: colors.blue300,
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    ...shadows.elevation2,
+    width: "60px",
+    height: "60px"
+  }
+}

--- a/examples/generated/test/react-dom/style/TextAlignment.js
+++ b/examples/generated/test/react-dom/style/TextAlignment.js
@@ -2,6 +2,7 @@ import React from "react"
 import styled, { ThemeProvider } from "styled-components"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class TextAlignment extends React.Component {

--- a/examples/generated/test/react-dom/style/TextStyleConditional.js
+++ b/examples/generated/test/react-dom/style/TextStyleConditional.js
@@ -2,6 +2,7 @@ import React from "react"
 import styled, { ThemeProvider } from "styled-components"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class TextStyleConditional extends React.Component {

--- a/examples/generated/test/react-dom/style/TextStylesTest.js
+++ b/examples/generated/test/react-dom/style/TextStylesTest.js
@@ -2,6 +2,7 @@ import React from "react"
 import styled, { ThemeProvider } from "styled-components"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class TextStylesTest extends React.Component {

--- a/examples/generated/test/react-dom/style/VisibilityTest.js
+++ b/examples/generated/test/react-dom/style/VisibilityTest.js
@@ -2,6 +2,7 @@ import React from "react"
 import styled, { ThemeProvider } from "styled-components"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class VisibilityTest extends React.Component {

--- a/examples/generated/test/react-native/components/ComponentParameterInstance.js
+++ b/examples/generated/test/react-native/components/ComponentParameterInstance.js
@@ -2,6 +2,7 @@ import React from "react"
 import { View, StyleSheet } from "react-native"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 import ComponentParameterTemplate from "./ComponentParameterTemplate"
 

--- a/examples/generated/test/react-native/components/NestedBottomLeftLayout.js
+++ b/examples/generated/test/react-native/components/NestedBottomLeftLayout.js
@@ -2,6 +2,7 @@ import React from "react"
 import { View, StyleSheet } from "react-native"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 import LocalAsset from "../images/LocalAsset"
 

--- a/examples/generated/test/react-native/components/NestedButtons.js
+++ b/examples/generated/test/react-native/components/NestedButtons.js
@@ -2,6 +2,7 @@ import React from "react"
 import { View, StyleSheet } from "react-native"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 import Button from "../interactivity/Button"
 

--- a/examples/generated/test/react-native/components/NestedComponent.js
+++ b/examples/generated/test/react-native/components/NestedComponent.js
@@ -2,6 +2,7 @@ import React from "react"
 import { Text, View, StyleSheet } from "react-native"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 import FitContentParentSecondaryChildren from
   "../layouts/FitContentParentSecondaryChildren"

--- a/examples/generated/test/react-native/components/NestedLayout.js
+++ b/examples/generated/test/react-native/components/NestedLayout.js
@@ -2,6 +2,7 @@ import React from "react"
 import { View, StyleSheet } from "react-native"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 import LocalAsset from "../images/LocalAsset"
 

--- a/examples/generated/test/react-native/images/LocalAsset.js
+++ b/examples/generated/test/react-native/images/LocalAsset.js
@@ -2,6 +2,7 @@ import React from "react"
 import { Image, View, StyleSheet } from "react-native"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class LocalAsset extends React.Component {

--- a/examples/generated/test/react-native/interactivity/Button.js
+++ b/examples/generated/test/react-native/interactivity/Button.js
@@ -2,6 +2,7 @@ import React from "react"
 import { Text, View, StyleSheet } from "react-native"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class Button extends React.Component {

--- a/examples/generated/test/react-native/interactivity/PressableRootView.js
+++ b/examples/generated/test/react-native/interactivity/PressableRootView.js
@@ -2,6 +2,7 @@ import React from "react"
 import { Text, View, StyleSheet } from "react-native"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class PressableRootView extends React.Component {

--- a/examples/generated/test/react-native/layouts/FitContentParentSecondaryChildren.js
+++ b/examples/generated/test/react-native/layouts/FitContentParentSecondaryChildren.js
@@ -2,6 +2,7 @@ import React from "react"
 import { View, StyleSheet } from "react-native"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class FitContentParentSecondaryChildren extends React.Component {

--- a/examples/generated/test/react-native/layouts/FixedParentFillAndFitChildren.js
+++ b/examples/generated/test/react-native/layouts/FixedParentFillAndFitChildren.js
@@ -2,6 +2,7 @@ import React from "react"
 import { View, StyleSheet } from "react-native"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class FixedParentFillAndFitChildren extends React.Component {

--- a/examples/generated/test/react-native/layouts/FixedParentFitChild.js
+++ b/examples/generated/test/react-native/layouts/FixedParentFitChild.js
@@ -2,6 +2,7 @@ import React from "react"
 import { View, StyleSheet } from "react-native"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class FixedParentFitChild extends React.Component {

--- a/examples/generated/test/react-native/layouts/MultipleFlexText.js
+++ b/examples/generated/test/react-native/layouts/MultipleFlexText.js
@@ -2,6 +2,7 @@ import React from "react"
 import { Text, View, StyleSheet } from "react-native"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class MultipleFlexText extends React.Component {

--- a/examples/generated/test/react-native/layouts/PrimaryAxis.js
+++ b/examples/generated/test/react-native/layouts/PrimaryAxis.js
@@ -2,6 +2,7 @@ import React from "react"
 import { Text, View, StyleSheet } from "react-native"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class PrimaryAxis extends React.Component {

--- a/examples/generated/test/react-native/layouts/SecondaryAxis.js
+++ b/examples/generated/test/react-native/layouts/SecondaryAxis.js
@@ -2,6 +2,7 @@ import React from "react"
 import { Text, View, StyleSheet } from "react-native"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class SecondaryAxis extends React.Component {

--- a/examples/generated/test/react-native/logic/Assign.js
+++ b/examples/generated/test/react-native/logic/Assign.js
@@ -2,6 +2,7 @@ import React from "react"
 import { Text, View, StyleSheet } from "react-native"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class Assign extends React.Component {

--- a/examples/generated/test/react-native/logic/If.js
+++ b/examples/generated/test/react-native/logic/If.js
@@ -2,6 +2,7 @@ import React from "react"
 import { View, StyleSheet } from "react-native"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class If extends React.Component {

--- a/examples/generated/test/react-native/style/BorderWidthColor.js
+++ b/examples/generated/test/react-native/style/BorderWidthColor.js
@@ -2,6 +2,7 @@ import React from "react"
 import { View, StyleSheet } from "react-native"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class BorderWidthColor extends React.Component {

--- a/examples/generated/test/react-native/style/BoxModelConditional.js
+++ b/examples/generated/test/react-native/style/BoxModelConditional.js
@@ -2,6 +2,7 @@ import React from "react"
 import { View, StyleSheet } from "react-native"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class BoxModelConditional extends React.Component {

--- a/examples/generated/test/react-native/style/ShadowsTest.js
+++ b/examples/generated/test/react-native/style/ShadowsTest.js
@@ -1,0 +1,44 @@
+import React from "react"
+import { View, StyleSheet } from "react-native"
+
+import colors from "../colors"
+import shadows from "../shadows"
+import textStyles from "../textStyles"
+
+export default class ShadowsTest extends React.Component {
+  render() {
+
+    let Inner$shadow
+    Inner$shadow = shadows.elevation2
+
+    if (this.props.largeShadow) {
+      Inner$shadow = shadows.elevation3
+    }
+    return (
+      <View style={[ styles.container, {} ]}>
+        <View style={[ styles.inner, { ...Inner$shadow } ]} />
+      </View>
+    );
+  }
+};
+
+let styles = StyleSheet.create({
+  container: {
+    alignItems: "center",
+    alignSelf: "stretch",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    paddingTop: 20,
+    paddingBottom: 20
+  },
+  inner: {
+    alignItems: "flex-start",
+    backgroundColor: colors.blue300,
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    ...shadows.elevation2,
+    width: 60,
+    height: 60
+  }
+})

--- a/examples/generated/test/react-native/style/TextAlignment.js
+++ b/examples/generated/test/react-native/style/TextAlignment.js
@@ -2,6 +2,7 @@ import React from "react"
 import { Text, Image, View, StyleSheet } from "react-native"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class TextAlignment extends React.Component {

--- a/examples/generated/test/react-native/style/TextStyleConditional.js
+++ b/examples/generated/test/react-native/style/TextStyleConditional.js
@@ -2,6 +2,7 @@ import React from "react"
 import { Text, View, StyleSheet } from "react-native"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class TextStyleConditional extends React.Component {

--- a/examples/generated/test/react-native/style/TextStylesTest.js
+++ b/examples/generated/test/react-native/style/TextStylesTest.js
@@ -2,6 +2,7 @@ import React from "react"
 import { Text, View, StyleSheet } from "react-native"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class TextStylesTest extends React.Component {

--- a/examples/generated/test/react-native/style/VisibilityTest.js
+++ b/examples/generated/test/react-native/style/VisibilityTest.js
@@ -2,6 +2,7 @@ import React from "react"
 import { Text, View, StyleSheet } from "react-native"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class VisibilityTest extends React.Component {

--- a/examples/generated/test/sketchJs/components/ComponentParameterInstance.js
+++ b/examples/generated/test/sketchJs/components/ComponentParameterInstance.js
@@ -2,6 +2,7 @@ import React from "react"
 import { View, StyleSheet, TextStyles } from "@mathieudutour/react-sketchapp"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 import ComponentParameterTemplate from "./ComponentParameterTemplate"
 

--- a/examples/generated/test/sketchJs/components/NestedBottomLeftLayout.js
+++ b/examples/generated/test/sketchJs/components/NestedBottomLeftLayout.js
@@ -2,6 +2,7 @@ import React from "react"
 import { View, StyleSheet, TextStyles } from "@mathieudutour/react-sketchapp"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 import LocalAsset from "../images/LocalAsset"
 

--- a/examples/generated/test/sketchJs/components/NestedButtons.js
+++ b/examples/generated/test/sketchJs/components/NestedButtons.js
@@ -2,6 +2,7 @@ import React from "react"
 import { View, StyleSheet, TextStyles } from "@mathieudutour/react-sketchapp"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 import Button from "../interactivity/Button"
 

--- a/examples/generated/test/sketchJs/components/NestedComponent.js
+++ b/examples/generated/test/sketchJs/components/NestedComponent.js
@@ -3,6 +3,7 @@ import { Text, View, StyleSheet, TextStyles } from
   "@mathieudutour/react-sketchapp"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 import FitContentParentSecondaryChildren from
   "../layouts/FitContentParentSecondaryChildren"

--- a/examples/generated/test/sketchJs/components/NestedLayout.js
+++ b/examples/generated/test/sketchJs/components/NestedLayout.js
@@ -2,6 +2,7 @@ import React from "react"
 import { View, StyleSheet, TextStyles } from "@mathieudutour/react-sketchapp"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 import LocalAsset from "../images/LocalAsset"
 

--- a/examples/generated/test/sketchJs/images/LocalAsset.js
+++ b/examples/generated/test/sketchJs/images/LocalAsset.js
@@ -3,6 +3,7 @@ import { Image, View, StyleSheet, TextStyles } from
   "@mathieudutour/react-sketchapp"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class LocalAsset extends React.Component {

--- a/examples/generated/test/sketchJs/interactivity/Button.js
+++ b/examples/generated/test/sketchJs/interactivity/Button.js
@@ -3,6 +3,7 @@ import { Text, View, StyleSheet, TextStyles } from
   "@mathieudutour/react-sketchapp"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class Button extends React.Component {

--- a/examples/generated/test/sketchJs/interactivity/PressableRootView.js
+++ b/examples/generated/test/sketchJs/interactivity/PressableRootView.js
@@ -3,6 +3,7 @@ import { Text, View, StyleSheet, TextStyles } from
   "@mathieudutour/react-sketchapp"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class PressableRootView extends React.Component {

--- a/examples/generated/test/sketchJs/layouts/FitContentParentSecondaryChildren.js
+++ b/examples/generated/test/sketchJs/layouts/FitContentParentSecondaryChildren.js
@@ -2,6 +2,7 @@ import React from "react"
 import { View, StyleSheet, TextStyles } from "@mathieudutour/react-sketchapp"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class FitContentParentSecondaryChildren extends React.Component {

--- a/examples/generated/test/sketchJs/layouts/FixedParentFillAndFitChildren.js
+++ b/examples/generated/test/sketchJs/layouts/FixedParentFillAndFitChildren.js
@@ -2,6 +2,7 @@ import React from "react"
 import { View, StyleSheet, TextStyles } from "@mathieudutour/react-sketchapp"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class FixedParentFillAndFitChildren extends React.Component {

--- a/examples/generated/test/sketchJs/layouts/FixedParentFitChild.js
+++ b/examples/generated/test/sketchJs/layouts/FixedParentFitChild.js
@@ -2,6 +2,7 @@ import React from "react"
 import { View, StyleSheet, TextStyles } from "@mathieudutour/react-sketchapp"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class FixedParentFitChild extends React.Component {

--- a/examples/generated/test/sketchJs/layouts/MultipleFlexText.js
+++ b/examples/generated/test/sketchJs/layouts/MultipleFlexText.js
@@ -3,6 +3,7 @@ import { Text, View, StyleSheet, TextStyles } from
   "@mathieudutour/react-sketchapp"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class MultipleFlexText extends React.Component {

--- a/examples/generated/test/sketchJs/layouts/PrimaryAxis.js
+++ b/examples/generated/test/sketchJs/layouts/PrimaryAxis.js
@@ -3,6 +3,7 @@ import { Text, View, StyleSheet, TextStyles } from
   "@mathieudutour/react-sketchapp"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class PrimaryAxis extends React.Component {

--- a/examples/generated/test/sketchJs/layouts/SecondaryAxis.js
+++ b/examples/generated/test/sketchJs/layouts/SecondaryAxis.js
@@ -3,6 +3,7 @@ import { Text, View, StyleSheet, TextStyles } from
   "@mathieudutour/react-sketchapp"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class SecondaryAxis extends React.Component {

--- a/examples/generated/test/sketchJs/logic/Assign.js
+++ b/examples/generated/test/sketchJs/logic/Assign.js
@@ -3,6 +3,7 @@ import { Text, View, StyleSheet, TextStyles } from
   "@mathieudutour/react-sketchapp"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class Assign extends React.Component {

--- a/examples/generated/test/sketchJs/logic/If.js
+++ b/examples/generated/test/sketchJs/logic/If.js
@@ -2,6 +2,7 @@ import React from "react"
 import { View, StyleSheet, TextStyles } from "@mathieudutour/react-sketchapp"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class If extends React.Component {

--- a/examples/generated/test/sketchJs/style/BorderWidthColor.js
+++ b/examples/generated/test/sketchJs/style/BorderWidthColor.js
@@ -2,6 +2,7 @@ import React from "react"
 import { View, StyleSheet, TextStyles } from "@mathieudutour/react-sketchapp"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class BorderWidthColor extends React.Component {

--- a/examples/generated/test/sketchJs/style/BoxModelConditional.js
+++ b/examples/generated/test/sketchJs/style/BoxModelConditional.js
@@ -2,6 +2,7 @@ import React from "react"
 import { View, StyleSheet, TextStyles } from "@mathieudutour/react-sketchapp"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class BoxModelConditional extends React.Component {

--- a/examples/generated/test/sketchJs/style/ShadowsTest.js
+++ b/examples/generated/test/sketchJs/style/ShadowsTest.js
@@ -1,0 +1,44 @@
+import React from "react"
+import { View, StyleSheet, TextStyles } from "@mathieudutour/react-sketchapp"
+
+import colors from "../colors"
+import shadows from "../shadows"
+import textStyles from "../textStyles"
+
+export default class ShadowsTest extends React.Component {
+  render() {
+
+    let Inner$shadow
+    Inner$shadow = shadows.elevation2
+
+    if (this.props.largeShadow) {
+      Inner$shadow = shadows.elevation3
+    }
+    return (
+      <View style={[ styles.container, {} ]}>
+        <View style={[ styles.inner, { ...Inner$shadow } ]} />
+      </View>
+    );
+  }
+};
+
+let styles = StyleSheet.create({
+  container: {
+    alignItems: "center",
+    alignSelf: "stretch",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    paddingTop: 20,
+    paddingBottom: 20
+  },
+  inner: {
+    alignItems: "flex-start",
+    backgroundColor: colors.blue300,
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    ...Shadows.get("elevation2"),
+    width: 60,
+    height: 60
+  }
+})

--- a/examples/generated/test/sketchJs/style/TextAlignment.js
+++ b/examples/generated/test/sketchJs/style/TextAlignment.js
@@ -3,6 +3,7 @@ import { Text, Image, View, StyleSheet, TextStyles } from
   "@mathieudutour/react-sketchapp"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class TextAlignment extends React.Component {

--- a/examples/generated/test/sketchJs/style/TextStyleConditional.js
+++ b/examples/generated/test/sketchJs/style/TextStyleConditional.js
@@ -3,6 +3,7 @@ import { Text, View, StyleSheet, TextStyles } from
   "@mathieudutour/react-sketchapp"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class TextStyleConditional extends React.Component {

--- a/examples/generated/test/sketchJs/style/TextStylesTest.js
+++ b/examples/generated/test/sketchJs/style/TextStylesTest.js
@@ -3,6 +3,7 @@ import { Text, View, StyleSheet, TextStyles } from
   "@mathieudutour/react-sketchapp"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class TextStylesTest extends React.Component {

--- a/examples/generated/test/sketchJs/style/VisibilityTest.js
+++ b/examples/generated/test/sketchJs/style/VisibilityTest.js
@@ -3,6 +3,7 @@ import { Text, View, StyleSheet, TextStyles } from
   "@mathieudutour/react-sketchapp"
 
 import colors from "../colors"
+import shadows from "../shadows"
 import textStyles from "../textStyles"
 
 export default class VisibilityTest extends React.Component {

--- a/examples/generated/test/swift/Shadows.swift
+++ b/examples/generated/test/swift/Shadows.swift
@@ -3,5 +3,5 @@ import UIKit
 public enum Shadows {
   public static let elevation1 = Shadow(color: #colorLiteral(red: 0, green: 0, blue: 0, alpha: 0.5), offset: CGSize(width: 0, height: 1), blur: 2)
   public static let elevation2 = Shadow(color: #colorLiteral(red: 0, green: 0, blue: 0, alpha: 0.5), offset: CGSize(width: 0, height: 2), blur: 4)
-  public static let elevation3 = Shadow(color: #colorLiteral(red: 0, green: 0, blue: 0, alpha: 0.5), offset: CGSize(width: 0, height: 3), blur: 9)
+  public static let elevation3 = Shadow(color: Colors.grey900, offset: CGSize(width: 0, height: 3), blur: 9)
 }

--- a/examples/test/shadows.json
+++ b/examples/test/shadows.json
@@ -20,7 +20,7 @@
     {
       "id": "elevation3",
       "name": "Elevation 3",
-      "color": "rgba(0,0,0,0.5)",
+      "color": "grey900",
       "x": 0,
       "y": 3,
       "blur": 9


### PR DESCRIPTION
## What

I added shadows for react dom. It doesn't generate any shadows in the shadows file for the other JS frameworks right now. I believe that shadowsTest.components will continue to be unusable for react-native and sketch. 

I also added watchers for the different compiler snapshot targets, using nodemon. It gives almost instant feedback as you modify the compiler, so I've found it really helpful and thought it should be shared.