### PR TITLE
Optional component parameters

### DIFF
--- a/compiler/core/src/core/decode.re
+++ b/compiler/core/src/core/decode.re
@@ -295,7 +295,7 @@ let rec logicNode = json => {
   let rec logicValueFromExpr = expr =>
     switch (expr) {
     | LonaLogic.MemberExpression(items) =>
-      let ltype = Reference("???");
+      let ltype = Reference("UnknownReferenceType");
       let path = items |> List.map(identifierFromExpr);
       Logic.Identifier(ltype, path);
     | LonaLogic.LiteralExpression(value) => Logic.Literal(value)

--- a/compiler/core/src/core/decode.re
+++ b/compiler/core/src/core/decode.re
@@ -314,15 +314,10 @@ let rec logicNode = json => {
         | VariableDeclarationExpression(decl) =>
           let id = decl##identifier |> identifierFromExpr;
           let content = decl##content |> logicValueFromExpr;
-          Logic.IfExists(
+          Logic.IfLet(
+            Logic.Identifier(undefinedType, [id]),
             content,
-            Logic.Block([
-              Logic.LetEqual(
-                Logic.Identifier(undefinedType, [id]),
-                content,
-              ),
-              ...body,
-            ]),
+            Logic.Block(body),
           );
         | BinaryExpression(bin) =>
           let left = bin##left |> logicValueFromExpr;

--- a/compiler/core/src/core/logic.re
+++ b/compiler/core/src/core/logic.re
@@ -9,6 +9,7 @@ type logicNode =
   | Add(logicValue, logicValue, logicValue)
   | Let(logicValue)
   | LetEqual(logicValue, logicValue)
+  | IfLet(logicValue, logicValue, logicNode)
   | Block(list(logicNode))
   | None;
 
@@ -51,6 +52,7 @@ module LogicTree =
       | Block(body) => body
       | Let(_) => []
       | LetEqual(_, _) => []
+      | IfLet(_, _, value) => [value]
       | None => []
       };
     let restore = (node, contents) => {
@@ -63,6 +65,7 @@ module LogicTree =
       | Block(_) => Block(contents)
       | Let(_) => node
       | LetEqual(_, _) => node
+      | IfLet(a, b, _) => IfLet(a, b, at(0))
       | None => node
       };
     };
@@ -177,6 +180,8 @@ let rec replaceIdentifiersNamed = (oldName, newName, node) => {
   | Add(a, b, c) => Add(replace(a), replace(b), replace(c))
   | Let(a) => Let(replace(a))
   | LetEqual(a, b) => LetEqual(replace(a), replace(b))
+  | IfLet(a, b, body) =>
+    IfLet(replace(a), replace(b), body |> replaceChild)
   | Block(body) => Block(body |> List.map(replaceChild))
   | None => node
   };

--- a/compiler/core/src/core/lonaValue.re
+++ b/compiler/core/src/core/lonaValue.re
@@ -90,12 +90,18 @@ let unwrapOptionalType = (ltype: Types.lonaType): Types.lonaType =>
     raise(Not_found);
   };
 
-let unwrapOptional = (value: Types.lonaValue): Types.lonaValue =>
+let decodeOptional = (value: Types.lonaValue): option(Types.lonaValue) =>
   switch (value.ltype) {
   | Reference(typeName) when Js.String.endsWith("?", typeName) =>
     let unwrappedType = unwrapOptionalType(value.ltype);
-    let unwrappedData = value.data |> Json.Decode.field("data", x => x);
-    {ltype: unwrappedType, data: unwrappedData};
+    let case = value.data |> Json.Decode.field("case", Json.Decode.string);
+    switch (case) {
+    | "Some" =>
+      let unwrappedData = value.data |> Json.Decode.field("data", x => x);
+      Some({ltype: unwrappedType, data: unwrappedData});
+    | "None"
+    | _ => None
+    };
   | _ =>
     Js.log3(
       "Failed to unwrap value -- not an optional value",

--- a/compiler/core/src/core/lonaValue.re
+++ b/compiler/core/src/core/lonaValue.re
@@ -73,15 +73,18 @@ let defaultValueForParameter = name => parameterDefaultValue(name);
 let decodeNumber = (value: Types.lonaValue): float =>
   value.data |> Json.Decode.float;
 
+let isOptionalTypeName = (typeName: string): bool =>
+  Js.String.endsWith("?", typeName);
+
 let isOptionalType = (ltype: Types.lonaType): bool =>
   switch (ltype) {
-  | Reference(typeName) when Js.String.endsWith("?", typeName) => true
+  | Reference(typeName) when isOptionalTypeName(typeName) => true
   | _ => false
   };
 
 let unwrapOptionalType = (ltype: Types.lonaType): Types.lonaType =>
   switch (ltype) {
-  | Reference(typeName) when Js.String.endsWith("?", typeName) =>
+  | Reference(typeName) when isOptionalTypeName(typeName) =>
     let unwrappedTypeName =
       String.sub(typeName, 0, String.length(typeName) - 1);
     Reference(unwrappedTypeName);
@@ -92,7 +95,7 @@ let unwrapOptionalType = (ltype: Types.lonaType): Types.lonaType =>
 
 let decodeOptional = (value: Types.lonaValue): option(Types.lonaValue) =>
   switch (value.ltype) {
-  | Reference(typeName) when Js.String.endsWith("?", typeName) =>
+  | Reference(typeName) when isOptionalTypeName(typeName) =>
     let unwrappedType = unwrapOptionalType(value.ltype);
     let case = value.data |> Json.Decode.field("case", Json.Decode.string);
     switch (case) {

--- a/compiler/core/src/javaScript/javaScriptAst.re
+++ b/compiler/core/src/javaScript/javaScriptAst.re
@@ -3,6 +3,7 @@ type binaryOperator =
   | Eq
   | LooseEq
   | Neq
+  | LooseNeq
   | Gt
   | Gte
   | Lt

--- a/compiler/core/src/javaScript/javaScriptAst.re
+++ b/compiler/core/src/javaScript/javaScriptAst.re
@@ -1,6 +1,7 @@
 [@bs.deriving accessors]
 type binaryOperator =
   | Eq
+  | LooseEq
   | Neq
   | Gt
   | Gte

--- a/compiler/core/src/javaScript/javaScriptLogic.re
+++ b/compiler/core/src/javaScript/javaScriptLogic.re
@@ -94,8 +94,10 @@ let rec toJavaScriptAST = (framework, config, node) => {
     IfStatement({
       test: condition,
       consequent: [
-        toJavaScriptAST(framework, config, Logic.LetEqual(a, b)),
-        toJavaScriptAST(framework, config, body),
+        Ast.Block([
+          toJavaScriptAST(framework, config, Logic.LetEqual(a, b)),
+          toJavaScriptAST(framework, config, body),
+        ]),
       ],
     });
   | Add(lhs, rhs, value) =>

--- a/compiler/core/src/javaScript/javaScriptLogic.re
+++ b/compiler/core/src/javaScript/javaScriptLogic.re
@@ -83,6 +83,21 @@ let rec toJavaScriptAST = (framework, config, node) => {
       test: condition,
       consequent: [toJavaScriptAST(framework, config, body)],
     });
+  | IfLet(a, b, body) =>
+    let condition =
+      Ast.BinaryExpression({
+        left: logicValueToJavaScriptASTWithConfig(b),
+        operator: Ast.LooseNeq,
+        right:
+          logicValueToJavaScriptASTWithConfig(Literal(LonaValue.null())),
+      });
+    IfStatement({
+      test: condition,
+      consequent: [
+        toJavaScriptAST(framework, config, Logic.LetEqual(a, b)),
+        toJavaScriptAST(framework, config, body),
+      ],
+    });
   | Add(lhs, rhs, value) =>
     let addition =
       Ast.BinaryExpression({

--- a/compiler/core/src/javaScript/javaScriptRender.re
+++ b/compiler/core/src/javaScript/javaScriptRender.re
@@ -8,6 +8,7 @@ let renderBinaryOperator = x => {
     | Ast.Eq => "==="
     | LooseEq => "=="
     | Neq => "!=="
+    | LooseNeq => "!="
     | Gt => ">"
     | Gte => ">="
     | Lt => "<"

--- a/compiler/core/src/javaScript/javaScriptRender.re
+++ b/compiler/core/src/javaScript/javaScriptRender.re
@@ -6,6 +6,7 @@ let renderBinaryOperator = x => {
   let op =
     switch (x) {
     | Ast.Eq => "==="
+    | LooseEq => "=="
     | Neq => "!=="
     | Gt => ">"
     | Gte => ">="

--- a/compiler/core/src/swift/swiftComponent.re
+++ b/compiler/core/src/swift/swiftComponent.re
@@ -606,40 +606,31 @@ let generate =
         ),
     });
   let convenienceInitializerDoc = () =>
-    SwiftAst.Builders.convenienceInit(
-      SwiftDocument.joinGroups(
-        Empty,
-        [
-          [
-            MemberExpression([
-              SwiftIdentifier("self"),
-              FunctionCallExpression({
-                "name": SwiftIdentifier("init"),
-                "arguments":
-                  parameters
-                  |> List.filter(param => !Parameter.isFunction(param))
-                  |> List.map((param: Decode.parameter) =>
-                       FunctionCallArgument({
-                         "name":
-                           Some(
-                             SwiftIdentifier(
-                               param.name |> ParameterKey.toString,
-                             ),
-                           ),
-                         "value":
-                           SwiftDocument.defaultValueForLonaType(
-                             swiftOptions.framework,
-                             config,
-                             param.ltype,
-                           ),
-                       })
+    SwiftAst.Builders.convenienceInit([
+      MemberExpression([
+        SwiftIdentifier("self"),
+        FunctionCallExpression({
+          "name": SwiftIdentifier("init"),
+          "arguments":
+            parameters
+            |> List.filter(param => !Parameter.isFunction(param))
+            |> List.map((param: Decode.parameter) =>
+                 FunctionCallArgument({
+                   "name":
+                     Some(
+                       SwiftIdentifier(param.name |> ParameterKey.toString),
                      ),
-              }),
-            ]),
-          ],
-        ],
-      ),
-    );
+                   "value":
+                     SwiftDocument.defaultValueForLonaType(
+                       swiftOptions.framework,
+                       config,
+                       param.ltype,
+                     ),
+                 })
+               ),
+        }),
+      ]),
+    ]);
   let memberOrSelfExpression = (firstIdentifier, statements) =>
     switch (firstIdentifier) {
     | "self" => MemberExpression(statements)

--- a/compiler/core/src/swift/swiftDocument.re
+++ b/compiler/core/src/swift/swiftDocument.re
@@ -139,7 +139,10 @@ let rec lonaValue =
   | Reference(typeName) =>
     switch (typeName) {
     | name when Js.String.endsWith("?", name) =>
-      lonaValue(framework, config, LonaValue.unwrapOptional(value))
+      switch (LonaValue.decodeOptional(value)) {
+      | Some(innerValue) => lonaValue(framework, config, innerValue)
+      | None => LiteralExpression(Nil)
+      }
     | "Boolean" => LiteralExpression(Boolean(value.data |> Json.Decode.bool))
     | "Number" =>
       LiteralExpression(FloatingPoint(value.data |> Json.Decode.float))

--- a/compiler/core/src/swift/swiftDocument.re
+++ b/compiler/core/src/swift/swiftDocument.re
@@ -136,13 +136,13 @@ let rec lonaValue =
           value: Types.lonaValue,
         ) =>
   switch (value.ltype) {
+  | Reference(typeName) when Js.String.endsWith("?", typeName) =>
+    switch (LonaValue.decodeOptional(value)) {
+    | Some(innerValue) => lonaValue(framework, config, innerValue)
+    | None => LiteralExpression(Nil)
+    }
   | Reference(typeName) =>
     switch (typeName) {
-    | name when Js.String.endsWith("?", name) =>
-      switch (LonaValue.decodeOptional(value)) {
-      | Some(innerValue) => lonaValue(framework, config, innerValue)
-      | None => LiteralExpression(Nil)
-      }
     | "Boolean" => LiteralExpression(Boolean(value.data |> Json.Decode.bool))
     | "Number" =>
       LiteralExpression(FloatingPoint(value.data |> Json.Decode.float))
@@ -161,8 +161,7 @@ let rec lonaValue =
         config,
         {ltype: Named(typeName, Reference("String")), data: value.data},
       )
-    | _ =>
-      SwiftIdentifier("UnknownReferenceType: " ++ typeName);
+    | _ => SwiftIdentifier("UnknownReferenceType: " ++ typeName)
     }
   | Function(_) => SwiftIdentifier("PLACEHOLDER")
   | Named(alias, subtype) =>
@@ -240,6 +239,8 @@ let rec defaultValueForLonaType =
           ltype: Types.lonaType,
         ) =>
   switch (ltype) {
+  | Reference(typeName) when Js.String.endsWith("?", typeName) =>
+    LiteralExpression(Nil)
   | Reference(typeName) =>
     switch (typeName) {
     | "Boolean" => LiteralExpression(Boolean(false))

--- a/compiler/core/src/swift/swiftDocument.re
+++ b/compiler/core/src/swift/swiftDocument.re
@@ -110,7 +110,7 @@ let localImageName = (framework: SwiftOptions.framework, name) => {
 let rec typeAnnotationDoc =
         (framework: SwiftOptions.framework, ltype: Types.lonaType) =>
   switch (ltype) {
-  | Types.Reference(typeName) when Js.String.endsWith("?", typeName) =>
+  | Types.Reference(typeName) when LonaValue.isOptionalTypeName(typeName) =>
     let unwrapped = LonaValue.unwrapOptionalType(ltype);
     OptionalType(typeAnnotationDoc(framework, unwrapped));
   | Types.Reference(typeName) =>
@@ -136,7 +136,7 @@ let rec lonaValue =
           value: Types.lonaValue,
         ) =>
   switch (value.ltype) {
-  | Reference(typeName) when Js.String.endsWith("?", typeName) =>
+  | Reference(typeName) when LonaValue.isOptionalTypeName(typeName) =>
     switch (LonaValue.decodeOptional(value)) {
     | Some(innerValue) => lonaValue(framework, config, innerValue)
     | None => LiteralExpression(Nil)
@@ -239,7 +239,7 @@ let rec defaultValueForLonaType =
           ltype: Types.lonaType,
         ) =>
   switch (ltype) {
-  | Reference(typeName) when Js.String.endsWith("?", typeName) =>
+  | Reference(typeName) when LonaValue.isOptionalTypeName(typeName) =>
     LiteralExpression(Nil)
   | Reference(typeName) =>
     switch (typeName) {
@@ -258,12 +258,6 @@ let rec defaultValueForLonaType =
         framework,
         config,
         Named(typeName, Reference("String")),
-      )
-    | value when Js.String.endsWith("?", value) =>
-      defaultValueForLonaType(
-        framework,
-        config,
-        Reference(Js.String.replace("?", "", value)),
       )
     | _ => LiteralExpression(Nil)
     }

--- a/compiler/core/src/swift/swiftLogic.re
+++ b/compiler/core/src/swift/swiftLogic.re
@@ -121,7 +121,7 @@ let toSwiftAST =
     | Gte => ">="
     | Lt => "<"
     | Lte => "<="
-    | Unknown => "???"
+    | Unknown => "UnknownCmp"
     };
   let unwrapBlock =
     fun
@@ -328,9 +328,14 @@ let toSwiftAST =
       let right = logicValueToSwiftAST(b);
       let operator = fromCmp(cmp);
       let body = unwrapBlock(body) |> List.map(inner);
+
+      let aIsOptional = LonaValue.isOptionalType(Logic.getValueType(a));
+      let bIsOptional = LonaValue.isOptionalType(Logic.getValueType(b));
+
       switch (left, operator, right) {
       | (Ast.LiteralExpression(Boolean(true)), "==", condition)
-      | (condition, "==", Ast.LiteralExpression(Boolean(true))) =>
+      | (condition, "==", Ast.LiteralExpression(Boolean(true)))
+          when !aIsOptional && !bIsOptional =>
         Ast.IfStatement({"condition": condition, "block": body})
       | _ =>
         Ast.IfStatement({

--- a/compiler/core/src/swift/swiftLogic.re
+++ b/compiler/core/src/swift/swiftLogic.re
@@ -348,6 +348,23 @@ let toSwiftAST =
           "block": body,
         })
       };
+    | IfLet(a, b, body) =>
+      let left = logicValueToSwiftAST(a);
+      let right = logicValueToSwiftAST(b);
+      let body = unwrapBlock(body) |> List.map(inner);
+
+      Ast.(
+        IfStatement({
+          "condition":
+            OptionalBindingCondition({
+              "const": true,
+              "pattern":
+                IdentifierPattern({"identifier": left, "annotation": None}),
+              "init": right,
+            }),
+          "block": body,
+        })
+      );
     | Add(lhs, rhs, value) =>
       BinaryExpression({
         "left": logicValueToSwiftAST(value),

--- a/compiler/core/src/swift/swiftRender.re
+++ b/compiler/core/src/swift/swiftRender.re
@@ -484,6 +484,8 @@ let rec render = ast: Prettier.Doc.t('a) =>
       <+> s(" ")
       <+> renderPattern(o##pattern)
       <+> line
+      <+> s("=")
+      <+> line
       <+> render(o##init),
     );
   | Empty => empty /* This only works if lines are added between statements... */

--- a/examples/LonaViewer/LonaViewer.xcodeproj/project.pbxproj
+++ b/examples/LonaViewer/LonaViewer.xcodeproj/project.pbxproj
@@ -63,6 +63,8 @@
 		6B39170A2164492600B20F9E /* Shadow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3917092164492600B20F9E /* Shadow.swift */; };
 		6BA5BBCF216D4A7D00F086A7 /* VisibilityTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA5BBCE216D4A7D00F086A7 /* VisibilityTest.swift */; };
 		6BA5BBD1216D4B6700F086A7 /* VisibilityTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA5BBD0216D4B6700F086A7 /* VisibilityTest.swift */; };
+		6BA5BBD3217017AC00F086A7 /* Optionals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA5BBD2217017AC00F086A7 /* Optionals.swift */; };
+		6BA5BBD5217021A000F086A7 /* Optionals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA5BBD4217021A000F086A7 /* Optionals.swift */; };
 		6BA694032082E4420090CA74 /* NestedComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA694022082E4420090CA74 /* NestedComponent.swift */; };
 		6BA69406208439DB0090CA74 /* NestedComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA69405208439DB0090CA74 /* NestedComponent.swift */; };
 		6BA6940820843CE70090CA74 /* Button.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA6940720843CE70090CA74 /* Button.swift */; };
@@ -133,6 +135,8 @@
 		6B3917092164492600B20F9E /* Shadow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Shadow.swift; sourceTree = "<group>"; };
 		6BA5BBCE216D4A7D00F086A7 /* VisibilityTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VisibilityTest.swift; sourceTree = "<group>"; };
 		6BA5BBD0216D4B6700F086A7 /* VisibilityTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VisibilityTest.swift; sourceTree = "<group>"; };
+		6BA5BBD2217017AC00F086A7 /* Optionals.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Optionals.swift; sourceTree = "<group>"; };
+		6BA5BBD4217021A000F086A7 /* Optionals.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Optionals.swift; sourceTree = "<group>"; };
 		6BA694022082E4420090CA74 /* NestedComponent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NestedComponent.swift; sourceTree = "<group>"; };
 		6BA69405208439DB0090CA74 /* NestedComponent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NestedComponent.swift; sourceTree = "<group>"; };
 		6BA6940720843CE70090CA74 /* Button.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Button.swift; sourceTree = "<group>"; };
@@ -241,6 +245,7 @@
 			children = (
 				12BBFDC9206B02720041620C /* Assign.swift */,
 				12BBFDCA206B02720041620C /* If.swift */,
+				6BA5BBD2217017AC00F086A7 /* Optionals.swift */,
 			);
 			path = logic;
 			sourceTree = "<group>";
@@ -321,6 +326,7 @@
 			children = (
 				12BBFDF0206B02AC0041620C /* Assign.swift */,
 				12BBFDF1206B02AC0041620C /* If.swift */,
+				6BA5BBD4217021A000F086A7 /* Optionals.swift */,
 			);
 			path = logic;
 			sourceTree = "<group>";
@@ -505,6 +511,7 @@
 				1296255E204B2DC20057CDFF /* DetailVC.swift in Sources */,
 				6BA69406208439DB0090CA74 /* NestedComponent.swift in Sources */,
 				12BBFE0E206B02AC0041620C /* SecondaryAxis.swift in Sources */,
+				6BA5BBD5217021A000F086A7 /* Optionals.swift in Sources */,
 				12BBFE11206B02AC0041620C /* Colors.swift in Sources */,
 				30F870B920864A88007ADA5B /* NestedButtons.swift in Sources */,
 				12BBFE0D206B02AC0041620C /* FixedParentFitChild.swift in Sources */,
@@ -545,6 +552,7 @@
 				12BBFDE3206B02720041620C /* FixedParentFillAndFitChildren.swift in Sources */,
 				12BBFDDD206B02720041620C /* Assign.swift in Sources */,
 				12BBFDE6206B02720041620C /* FitContentParentSecondaryChildren.swift in Sources */,
+				6BA5BBD3217017AC00F086A7 /* Optionals.swift in Sources */,
 				12BBFDE1206B02720041620C /* TextStyleConditional.swift in Sources */,
 				12BBFCF0206A8BCD0041620C /* Generated.swift in Sources */,
 				6BA694032082E4420090CA74 /* NestedComponent.swift in Sources */,

--- a/examples/LonaViewer/MacOS/Generated.swift
+++ b/examples/LonaViewer/MacOS/Generated.swift
@@ -31,6 +31,7 @@ enum Generated: String {
     case boxModelConditionalLarge = "Box Model Conditional Large"
     case shadowsTest = "Shadow Test"
     case visibilityTest = "Visibility Test"
+    case optionals = "Optionals"
 
     static func allValues() -> [Generated] {
         return [
@@ -56,6 +57,7 @@ enum Generated: String {
             boxModelConditionalLarge,
             shadowsTest,
             visibilityTest,
+            optionals,
         ]
     }
 
@@ -111,6 +113,8 @@ enum Generated: String {
             return ShadowsTest()
         case .visibilityTest:
             return VisibilityTest(enabled: true)
+        case .optionals:
+            return Optionals(boolParam: true)
         }
     }
 
@@ -135,7 +139,8 @@ enum Generated: String {
              .boxModelConditionalSmall,
              .boxModelConditionalLarge,
              .shadowsTest,
-             .visibilityTest:
+             .visibilityTest,
+             .optionals:
             return [
                 equal(\.topAnchor),
                 equal(\.leftAnchor),

--- a/examples/LonaViewer/MacOS/Generated.swift
+++ b/examples/LonaViewer/MacOS/Generated.swift
@@ -114,7 +114,7 @@ enum Generated: String {
         case .visibilityTest:
             return VisibilityTest(enabled: true)
         case .optionals:
-            return Optionals(boolParam: true)
+          return Optionals(boolParam: true, stringParam: "Hello World")
         }
     }
 

--- a/examples/LonaViewer/iOS/Generated.swift
+++ b/examples/LonaViewer/iOS/Generated.swift
@@ -114,7 +114,7 @@ enum Generated: String {
         case .visibilityTest:
             return VisibilityTest(enabled: true)
         case .optionals:
-            return Optionals(boolParam: true)
+            return Optionals(boolParam: true, stringParam: "Hello World")
         }
     }
 

--- a/examples/LonaViewer/iOS/Generated.swift
+++ b/examples/LonaViewer/iOS/Generated.swift
@@ -31,6 +31,7 @@ enum Generated: String {
     case boxModelConditionalLarge = "Box Model Conditional Large"
     case shadowsTest = "Shadow Test"
     case visibilityTest = "Visibility Test"
+    case optionals = "Optionals"
 
     static func allValues() -> [Generated] {
         return [
@@ -55,7 +56,8 @@ enum Generated: String {
             boxModelConditionalSmall,
             boxModelConditionalLarge,
             shadowsTest,
-            visibilityTest
+            visibilityTest,
+            optionals
         ]
     }
     
@@ -111,6 +113,8 @@ enum Generated: String {
             return ShadowsTest()
         case .visibilityTest:
             return VisibilityTest(enabled: true)
+        case .optionals:
+            return Optionals(boolParam: true)
         }
     }
 
@@ -134,7 +138,8 @@ enum Generated: String {
              .boxModelConditionalSmall,
              .boxModelConditionalLarge,
              .shadowsTest,
-             .visibilityTest:
+             .visibilityTest,
+             .optionals:
             return [
                 equal(\.topAnchor, \.safeAreaLayoutGuide.topAnchor),
                 equal(\.leftAnchor),

--- a/examples/generated/test/appkit/logic/Optionals.swift
+++ b/examples/generated/test/appkit/logic/Optionals.swift
@@ -1,0 +1,80 @@
+import AppKit
+import Foundation
+
+// MARK: - Optionals
+
+public class Optionals: NSBox {
+
+  // MARK: Lifecycle
+
+  public init(boolParam: Bool?) {
+    self.boolParam = boolParam
+
+    super.init(frame: .zero)
+
+    setUpViews()
+    setUpConstraints()
+
+    update()
+  }
+
+  public convenience init() {
+    self.init(boolParam: false)
+  }
+
+  public required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: Public
+
+  public var boolParam: Bool? { didSet { update() } }
+
+  // MARK: Private
+
+  private var labelView = NSTextField(labelWithString: "")
+
+  private var labelViewTextStyle = TextStyles.body1
+
+  private func setUpViews() {
+    boxType = .custom
+    borderType = .noBorder
+    contentViewMargins = .zero
+    labelView.lineBreakMode = .byWordWrapping
+
+    addSubview(labelView)
+  }
+
+  private func setUpConstraints() {
+    translatesAutoresizingMaskIntoConstraints = false
+    labelView.translatesAutoresizingMaskIntoConstraints = false
+
+    let labelViewTopAnchorConstraint = labelView.topAnchor.constraint(equalTo: topAnchor)
+    let labelViewBottomAnchorConstraint = labelView.bottomAnchor.constraint(equalTo: bottomAnchor)
+    let labelViewLeadingAnchorConstraint = labelView.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let labelViewTrailingAnchorConstraint = labelView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor)
+
+    NSLayoutConstraint.activate([
+      labelViewTopAnchorConstraint,
+      labelViewBottomAnchorConstraint,
+      labelViewLeadingAnchorConstraint,
+      labelViewTrailingAnchorConstraint
+    ])
+  }
+
+  private func update() {
+    labelView.attributedStringValue = labelViewTextStyle.apply(to: "")
+    fillColor = #colorLiteral(red: 0, green: 0, blue: 0, alpha: 0)
+    if boolParam == true {
+      labelView.attributedStringValue = labelViewTextStyle.apply(to: "boolParam is true")
+      fillColor = Colors.green200
+    }
+    if boolParam == false {
+      labelView.attributedStringValue = labelViewTextStyle.apply(to: "boolParam is false")
+      fillColor = Colors.red200
+    }
+    if boolParam == nil {
+      labelView.attributedStringValue = labelViewTextStyle.apply(to: "boolParam is null")
+    }
+  }
+}

--- a/examples/generated/test/appkit/logic/Optionals.swift
+++ b/examples/generated/test/appkit/logic/Optionals.swift
@@ -7,8 +7,9 @@ public class Optionals: NSBox {
 
   // MARK: Lifecycle
 
-  public init(boolParam: Bool?) {
+  public init(boolParam: Bool?, stringParam: String?) {
     self.boolParam = boolParam
+    self.stringParam = stringParam
 
     super.init(frame: .zero)
 
@@ -19,7 +20,7 @@ public class Optionals: NSBox {
   }
 
   public convenience init() {
-    self.init(boolParam: false)
+    self.init(boolParam: nil, stringParam: nil)
   }
 
   public required init?(coder aDecoder: NSCoder) {
@@ -29,41 +30,56 @@ public class Optionals: NSBox {
   // MARK: Public
 
   public var boolParam: Bool? { didSet { update() } }
+  public var stringParam: String? { didSet { update() } }
 
   // MARK: Private
 
   private var labelView = NSTextField(labelWithString: "")
+  private var stringParamView = NSTextField(labelWithString: "")
 
   private var labelViewTextStyle = TextStyles.body1
+  private var stringParamViewTextStyle = TextStyles.body1
 
   private func setUpViews() {
     boxType = .custom
     borderType = .noBorder
     contentViewMargins = .zero
     labelView.lineBreakMode = .byWordWrapping
+    stringParamView.lineBreakMode = .byWordWrapping
 
     addSubview(labelView)
+    addSubview(stringParamView)
   }
 
   private func setUpConstraints() {
     translatesAutoresizingMaskIntoConstraints = false
     labelView.translatesAutoresizingMaskIntoConstraints = false
+    stringParamView.translatesAutoresizingMaskIntoConstraints = false
 
     let labelViewTopAnchorConstraint = labelView.topAnchor.constraint(equalTo: topAnchor)
-    let labelViewBottomAnchorConstraint = labelView.bottomAnchor.constraint(equalTo: bottomAnchor)
     let labelViewLeadingAnchorConstraint = labelView.leadingAnchor.constraint(equalTo: leadingAnchor)
     let labelViewTrailingAnchorConstraint = labelView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor)
+    let stringParamViewBottomAnchorConstraint = stringParamView.bottomAnchor.constraint(equalTo: bottomAnchor)
+    let stringParamViewTopAnchorConstraint = stringParamView.topAnchor.constraint(equalTo: labelView.bottomAnchor)
+    let stringParamViewLeadingAnchorConstraint = stringParamView.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let stringParamViewTrailingAnchorConstraint = stringParamView
+      .trailingAnchor
+      .constraint(lessThanOrEqualTo: trailingAnchor)
 
     NSLayoutConstraint.activate([
       labelViewTopAnchorConstraint,
-      labelViewBottomAnchorConstraint,
       labelViewLeadingAnchorConstraint,
-      labelViewTrailingAnchorConstraint
+      labelViewTrailingAnchorConstraint,
+      stringParamViewBottomAnchorConstraint,
+      stringParamViewTopAnchorConstraint,
+      stringParamViewLeadingAnchorConstraint,
+      stringParamViewTrailingAnchorConstraint
     ])
   }
 
   private func update() {
     labelView.attributedStringValue = labelViewTextStyle.apply(to: "")
+    stringParamView.attributedStringValue = stringParamViewTextStyle.apply(to: "No string param")
     fillColor = #colorLiteral(red: 0, green: 0, blue: 0, alpha: 0)
     if boolParam == true {
       labelView.attributedStringValue = labelViewTextStyle.apply(to: "boolParam is true")
@@ -75,6 +91,9 @@ public class Optionals: NSBox {
     }
     if boolParam == nil {
       labelView.attributedStringValue = labelViewTextStyle.apply(to: "boolParam is null")
+    }
+    if let unwrapped = stringParam {
+      stringParamView.attributedStringValue = stringParamViewTextStyle.apply(to: unwrapped)
     }
   }
 }

--- a/examples/generated/test/react-dom/logic/Optionals.js
+++ b/examples/generated/test/react-dom/logic/Optionals.js
@@ -1,0 +1,59 @@
+import React from "react"
+import styled, { ThemeProvider } from "styled-components"
+
+import colors from "../colors"
+import shadows from "../shadows"
+import textStyles from "../textStyles"
+
+export default class Optionals extends React.Component {
+  render() {
+
+    let Label$text
+    let View$backgroundColor
+    Label$text = ""
+    View$backgroundColor = "transparent"
+
+    if (this.props.boolParam == true) {
+      Label$text = "boolParam is true"
+      View$backgroundColor = colors.green200
+    }
+    if (this.props.boolParam == false) {
+      Label$text = "boolParam is false"
+      View$backgroundColor = colors.red200
+    }
+    if (this.props.boolParam == null) {
+      Label$text = "boolParam is null"
+    }
+    let theme = { "view": { "normal": {} }, "label": { "normal": {} } }
+    return (
+      <ThemeProvider theme={theme}>
+        <div
+          style={Object.assign({}, styles.view, {
+            backgroundColor: View$backgroundColor
+          })}
+        >
+          <span style={Object.assign({}, styles.label, {})}>
+            {Label$text}
+          </span>
+        </div>
+      </ThemeProvider>
+    );
+  }
+};
+
+let styles = {
+  view: {
+    alignItems: "flex-start",
+    display: "flex",
+    flex: "1 1 0%",
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  label: {
+    ...textStyles.body1,
+    alignItems: "flex-start",
+    flex: "0 0 auto",
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  }
+}

--- a/examples/generated/test/react-dom/logic/Optionals.js
+++ b/examples/generated/test/react-dom/logic/Optionals.js
@@ -9,8 +9,11 @@ export default class Optionals extends React.Component {
   render() {
 
     let Label$text
+    let StringParam$text
     let View$backgroundColor
+    let unwrapped
     Label$text = ""
+    StringParam$text = "No string param"
     View$backgroundColor = "transparent"
 
     if (this.props.boolParam == true) {
@@ -24,7 +27,16 @@ export default class Optionals extends React.Component {
     if (this.props.boolParam == null) {
       Label$text = "boolParam is null"
     }
-    let theme = { "view": { "normal": {} }, "label": { "normal": {} } }
+    if (this.props.stringParam != null) {
+      let unwrapped = this.props.stringParam
+
+      StringParam$text = unwrapped
+    }
+    let theme = {
+      "view": { "normal": {} },
+      "label": { "normal": {} },
+      "stringParam": { "normal": {} }
+    }
     return (
       <ThemeProvider theme={theme}>
         <div
@@ -34,6 +46,9 @@ export default class Optionals extends React.Component {
         >
           <span style={Object.assign({}, styles.label, {})}>
             {Label$text}
+          </span>
+          <span style={Object.assign({}, styles.stringParam, {})}>
+            {StringParam$text}
           </span>
         </div>
       </ThemeProvider>
@@ -50,6 +65,13 @@ let styles = {
     justifyContent: "flex-start"
   },
   label: {
+    ...textStyles.body1,
+    alignItems: "flex-start",
+    flex: "0 0 auto",
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  stringParam: {
     ...textStyles.body1,
     alignItems: "flex-start",
     flex: "0 0 auto",

--- a/examples/generated/test/react-native/logic/Optionals.js
+++ b/examples/generated/test/react-native/logic/Optionals.js
@@ -9,8 +9,11 @@ export default class Optionals extends React.Component {
   render() {
 
     let Label$text
+    let StringParam$text
     let View$backgroundColor
+    let unwrapped
     Label$text = ""
+    StringParam$text = "No string param"
     View$backgroundColor = "transparent"
 
     if (this.props.boolParam == true) {
@@ -24,10 +27,18 @@ export default class Optionals extends React.Component {
     if (this.props.boolParam == null) {
       Label$text = "boolParam is null"
     }
+    if (this.props.stringParam != null) {
+      let unwrapped = this.props.stringParam
+
+      StringParam$text = unwrapped
+    }
     return (
       <View style={[ styles.view, { backgroundColor: View$backgroundColor } ]}>
         <Text style={[ styles.label, {} ]}>
           {Label$text}
+        </Text>
+        <Text style={[ styles.stringParam, {} ]}>
+          {StringParam$text}
         </Text>
       </View>
     );
@@ -43,6 +54,13 @@ let styles = StyleSheet.create({
     justifyContent: "flex-start"
   },
   label: {
+    ...textStyles.body1,
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  stringParam: {
     ...textStyles.body1,
     alignItems: "flex-start",
     flex: 0,

--- a/examples/generated/test/react-native/logic/Optionals.js
+++ b/examples/generated/test/react-native/logic/Optionals.js
@@ -1,0 +1,52 @@
+import React from "react"
+import { Text, View, StyleSheet } from "react-native"
+
+import colors from "../colors"
+import shadows from "../shadows"
+import textStyles from "../textStyles"
+
+export default class Optionals extends React.Component {
+  render() {
+
+    let Label$text
+    let View$backgroundColor
+    Label$text = ""
+    View$backgroundColor = "transparent"
+
+    if (this.props.boolParam == true) {
+      Label$text = "boolParam is true"
+      View$backgroundColor = colors.green200
+    }
+    if (this.props.boolParam == false) {
+      Label$text = "boolParam is false"
+      View$backgroundColor = colors.red200
+    }
+    if (this.props.boolParam == null) {
+      Label$text = "boolParam is null"
+    }
+    return (
+      <View style={[ styles.view, { backgroundColor: View$backgroundColor } ]}>
+        <Text style={[ styles.label, {} ]}>
+          {Label$text}
+        </Text>
+      </View>
+    );
+  }
+};
+
+let styles = StyleSheet.create({
+  view: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  label: {
+    ...textStyles.body1,
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  }
+})

--- a/examples/generated/test/sketchJs/logic/Optionals.js
+++ b/examples/generated/test/sketchJs/logic/Optionals.js
@@ -1,0 +1,53 @@
+import React from "react"
+import { Text, View, StyleSheet, TextStyles } from
+  "@mathieudutour/react-sketchapp"
+
+import colors from "../colors"
+import shadows from "../shadows"
+import textStyles from "../textStyles"
+
+export default class Optionals extends React.Component {
+  render() {
+
+    let Label$text
+    let View$backgroundColor
+    Label$text = ""
+    View$backgroundColor = "transparent"
+
+    if (this.props.boolParam == true) {
+      Label$text = "boolParam is true"
+      View$backgroundColor = colors.green200
+    }
+    if (this.props.boolParam == false) {
+      Label$text = "boolParam is false"
+      View$backgroundColor = colors.red200
+    }
+    if (this.props.boolParam == null) {
+      Label$text = "boolParam is null"
+    }
+    return (
+      <View style={[ styles.view, { backgroundColor: View$backgroundColor } ]}>
+        <Text style={[ styles.label, {} ]}>
+          {Label$text}
+        </Text>
+      </View>
+    );
+  }
+};
+
+let styles = StyleSheet.create({
+  view: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  label: {
+    ...TextStyles.get("body1"),
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  }
+})

--- a/examples/generated/test/sketchJs/logic/Optionals.js
+++ b/examples/generated/test/sketchJs/logic/Optionals.js
@@ -10,8 +10,11 @@ export default class Optionals extends React.Component {
   render() {
 
     let Label$text
+    let StringParam$text
     let View$backgroundColor
+    let unwrapped
     Label$text = ""
+    StringParam$text = "No string param"
     View$backgroundColor = "transparent"
 
     if (this.props.boolParam == true) {
@@ -25,10 +28,18 @@ export default class Optionals extends React.Component {
     if (this.props.boolParam == null) {
       Label$text = "boolParam is null"
     }
+    if (this.props.stringParam != null) {
+      let unwrapped = this.props.stringParam
+
+      StringParam$text = unwrapped
+    }
     return (
       <View style={[ styles.view, { backgroundColor: View$backgroundColor } ]}>
         <Text style={[ styles.label, {} ]}>
           {Label$text}
+        </Text>
+        <Text style={[ styles.stringParam, {} ]}>
+          {StringParam$text}
         </Text>
       </View>
     );
@@ -44,6 +55,13 @@ let styles = StyleSheet.create({
     justifyContent: "flex-start"
   },
   label: {
+    ...TextStyles.get("body1"),
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  stringParam: {
     ...TextStyles.get("body1"),
     alignItems: "flex-start",
     flex: 0,

--- a/examples/generated/test/swift/logic/Optionals.swift
+++ b/examples/generated/test/swift/logic/Optionals.swift
@@ -1,0 +1,77 @@
+import UIKit
+import Foundation
+
+// MARK: - Optionals
+
+public class Optionals: UIView {
+
+  // MARK: Lifecycle
+
+  public init(boolParam: Bool?) {
+    self.boolParam = boolParam
+
+    super.init(frame: .zero)
+
+    setUpViews()
+    setUpConstraints()
+
+    update()
+  }
+
+  public convenience init() {
+    self.init(boolParam: false)
+  }
+
+  public required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: Public
+
+  public var boolParam: Bool? { didSet { update() } }
+
+  // MARK: Private
+
+  private var labelView = UILabel()
+
+  private var labelViewTextStyle = TextStyles.body1
+
+  private func setUpViews() {
+    labelView.numberOfLines = 0
+
+    addSubview(labelView)
+  }
+
+  private func setUpConstraints() {
+    translatesAutoresizingMaskIntoConstraints = false
+    labelView.translatesAutoresizingMaskIntoConstraints = false
+
+    let labelViewTopAnchorConstraint = labelView.topAnchor.constraint(equalTo: topAnchor)
+    let labelViewBottomAnchorConstraint = labelView.bottomAnchor.constraint(equalTo: bottomAnchor)
+    let labelViewLeadingAnchorConstraint = labelView.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let labelViewTrailingAnchorConstraint = labelView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor)
+
+    NSLayoutConstraint.activate([
+      labelViewTopAnchorConstraint,
+      labelViewBottomAnchorConstraint,
+      labelViewLeadingAnchorConstraint,
+      labelViewTrailingAnchorConstraint
+    ])
+  }
+
+  private func update() {
+    labelView.attributedText = labelViewTextStyle.apply(to: "")
+    backgroundColor = #colorLiteral(red: 0, green: 0, blue: 0, alpha: 0)
+    if boolParam == true {
+      labelView.attributedText = labelViewTextStyle.apply(to: "boolParam is true")
+      backgroundColor = Colors.green200
+    }
+    if boolParam == false {
+      labelView.attributedText = labelViewTextStyle.apply(to: "boolParam is false")
+      backgroundColor = Colors.red200
+    }
+    if boolParam == nil {
+      labelView.attributedText = labelViewTextStyle.apply(to: "boolParam is null")
+    }
+  }
+}

--- a/examples/generated/test/swift/logic/Optionals.swift
+++ b/examples/generated/test/swift/logic/Optionals.swift
@@ -7,8 +7,9 @@ public class Optionals: UIView {
 
   // MARK: Lifecycle
 
-  public init(boolParam: Bool?) {
+  public init(boolParam: Bool?, stringParam: String?) {
     self.boolParam = boolParam
+    self.stringParam = stringParam
 
     super.init(frame: .zero)
 
@@ -19,7 +20,7 @@ public class Optionals: UIView {
   }
 
   public convenience init() {
-    self.init(boolParam: false)
+    self.init(boolParam: nil, stringParam: nil)
   }
 
   public required init?(coder aDecoder: NSCoder) {
@@ -29,38 +30,53 @@ public class Optionals: UIView {
   // MARK: Public
 
   public var boolParam: Bool? { didSet { update() } }
+  public var stringParam: String? { didSet { update() } }
 
   // MARK: Private
 
   private var labelView = UILabel()
+  private var stringParamView = UILabel()
 
   private var labelViewTextStyle = TextStyles.body1
+  private var stringParamViewTextStyle = TextStyles.body1
 
   private func setUpViews() {
     labelView.numberOfLines = 0
+    stringParamView.numberOfLines = 0
 
     addSubview(labelView)
+    addSubview(stringParamView)
   }
 
   private func setUpConstraints() {
     translatesAutoresizingMaskIntoConstraints = false
     labelView.translatesAutoresizingMaskIntoConstraints = false
+    stringParamView.translatesAutoresizingMaskIntoConstraints = false
 
     let labelViewTopAnchorConstraint = labelView.topAnchor.constraint(equalTo: topAnchor)
-    let labelViewBottomAnchorConstraint = labelView.bottomAnchor.constraint(equalTo: bottomAnchor)
     let labelViewLeadingAnchorConstraint = labelView.leadingAnchor.constraint(equalTo: leadingAnchor)
     let labelViewTrailingAnchorConstraint = labelView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor)
+    let stringParamViewBottomAnchorConstraint = stringParamView.bottomAnchor.constraint(equalTo: bottomAnchor)
+    let stringParamViewTopAnchorConstraint = stringParamView.topAnchor.constraint(equalTo: labelView.bottomAnchor)
+    let stringParamViewLeadingAnchorConstraint = stringParamView.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let stringParamViewTrailingAnchorConstraint = stringParamView
+      .trailingAnchor
+      .constraint(lessThanOrEqualTo: trailingAnchor)
 
     NSLayoutConstraint.activate([
       labelViewTopAnchorConstraint,
-      labelViewBottomAnchorConstraint,
       labelViewLeadingAnchorConstraint,
-      labelViewTrailingAnchorConstraint
+      labelViewTrailingAnchorConstraint,
+      stringParamViewBottomAnchorConstraint,
+      stringParamViewTopAnchorConstraint,
+      stringParamViewLeadingAnchorConstraint,
+      stringParamViewTrailingAnchorConstraint
     ])
   }
 
   private func update() {
     labelView.attributedText = labelViewTextStyle.apply(to: "")
+    stringParamView.attributedText = stringParamViewTextStyle.apply(to: "No string param")
     backgroundColor = #colorLiteral(red: 0, green: 0, blue: 0, alpha: 0)
     if boolParam == true {
       labelView.attributedText = labelViewTextStyle.apply(to: "boolParam is true")
@@ -72,6 +88,9 @@ public class Optionals: UIView {
     }
     if boolParam == nil {
       labelView.attributedText = labelViewTextStyle.apply(to: "boolParam is null")
+    }
+    if let unwrapped = stringParam {
+      stringParamView.attributedText = stringParamViewTextStyle.apply(to: unwrapped)
     }
   }
 }

--- a/examples/test/logic/Optionals.component
+++ b/examples/test/logic/Optionals.component
@@ -1,0 +1,194 @@
+{
+  "devices" : [
+    {
+      "height" : 100,
+      "heightMode" : "At Least",
+      "name" : "iPhone SE",
+      "width" : 320
+    }
+  ],
+  "examples" : [
+    {
+      "id" : "Default",
+      "name" : "Default",
+      "params" : {
+        "boolParam" : null
+      }
+    },
+    {
+      "id" : "name",
+      "name" : "name",
+      "params" : {
+        "boolParam" : true
+      }
+    }
+  ],
+  "logic" : [
+    {
+      "body" : [
+        {
+          "assignee" : [
+            "layers",
+            "Label",
+            "text"
+          ],
+          "content" : {
+            "type" : "LitExpr",
+            "value" : {
+              "data" : "boolParam is true",
+              "type" : "String"
+            }
+          },
+          "type" : "AssignExpr"
+        },
+        {
+          "assignee" : [
+            "layers",
+            "View",
+            "backgroundColor"
+          ],
+          "content" : {
+            "type" : "LitExpr",
+            "value" : {
+              "data" : "green200",
+              "type" : "Color"
+            }
+          },
+          "type" : "AssignExpr"
+        }
+      ],
+      "condition" : {
+        "left" : [
+          "parameters",
+          "boolParam"
+        ],
+        "op" : "==",
+        "right" : {
+          "type" : "LitExpr",
+          "value" : {
+            "data" : {
+              "case" : "Some",
+              "data" : true
+            },
+            "type" : "Boolean?"
+          }
+        },
+        "type" : "BinExpr"
+      },
+      "type" : "IfExpr"
+    },
+    {
+      "body" : [
+        {
+          "assignee" : [
+            "layers",
+            "Label",
+            "text"
+          ],
+          "content" : {
+            "type" : "LitExpr",
+            "value" : {
+              "data" : "boolParam is false",
+              "type" : "String"
+            }
+          },
+          "type" : "AssignExpr"
+        },
+        {
+          "assignee" : [
+            "layers",
+            "View",
+            "backgroundColor"
+          ],
+          "content" : {
+            "type" : "LitExpr",
+            "value" : {
+              "data" : "red200",
+              "type" : "Color"
+            }
+          },
+          "type" : "AssignExpr"
+        }
+      ],
+      "condition" : {
+        "left" : [
+          "parameters",
+          "boolParam"
+        ],
+        "op" : "==",
+        "right" : {
+          "type" : "LitExpr",
+          "value" : {
+            "data" : {
+              "case" : "Some",
+              "data" : false
+            },
+            "type" : "Boolean?"
+          }
+        },
+        "type" : "BinExpr"
+      },
+      "type" : "IfExpr"
+    },
+    {
+      "body" : [
+        {
+          "assignee" : [
+            "layers",
+            "Label",
+            "text"
+          ],
+          "content" : {
+            "type" : "LitExpr",
+            "value" : {
+              "data" : "boolParam is null",
+              "type" : "String"
+            }
+          },
+          "type" : "AssignExpr"
+        }
+      ],
+      "condition" : {
+        "left" : [
+          "parameters",
+          "boolParam"
+        ],
+        "op" : "==",
+        "right" : {
+          "type" : "LitExpr",
+          "value" : {
+            "data" : {
+              "case" : "None",
+              "data" : null
+            },
+            "type" : "Boolean?"
+          }
+        },
+        "type" : "BinExpr"
+      },
+      "type" : "IfExpr"
+    }
+  ],
+  "params" : [
+    {
+      "name" : "boolParam",
+      "type" : "Boolean?"
+    }
+  ],
+  "root" : {
+    "children" : [
+      {
+        "id" : "Label",
+        "params" : {
+          "text" : ""
+        },
+        "type" : "Lona:Text"
+      }
+    ],
+    "id" : "View",
+    "params" : {
+      "alignSelf" : "stretch"
+    },
+    "type" : "Lona:View"
+  }
+}

--- a/examples/test/logic/Optionals.component
+++ b/examples/test/logic/Optionals.component
@@ -12,14 +12,16 @@
       "id" : "Default",
       "name" : "Default",
       "params" : {
-        "boolParam" : null
+        "boolParam" : null,
+        "stringParam" : null
       }
     },
     {
       "id" : "name",
       "name" : "name",
       "params" : {
-        "boolParam" : true
+        "boolParam" : true,
+        "stringParam" : "String param value"
       }
     }
   ],
@@ -167,12 +169,40 @@
         "type" : "BinExpr"
       },
       "type" : "IfExpr"
+    },
+    {
+      "body" : [
+        {
+          "assignee" : [
+            "layers",
+            "StringParam",
+            "text"
+          ],
+          "content" : [
+            "unwrapped"
+          ],
+          "type" : "AssignExpr"
+        }
+      ],
+      "condition" : {
+        "content" : [
+          "parameters",
+          "stringParam"
+        ],
+        "id" : "unwrapped",
+        "type" : "VarDeclExpr"
+      },
+      "type" : "IfExpr"
     }
   ],
   "params" : [
     {
       "name" : "boolParam",
       "type" : "Boolean?"
+    },
+    {
+      "name" : "stringParam",
+      "type" : "String?"
     }
   ],
   "root" : {
@@ -181,6 +211,13 @@
         "id" : "Label",
         "params" : {
           "text" : ""
+        },
+        "type" : "Lona:Text"
+      },
+      {
+        "id" : "StringParam",
+        "params" : {
+          "text" : "No string param"
         },
         "type" : "Lona:Text"
       }


### PR DESCRIPTION
## What

Optional component parameters now generate correct code for JS and Swift. When used in logic, they can be unwrapped with the `If let` statement.

Note: I'm not sure if optional custom types work -- they probably don't, but we can add that separately if needed. Default values for parameters don't do anything yet.

## Testing Plan

- [X] Tested this change locally
- [X] Checked that existing features work

@outdooricon 