### PR TITLE
Improve save, save as, and duplicate menu commands

### DIFF
--- a/studio/LonaStudio/Models/ComponentDocument.swift
+++ b/studio/LonaStudio/Models/ComponentDocument.swift
@@ -21,7 +21,15 @@ class ComponentDocument: NSDocument {
         return true
     }
 
+    private var isDuplicating = false
+
+    // Returning nil disables autosaving.
+    // However, duplicate doesn't work correctly if we return nil. Workaround this by returning
+    // the correct documentType if we know we're duplicating.
     override var autosavingFileType: String? {
+        if isDuplicating {
+            return "DocumentType"
+        }
         return nil
     }
 
@@ -47,6 +55,13 @@ class ComponentDocument: NSDocument {
         }
 
         WorkspaceWindowController.create(andAttachTo: self)
+    }
+
+    override func duplicate() throws -> NSDocument {
+        isDuplicating = true
+        defer { isDuplicating = false }
+
+        return try super.duplicate()
     }
 
     override func writeSafely(to url: URL, ofType typeName: String, for saveOperation: NSDocument.SaveOperationType) throws {

--- a/studio/LonaStudio/Workspace/FileNavigator.swift
+++ b/studio/LonaStudio/Workspace/FileNavigator.swift
@@ -58,6 +58,10 @@ class FileNavigator: NSBox {
 
     // MARK: - Public
 
+    public func reloadData() {
+        fileTree.reloadData()
+    }
+
     public var rootPath: String
 
     public var titleText: String {

--- a/studio/LonaStudio/Workspace/WorkspaceViewController.swift
+++ b/studio/LonaStudio/Workspace/WorkspaceViewController.swift
@@ -657,6 +657,15 @@ extension WorkspaceViewController {
         createAndShowNewDocument(in: windowController)
     }
 
+    @objc func document(_ doc: NSDocument?, didSave: Bool, contextInfo: UnsafeMutableRawPointer?) {
+        update()
+        fileNavigator.reloadData()
+    }
+
+    @IBAction func saveDocument(_ sender: AnyObject) {
+        document?.save(withDelegate: self, didSave: #selector(document(_:didSave:contextInfo:)), contextInfo: nil)
+    }
+
     @IBAction func zoomToActualSize(_ sender: AnyObject) {
         componentEditorViewController.zoomToActualSize()
     }

--- a/studio/LonaStudio/Workspace/WorkspaceViewController.swift
+++ b/studio/LonaStudio/Workspace/WorkspaceViewController.swift
@@ -662,8 +662,40 @@ extension WorkspaceViewController {
         fileNavigator.reloadData()
     }
 
+    @objc func documentDidSaveAs(_ doc: NSDocument?, didSave: Bool, contextInfo: UnsafeMutableRawPointer?) {
+        update()
+        fileNavigator.reloadData()
+    }
+
+    @objc func document(_ doc: NSDocument?, didDuplicate: Bool, contextInfo: UnsafeMutableRawPointer?) {
+        update()
+        fileNavigator.reloadData()
+    }
+
     @IBAction func saveDocument(_ sender: AnyObject) {
-        document?.save(withDelegate: self, didSave: #selector(document(_:didSave:contextInfo:)), contextInfo: nil)
+        document?.save(
+            withDelegate: self,
+            didSave: #selector(document(_:didSave:contextInfo:)),
+            contextInfo: nil)
+    }
+
+    // https://developer.apple.com/documentation/appkit/nsdocument/1515171-saveas
+    // The default implementation runs the modal Save panel to get the file location under which
+    // to save the document. It writes the document to this file, sets the document’s file location
+    // and document type (if a native type), and clears the document’s edited status.
+    @IBAction func saveDocumentAs(_ sender: AnyObject) {
+        document?.runModalSavePanel(
+            for: .saveAsOperation,
+            delegate: self,
+            didSave: #selector(documentDidSaveAs(_:didSave:contextInfo:)),
+            contextInfo: nil)
+    }
+
+    @IBAction func duplicate(_ sender: AnyObject) {
+        document?.duplicate(
+            withDelegate: self,
+            didDuplicate: #selector(document(_:didDuplicate:contextInfo:)),
+            contextInfo: nil)
     }
 
     @IBAction func zoomToActualSize(_ sender: AnyObject) {


### PR DESCRIPTION
## What

The rest of the UI didn't update correctly after save and save as. Duplicate didn't work. Now they all work.

## Testing Plan

- [X] Tested this change locally
- [X] Checked that existing features work