### PR TITLE
Improve landing screen design

### DIFF
--- a/studio/LonaStudio/Generated/components/OpenProjectButton.swift
+++ b/studio/LonaStudio/Generated/components/OpenProjectButton.swift
@@ -49,6 +49,7 @@ public class OpenProjectButton: NSBox {
   private var innerView = NSBox()
   private var titleContainerView = NSBox()
   private var titleView = NSTextField(labelWithString: "")
+  private var dividerView = NSBox()
   private var plusContainerView = NSBox()
   private var plusView = NSImageView()
 
@@ -74,6 +75,9 @@ public class OpenProjectButton: NSBox {
     titleContainerView.boxType = .custom
     titleContainerView.borderType = .noBorder
     titleContainerView.contentViewMargins = .zero
+    dividerView.boxType = .custom
+    dividerView.borderType = .noBorder
+    dividerView.contentViewMargins = .zero
     plusContainerView.boxType = .custom
     plusContainerView.borderType = .noBorder
     plusContainerView.contentViewMargins = .zero
@@ -82,11 +86,13 @@ public class OpenProjectButton: NSBox {
     addSubview(topBorderView)
     addSubview(innerView)
     innerView.addSubview(titleContainerView)
+    innerView.addSubview(dividerView)
     innerView.addSubview(plusContainerView)
     titleContainerView.addSubview(titleView)
     plusContainerView.addSubview(plusView)
 
     topBorderView.fillColor = Colors.grey200
+    dividerView.fillColor = Colors.grey200
     plusView.image = #imageLiteral(resourceName: "icon-plus")
   }
 
@@ -95,6 +101,7 @@ public class OpenProjectButton: NSBox {
     topBorderView.translatesAutoresizingMaskIntoConstraints = false
     innerView.translatesAutoresizingMaskIntoConstraints = false
     titleContainerView.translatesAutoresizingMaskIntoConstraints = false
+    dividerView.translatesAutoresizingMaskIntoConstraints = false
     plusContainerView.translatesAutoresizingMaskIntoConstraints = false
     titleView.translatesAutoresizingMaskIntoConstraints = false
     plusView.translatesAutoresizingMaskIntoConstraints = false
@@ -110,7 +117,7 @@ public class OpenProjectButton: NSBox {
     let topBorderViewHeightAnchorConstraint = topBorderView.heightAnchor.constraint(equalToConstant: 1)
     let titleContainerViewLeadingAnchorConstraint = titleContainerView
       .leadingAnchor
-      .constraint(equalTo: innerView.leadingAnchor, constant: 20)
+      .constraint(equalTo: innerView.leadingAnchor, constant: 12)
     let titleContainerViewTopAnchorConstraint = titleContainerView
       .topAnchor
       .constraint(greaterThanOrEqualTo: innerView.topAnchor)
@@ -120,12 +127,18 @@ public class OpenProjectButton: NSBox {
     let titleContainerViewBottomAnchorConstraint = titleContainerView
       .bottomAnchor
       .constraint(lessThanOrEqualTo: innerView.bottomAnchor)
-    let plusContainerViewTrailingAnchorConstraint = plusContainerView
-      .trailingAnchor
-      .constraint(equalTo: innerView.trailingAnchor, constant: -20)
-    let plusContainerViewLeadingAnchorConstraint = plusContainerView
+    let dividerViewLeadingAnchorConstraint = dividerView
       .leadingAnchor
       .constraint(equalTo: titleContainerView.trailingAnchor, constant: 20)
+    let dividerViewTopAnchorConstraint = dividerView.topAnchor.constraint(equalTo: innerView.topAnchor)
+    let dividerViewCenterYAnchorConstraint = dividerView.centerYAnchor.constraint(equalTo: innerView.centerYAnchor)
+    let dividerViewBottomAnchorConstraint = dividerView.bottomAnchor.constraint(equalTo: innerView.bottomAnchor)
+    let plusContainerViewTrailingAnchorConstraint = plusContainerView
+      .trailingAnchor
+      .constraint(equalTo: innerView.trailingAnchor, constant: -16)
+    let plusContainerViewLeadingAnchorConstraint = plusContainerView
+      .leadingAnchor
+      .constraint(equalTo: dividerView.trailingAnchor, constant: 16)
     let plusContainerViewTopAnchorConstraint = plusContainerView
       .topAnchor
       .constraint(greaterThanOrEqualTo: innerView.topAnchor)
@@ -141,6 +154,7 @@ public class OpenProjectButton: NSBox {
     let titleViewTrailingAnchorConstraint = titleView
       .trailingAnchor
       .constraint(lessThanOrEqualTo: titleContainerView.trailingAnchor)
+    let dividerViewWidthAnchorConstraint = dividerView.widthAnchor.constraint(equalToConstant: 1)
     let plusViewWidthAnchorParentConstraint = plusView
       .widthAnchor
       .constraint(lessThanOrEqualTo: plusContainerView.widthAnchor)
@@ -166,6 +180,10 @@ public class OpenProjectButton: NSBox {
       titleContainerViewTopAnchorConstraint,
       titleContainerViewCenterYAnchorConstraint,
       titleContainerViewBottomAnchorConstraint,
+      dividerViewLeadingAnchorConstraint,
+      dividerViewTopAnchorConstraint,
+      dividerViewCenterYAnchorConstraint,
+      dividerViewBottomAnchorConstraint,
       plusContainerViewTrailingAnchorConstraint,
       plusContainerViewLeadingAnchorConstraint,
       plusContainerViewTopAnchorConstraint,
@@ -175,6 +193,7 @@ public class OpenProjectButton: NSBox {
       titleViewBottomAnchorConstraint,
       titleViewLeadingAnchorConstraint,
       titleViewTrailingAnchorConstraint,
+      dividerViewWidthAnchorConstraint,
       plusViewWidthAnchorParentConstraint,
       plusViewTopAnchorConstraint,
       plusViewBottomAnchorConstraint,

--- a/studio/LonaStudio/Generated/components/RecentProjectsList.swift
+++ b/studio/LonaStudio/Generated/components/RecentProjectsList.swift
@@ -22,16 +22,61 @@ public class RecentProjectsList: NSBox {
 
   // MARK: Private
 
+  private var recentProjectItemView = RecentProjectItem()
+  private var recentProjectItem2View = RecentProjectItem()
+
   private func setUpViews() {
     boxType = .custom
     borderType = .noBorder
     contentViewMargins = .zero
 
-    fillColor = Colors.pink50
+    addSubview(recentProjectItemView)
+    addSubview(recentProjectItem2View)
+
+    recentProjectItemView.projectDirectoryPath = "~/Projects/ExampleWorkspace"
+    recentProjectItemView.projectName = "ExampleWorkspace"
+    recentProjectItemView.selected = false
+    recentProjectItem2View.projectDirectoryPath = "~/Projects/TestWorkspace"
+    recentProjectItem2View.projectName = "Test"
+    recentProjectItem2View.selected = false
   }
 
   private func setUpConstraints() {
     translatesAutoresizingMaskIntoConstraints = false
+    recentProjectItemView.translatesAutoresizingMaskIntoConstraints = false
+    recentProjectItem2View.translatesAutoresizingMaskIntoConstraints = false
+
+    let recentProjectItemViewTopAnchorConstraint = recentProjectItemView.topAnchor.constraint(equalTo: topAnchor)
+    let recentProjectItemViewLeadingAnchorConstraint = recentProjectItemView
+      .leadingAnchor
+      .constraint(equalTo: leadingAnchor)
+    let recentProjectItemViewTrailingAnchorConstraint = recentProjectItemView
+      .trailingAnchor
+      .constraint(equalTo: trailingAnchor)
+    let recentProjectItem2ViewTopAnchorConstraint = recentProjectItem2View
+      .topAnchor
+      .constraint(equalTo: recentProjectItemView.bottomAnchor)
+    let recentProjectItem2ViewLeadingAnchorConstraint = recentProjectItem2View
+      .leadingAnchor
+      .constraint(equalTo: leadingAnchor)
+    let recentProjectItem2ViewTrailingAnchorConstraint = recentProjectItem2View
+      .trailingAnchor
+      .constraint(equalTo: trailingAnchor)
+    let recentProjectItemViewHeightAnchorConstraint = recentProjectItemView.heightAnchor.constraint(equalToConstant: 54)
+    let recentProjectItem2ViewHeightAnchorConstraint = recentProjectItem2View
+      .heightAnchor
+      .constraint(equalToConstant: 54)
+
+    NSLayoutConstraint.activate([
+      recentProjectItemViewTopAnchorConstraint,
+      recentProjectItemViewLeadingAnchorConstraint,
+      recentProjectItemViewTrailingAnchorConstraint,
+      recentProjectItem2ViewTopAnchorConstraint,
+      recentProjectItem2ViewLeadingAnchorConstraint,
+      recentProjectItem2ViewTrailingAnchorConstraint,
+      recentProjectItemViewHeightAnchorConstraint,
+      recentProjectItem2ViewHeightAnchorConstraint
+    ])
   }
 
   private func update() {}

--- a/studio/LonaStudio/Generated/screens/Welcome.swift
+++ b/studio/LonaStudio/Generated/screens/Welcome.swift
@@ -37,8 +37,6 @@ public class Welcome: NSBox {
   private var rowsView = NSBox()
   private var newButtonView = IconRow()
   private var spacerView = NSBox()
-  private var exampleButtonView = IconRow()
-  private var spacer2View = NSBox()
   private var documentationButtonView = IconRow()
   private var dividerView = NSBox()
   private var projectsView = NSBox()
@@ -72,9 +70,6 @@ public class Welcome: NSBox {
     spacerView.boxType = .custom
     spacerView.borderType = .noBorder
     spacerView.contentViewMargins = .zero
-    spacer2View.boxType = .custom
-    spacer2View.borderType = .noBorder
-    spacer2View.contentViewMargins = .zero
 
     addSubview(splashView)
     addSubview(dividerView)
@@ -86,8 +81,6 @@ public class Welcome: NSBox {
     bannerView.addSubview(versionView)
     rowsView.addSubview(newButtonView)
     rowsView.addSubview(spacerView)
-    rowsView.addSubview(exampleButtonView)
-    rowsView.addSubview(spacer2View)
     rowsView.addSubview(documentationButtonView)
     projectsView.addSubview(recentProjectsListView)
     projectsView.addSubview(openProjectButtonView)
@@ -102,9 +95,6 @@ public class Welcome: NSBox {
     newButtonView.icon = #imageLiteral(resourceName: "icon-blank-document")
     newButtonView.subtitleText = "Set up a new design system"
     newButtonView.titleText = "Create a new Lona workspace"
-    exampleButtonView.icon = #imageLiteral(resourceName: "icon-material-design-example")
-    exampleButtonView.subtitleText = "Explore the material design example workspace"
-    exampleButtonView.titleText = "Open an example workspace"
     documentationButtonView.icon = #imageLiteral(resourceName: "icon-documentation")
     documentationButtonView.subtitleText = "Check out the documentation to learn how Lona works"
     documentationButtonView.titleText = "Explore documentation"
@@ -125,8 +115,6 @@ public class Welcome: NSBox {
     versionView.translatesAutoresizingMaskIntoConstraints = false
     newButtonView.translatesAutoresizingMaskIntoConstraints = false
     spacerView.translatesAutoresizingMaskIntoConstraints = false
-    exampleButtonView.translatesAutoresizingMaskIntoConstraints = false
-    spacer2View.translatesAutoresizingMaskIntoConstraints = false
     documentationButtonView.translatesAutoresizingMaskIntoConstraints = false
     recentProjectsListView.translatesAutoresizingMaskIntoConstraints = false
     openProjectButtonView.translatesAutoresizingMaskIntoConstraints = false
@@ -173,7 +161,7 @@ public class Welcome: NSBox {
     let openProjectButtonViewTrailingAnchorConstraint = openProjectButtonView
       .trailingAnchor
       .constraint(equalTo: projectsView.trailingAnchor)
-    let imageViewTopAnchorConstraint = imageView.topAnchor.constraint(equalTo: bannerView.topAnchor, constant: 60)
+    let imageViewTopAnchorConstraint = imageView.topAnchor.constraint(equalTo: bannerView.topAnchor, constant: 80)
     let imageViewCenterXAnchorConstraint = imageView.centerXAnchor.constraint(equalTo: bannerView.centerXAnchor)
     let titleViewTopAnchorConstraint = titleView.topAnchor.constraint(equalTo: imageView.bottomAnchor)
     let titleViewLeadingAnchorConstraint = titleView
@@ -205,26 +193,12 @@ public class Welcome: NSBox {
     let spacerViewTrailingAnchorConstraint = spacerView
       .trailingAnchor
       .constraint(equalTo: rowsView.trailingAnchor, constant: -24)
-    let exampleButtonViewTopAnchorConstraint = exampleButtonView.topAnchor.constraint(equalTo: spacerView.bottomAnchor)
-    let exampleButtonViewLeadingAnchorConstraint = exampleButtonView
-      .leadingAnchor
-      .constraint(equalTo: rowsView.leadingAnchor, constant: 24)
-    let exampleButtonViewTrailingAnchorConstraint = exampleButtonView
-      .trailingAnchor
-      .constraint(equalTo: rowsView.trailingAnchor, constant: -24)
-    let spacer2ViewTopAnchorConstraint = spacer2View.topAnchor.constraint(equalTo: exampleButtonView.bottomAnchor)
-    let spacer2ViewLeadingAnchorConstraint = spacer2View
-      .leadingAnchor
-      .constraint(equalTo: rowsView.leadingAnchor, constant: 24)
-    let spacer2ViewTrailingAnchorConstraint = spacer2View
-      .trailingAnchor
-      .constraint(equalTo: rowsView.trailingAnchor, constant: -24)
     let documentationButtonViewBottomAnchorConstraint = documentationButtonView
       .bottomAnchor
       .constraint(equalTo: rowsView.bottomAnchor)
     let documentationButtonViewTopAnchorConstraint = documentationButtonView
       .topAnchor
-      .constraint(equalTo: spacer2View.bottomAnchor)
+      .constraint(equalTo: spacerView.bottomAnchor)
     let documentationButtonViewLeadingAnchorConstraint = documentationButtonView
       .leadingAnchor
       .constraint(equalTo: rowsView.leadingAnchor, constant: 24)
@@ -234,7 +208,6 @@ public class Welcome: NSBox {
     let imageViewHeightAnchorConstraint = imageView.heightAnchor.constraint(equalToConstant: 128)
     let imageViewWidthAnchorConstraint = imageView.widthAnchor.constraint(equalToConstant: 128)
     let spacerViewHeightAnchorConstraint = spacerView.heightAnchor.constraint(equalToConstant: 4)
-    let spacer2ViewHeightAnchorConstraint = spacer2View.heightAnchor.constraint(equalToConstant: 4)
     let openProjectButtonViewHeightAnchorConstraint = openProjectButtonView.heightAnchor.constraint(equalToConstant: 48)
 
     NSLayoutConstraint.activate([
@@ -280,12 +253,6 @@ public class Welcome: NSBox {
       spacerViewTopAnchorConstraint,
       spacerViewLeadingAnchorConstraint,
       spacerViewTrailingAnchorConstraint,
-      exampleButtonViewTopAnchorConstraint,
-      exampleButtonViewLeadingAnchorConstraint,
-      exampleButtonViewTrailingAnchorConstraint,
-      spacer2ViewTopAnchorConstraint,
-      spacer2ViewLeadingAnchorConstraint,
-      spacer2ViewTrailingAnchorConstraint,
       documentationButtonViewBottomAnchorConstraint,
       documentationButtonViewTopAnchorConstraint,
       documentationButtonViewLeadingAnchorConstraint,
@@ -293,7 +260,6 @@ public class Welcome: NSBox {
       imageViewHeightAnchorConstraint,
       imageViewWidthAnchorConstraint,
       spacerViewHeightAnchorConstraint,
-      spacer2ViewHeightAnchorConstraint,
       openProjectButtonViewHeightAnchorConstraint
     ])
   }
@@ -302,7 +268,6 @@ public class Welcome: NSBox {
     newButtonView.onClick = onCreateProject
     openProjectButtonView.onPressPlus = onCreateProject
     openProjectButtonView.onPressTitle = onOpenProject
-    exampleButtonView.onClick = onOpenExample
     documentationButtonView.onClick = onOpenDocumentation
   }
 }

--- a/workspace/components/OpenProjectButton.component
+++ b/workspace/components/OpenProjectButton.component
@@ -9,6 +9,7 @@
   ],
   "examples" : [
     {
+      "id" : "Default",
       "name" : "Default",
       "params" : {
         "titleText" : "Open another project..."
@@ -102,6 +103,15 @@
             "type" : "Lona:View"
           },
           {
+            "id" : "Divider",
+            "params" : {
+              "alignSelf" : "stretch",
+              "backgroundColor" : "grey200",
+              "width" : 1
+            },
+            "type" : "Lona:View"
+          },
+          {
             "children" : [
               {
                 "id" : "Plus",
@@ -115,7 +125,8 @@
             ],
             "id" : "PlusContainer",
             "params" : {
-
+              "marginLeft" : 16,
+              "marginRight" : 4
             },
             "type" : "Lona:View"
           }
@@ -126,8 +137,8 @@
           "alignSelf" : "stretch",
           "flex" : 1,
           "flexDirection" : "row",
-          "paddingLeft" : 20,
-          "paddingRight" : 20
+          "paddingLeft" : 12,
+          "paddingRight" : 12
         },
         "type" : "Lona:View"
       }

--- a/workspace/components/RecentProjectsList.component
+++ b/workspace/components/RecentProjectsList.component
@@ -21,6 +21,7 @@
   ],
   "examples" : [
     {
+      "id" : "Default",
       "name" : "Default",
       "params" : {
 
@@ -34,10 +35,29 @@
 
   ],
   "root" : {
+    "children" : [
+      {
+        "id" : "RecentProjectItem",
+        "params" : {
+          "projectDirectoryPath" : "~\/Projects\/ExampleWorkspace",
+          "projectName" : "ExampleWorkspace",
+          "selected" : false
+        },
+        "type" : "RecentProjectItem"
+      },
+      {
+        "id" : "RecentProjectItem2",
+        "params" : {
+          "projectDirectoryPath" : "~\/Projects\/TestWorkspace",
+          "projectName" : "Test",
+          "selected" : false
+        },
+        "type" : "RecentProjectItem"
+      }
+    ],
     "id" : "View",
     "params" : {
       "alignSelf" : "stretch",
-      "backgroundColor" : "pink50",
       "flex" : 1
     },
     "type" : "Lona:View"

--- a/workspace/screens/Welcome.component
+++ b/workspace/screens/Welcome.component
@@ -9,6 +9,7 @@
   ],
   "examples" : [
     {
+      "id" : "Default",
       "name" : "Default",
       "params" : {
 
@@ -49,18 +50,6 @@
       "content" : [
         "parameters",
         "onOpenProject"
-      ],
-      "type" : "AssignExpr"
-    },
-    {
-      "assignee" : [
-        "layers",
-        "ExampleButton",
-        "onClick"
-      ],
-      "content" : [
-        "parameters",
-        "onOpenExample"
       ],
       "type" : "AssignExpr"
     },
@@ -140,8 +129,8 @@
               "alignItems" : "center",
               "alignSelf" : "stretch",
               "flex" : 1,
-              "paddingBottom" : 60,
-              "paddingTop" : 60
+              "paddingBottom" : 80,
+              "paddingTop" : 80
             },
             "type" : "Lona:View"
           },
@@ -158,23 +147,6 @@
               },
               {
                 "id" : "Spacer",
-                "params" : {
-                  "alignSelf" : "stretch",
-                  "height" : 4
-                },
-                "type" : "Lona:View"
-              },
-              {
-                "id" : "ExampleButton",
-                "params" : {
-                  "icon" : "file:\/\/.\/assets\/icon-material-design-example@2x.png",
-                  "subtitleText" : "Explore the material design example workspace",
-                  "titleText" : "Open an example workspace"
-                },
-                "type" : "IconRow"
-              },
-              {
-                "id" : "Spacer2",
                 "params" : {
                   "alignSelf" : "stretch",
                   "height" : 4


### PR DESCRIPTION
## What

- Adds a divider between "open" and "new"
- Removes link to material design workspace (on github)

## Testing Plan

- [X] Tested this change locally
- [X] Checked that existing features work
