### PR TITLE
Fix optional decoding

### DIFF
--- a/compiler/core/src/core/decode.re
+++ b/compiler/core/src/core/decode.re
@@ -260,11 +260,10 @@ let rec decodeExpr = json => {
       })
     | "LitExpr" =>
       LiteralExpression(
-        {
+        LonaValue.expandDecodedValue({
           ltype: json |> at(["value", "type"], Types.lonaType),
           data: json |> at(["value", "data"], json => json),
-        }
-        |> LonaValue.expandDecodedValue,
+        }),
       )
     | _ => raise(UnknownExprType(exprType))
     };

--- a/compiler/core/src/core/decode.re
+++ b/compiler/core/src/core/decode.re
@@ -187,7 +187,8 @@ module Layer = {
                |> field("params", list(Parameters.parameter))
                |> List.find((param: parameter) => param.name == key);
              switch (param) {
-             | _ => {ltype: param.ltype, data: value}
+             | _ =>
+               LonaValue.expandDecodedValue({ltype: param.ltype, data: value})
              | exception _ =>
                Js.log2("Unknown built-in parameter when deserializing:", key);
                raise(UnknownParameter(ParameterKey.toString(key)));
@@ -258,10 +259,13 @@ let rec decodeExpr = json => {
         "right": json |> field("right", decodeExpr),
       })
     | "LitExpr" =>
-      LiteralExpression({
-        ltype: json |> at(["value", "type"], Types.lonaType),
-        data: json |> at(["value", "data"], json => json),
-      })
+      LiteralExpression(
+        {
+          ltype: json |> at(["value", "type"], Types.lonaType),
+          data: json |> at(["value", "data"], json => json),
+        }
+        |> LonaValue.expandDecodedValue,
+      )
     | _ => raise(UnknownExprType(exprType))
     };
   };

--- a/compiler/core/src/core/lonaValue.re
+++ b/compiler/core/src/core/lonaValue.re
@@ -126,7 +126,8 @@ let decodeCollapsedOptional =
 
 /* Optional values are stored in 2 formats, depending on where they appear
    in the save file. Eventually these should be unified. One format is more compact,
-   using special cases of types to store less data.
+   using special cases of types to store less data. In this function, we convert
+   the compact format into the verbose format.
 
    E.g. in the more verbose format, Optional is specified as an object, { case, data }.
    In the compact format, we treat "null" data as the case "None" and just store

--- a/compiler/core/src/javaScript/javaScriptLogic.re
+++ b/compiler/core/src/javaScript/javaScriptLogic.re
@@ -7,7 +7,7 @@ let rec logicValueToJavaScriptAST = (config: Config.t, x: Logic.logicValue) =>
     switch (LonaValue.decodeOptional(lonaValue)) {
     | Some(value) => logicValueToJavaScriptAST(config, Literal(value))
     | None => Literal(LonaValue.null())
-    }
+    };
   | Literal(lonaValue) =>
     switch (lonaValue.ltype) {
     | Reference("Color")

--- a/compiler/core/src/javaScript/javaScriptLogic.re
+++ b/compiler/core/src/javaScript/javaScriptLogic.re
@@ -7,7 +7,7 @@ let rec logicValueToJavaScriptAST = (config: Config.t, x: Logic.logicValue) =>
     switch (LonaValue.decodeOptional(lonaValue)) {
     | Some(value) => logicValueToJavaScriptAST(config, Literal(value))
     | None => Literal(LonaValue.null())
-    };
+    }
   | Literal(lonaValue) =>
     switch (lonaValue.ltype) {
     | Reference("Color")

--- a/examples/generated/test/appkit/components/NestedOptionals.swift
+++ b/examples/generated/test/appkit/components/NestedOptionals.swift
@@ -1,0 +1,56 @@
+import AppKit
+import Foundation
+
+// MARK: - NestedOptionals
+
+public class NestedOptionals: NSBox {
+
+  // MARK: Lifecycle
+
+  public init() {
+    super.init(frame: .zero)
+
+    setUpViews()
+    setUpConstraints()
+
+    update()
+  }
+
+  public required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: Private
+
+  private var optionalsView = Optionals()
+
+  private func setUpViews() {
+    boxType = .custom
+    borderType = .noBorder
+    contentViewMargins = .zero
+
+    addSubview(optionalsView)
+
+    optionalsView.boolParam = nil
+    optionalsView.stringParam = "Text"
+  }
+
+  private func setUpConstraints() {
+    translatesAutoresizingMaskIntoConstraints = false
+    optionalsView.translatesAutoresizingMaskIntoConstraints = false
+
+    let optionalsViewTopAnchorConstraint = optionalsView.topAnchor.constraint(equalTo: topAnchor)
+    let optionalsViewBottomAnchorConstraint = optionalsView.bottomAnchor.constraint(equalTo: bottomAnchor)
+    let optionalsViewLeadingAnchorConstraint = optionalsView.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let optionalsViewTrailingAnchorConstraint = optionalsView.trailingAnchor.constraint(equalTo: trailingAnchor)
+
+    NSLayoutConstraint.activate([
+      optionalsViewTopAnchorConstraint,
+      optionalsViewBottomAnchorConstraint,
+      optionalsViewLeadingAnchorConstraint,
+      optionalsViewTrailingAnchorConstraint
+    ])
+  }
+
+  private func update() {}
+}

--- a/examples/generated/test/react-dom/components/NestedOptionals.js
+++ b/examples/generated/test/react-dom/components/NestedOptionals.js
@@ -1,0 +1,42 @@
+import React from "react"
+import styled, { ThemeProvider } from "styled-components"
+
+import colors from "../colors"
+import shadows from "../shadows"
+import textStyles from "../textStyles"
+import Optionals from "../logic/Optionals"
+
+export default class NestedOptionals extends React.Component {
+  render() {
+
+
+    let theme = { "view": { "normal": {} }, "optionals": { "normal": {} } }
+    return (
+      <ThemeProvider theme={theme}>
+        <div style={Object.assign({}, styles.view, {})}>
+          <div style={Object.assign({}, styles.optionals, {})}>
+            <Optionals boolParam={null} stringParam={"Text"} />
+          </div>
+        </div>
+      </ThemeProvider>
+    );
+  }
+};
+
+let styles = {
+  view: {
+    alignItems: "flex-start",
+    display: "flex",
+    flex: "1 1 0%",
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  optionals: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    display: "flex",
+    flex: "1 1 auto",
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  }
+}

--- a/examples/generated/test/react-native/components/NestedOptionals.js
+++ b/examples/generated/test/react-native/components/NestedOptionals.js
@@ -1,0 +1,36 @@
+import React from "react"
+import { View, StyleSheet } from "react-native"
+
+import colors from "../colors"
+import shadows from "../shadows"
+import textStyles from "../textStyles"
+import Optionals from "../logic/Optionals"
+
+export default class NestedOptionals extends React.Component {
+  render() {
+
+
+    return (
+      <View style={[ styles.view, {} ]}>
+        <Optionals boolParam={null} stringParam={"Text"} />
+      </View>
+    );
+  }
+};
+
+let styles = StyleSheet.create({
+  view: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  optionals: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  }
+})

--- a/examples/generated/test/sketchJs/components/NestedOptionals.js
+++ b/examples/generated/test/sketchJs/components/NestedOptionals.js
@@ -1,0 +1,36 @@
+import React from "react"
+import { View, StyleSheet, TextStyles } from "@mathieudutour/react-sketchapp"
+
+import colors from "../colors"
+import shadows from "../shadows"
+import textStyles from "../textStyles"
+import Optionals from "../logic/Optionals"
+
+export default class NestedOptionals extends React.Component {
+  render() {
+
+
+    return (
+      <View style={[ styles.view, {} ]}>
+        <Optionals boolParam={null} stringParam={"Text"} />
+      </View>
+    );
+  }
+};
+
+let styles = StyleSheet.create({
+  view: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  optionals: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  }
+})

--- a/examples/generated/test/swift/components/NestedOptionals.swift
+++ b/examples/generated/test/swift/components/NestedOptionals.swift
@@ -1,0 +1,52 @@
+import UIKit
+import Foundation
+
+// MARK: - NestedOptionals
+
+public class NestedOptionals: UIView {
+
+  // MARK: Lifecycle
+
+  public init() {
+    super.init(frame: .zero)
+
+    setUpViews()
+    setUpConstraints()
+
+    update()
+  }
+
+  public required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: Private
+
+  private var optionalsView = Optionals()
+
+  private func setUpViews() {
+    addSubview(optionalsView)
+
+    optionalsView.boolParam = nil
+    optionalsView.stringParam = "Text"
+  }
+
+  private func setUpConstraints() {
+    translatesAutoresizingMaskIntoConstraints = false
+    optionalsView.translatesAutoresizingMaskIntoConstraints = false
+
+    let optionalsViewTopAnchorConstraint = optionalsView.topAnchor.constraint(equalTo: topAnchor)
+    let optionalsViewBottomAnchorConstraint = optionalsView.bottomAnchor.constraint(equalTo: bottomAnchor)
+    let optionalsViewLeadingAnchorConstraint = optionalsView.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let optionalsViewTrailingAnchorConstraint = optionalsView.trailingAnchor.constraint(equalTo: trailingAnchor)
+
+    NSLayoutConstraint.activate([
+      optionalsViewTopAnchorConstraint,
+      optionalsViewBottomAnchorConstraint,
+      optionalsViewLeadingAnchorConstraint,
+      optionalsViewTrailingAnchorConstraint
+    ])
+  }
+
+  private func update() {}
+}

--- a/examples/test/components/NestedOptionals.component
+++ b/examples/test/components/NestedOptionals.component
@@ -1,0 +1,54 @@
+{
+  "devices" : [
+    {
+      "height" : 100,
+      "heightMode" : "At Least",
+      "name" : "iPhone SE",
+      "width" : 320
+    },
+    {
+      "height" : 100,
+      "heightMode" : "At Least",
+      "name" : "iPhone 7",
+      "width" : 375
+    },
+    {
+      "height" : 100,
+      "heightMode" : "At Least",
+      "name" : "iPhone 7+",
+      "width" : 414
+    }
+  ],
+  "examples" : [
+    {
+      "id" : "Default",
+      "name" : "Default",
+      "params" : {
+
+      }
+    }
+  ],
+  "logic" : [
+
+  ],
+  "params" : [
+
+  ],
+  "root" : {
+    "children" : [
+      {
+        "id" : "Optionals",
+        "params" : {
+          "boolParam" : null,
+          "stringParam" : "Text"
+        },
+        "type" : "Optionals"
+      }
+    ],
+    "id" : "View",
+    "params" : {
+      "alignSelf" : "stretch"
+    },
+    "type" : "Lona:View"
+  }
+}

--- a/examples/test/logic/Optionals.component
+++ b/examples/test/logic/Optionals.component
@@ -68,10 +68,7 @@
         "right" : {
           "type" : "LitExpr",
           "value" : {
-            "data" : {
-              "case" : "Some",
-              "data" : true
-            },
+            "data" : true,
             "type" : "Boolean?"
           }
         },
@@ -121,10 +118,7 @@
         "right" : {
           "type" : "LitExpr",
           "value" : {
-            "data" : {
-              "case" : "Some",
-              "data" : false
-            },
+            "data" : false,
             "type" : "Boolean?"
           }
         },
@@ -159,10 +153,7 @@
         "right" : {
           "type" : "LitExpr",
           "value" : {
-            "data" : {
-              "case" : "None",
-              "data" : null
-            },
+            "data" : null,
             "type" : "Boolean?"
           }
         },

--- a/studio/LonaStudio/Models/CSValue.swift
+++ b/studio/LonaStudio/Models/CSValue.swift
@@ -13,8 +13,16 @@ struct CSValue: Equatable, CSDataSerializable, CSDataDeserializable {
     var data: CSData
 
     init(_ data: CSData) {
+        self.init(data, expand: true)
+    }
+
+    init(_ data: CSData, expand: Bool) {
         self.type = CSType(data.get(key: "type"))
         self.data = data.get(key: "data")
+
+        if expand {
+            self.data = CSValue.expand(type: self.type, data: self.data)
+        }
     }
 
     init(type: CSType, data: CSData) {
@@ -115,10 +123,16 @@ struct CSValue: Equatable, CSDataSerializable, CSDataDeserializable {
     }
 
     func toData() -> CSData {
+        return self.toData(compact: false)
+    }
+
+    func toData(compact: Bool) -> CSData {
+        let data = compact ? CSValue.compact(type: type, data: self.data) : self.data
+
         return CSData.Object([
             "type": type.toData(),
             "data": data
-        ])
+            ])
     }
 
     func get(key: String) -> CSValue {

--- a/studio/LonaStudio/Models/LonaLogic.swift
+++ b/studio/LonaStudio/Models/LonaLogic.swift
@@ -168,7 +168,7 @@ indirect enum LonaExpression: CSDataSerializable, CSDataDeserializable {
                     right: LonaExpression(data.get(key: BinaryExpressionNode.Keys.right.rawValue)))
                 self = .binaryExpression(content)
             case .literalExpression:
-                self = .literalExpression(CSValue(data.get(key: "value")))
+                self = .literalExpression(CSValue(data.get(key: "value"), expand: true))
             }
         } else {
             self = .placeholderExpression
@@ -200,7 +200,7 @@ indirect enum LonaExpression: CSDataSerializable, CSDataDeserializable {
         case .literalExpression(let value):
             return CSData.Object([
                 "type": ExpressionType.literalExpression.toData(),
-                "value": value.toData()])
+                "value": value.toData(compact: true)])
         case .placeholderExpression:
             return CSData.Null
         }


### PR DESCRIPTION
## What

Optionals were sometimes encoded in 2 different formats. Now they should always be encoded in a single format. The change should be backwards compatible.

## Testing Plan

- [X] Tested this change locally
- [X] Checked that existing features work
