### PR TITLE
Get rid of the sneaky semicolon

### DIFF
--- a/compiler/core/src/javaScript/javaScriptShadow.re
+++ b/compiler/core/src/javaScript/javaScriptShadow.re
@@ -22,10 +22,10 @@ let renderReactDom = (colors: list(Color.t), shadowsFile: Shadow.file) => {
               right: Identifier(["colors", color.id]),
             }),
           operator: Plus,
-          right: Literal(LonaValue.string(");")),
+          right: Literal(LonaValue.string(")")),
         })
       | None =>
-        Literal(LonaValue.string(dropShadowString ++ shadow.color ++ ");"))
+        Literal(LonaValue.string(dropShadowString ++ shadow.color ++ ")"))
       };
 
     Property({

--- a/examples/generated/test/react-dom/shadows.js
+++ b/examples/generated/test/react-dom/shadows.js
@@ -1,7 +1,7 @@
 import colors from "./colors"
 
 export default {
-  elevation1: { filter: "drop-shadow(0px 1px 2px rgba(0,0,0,0.5));" },
-  elevation2: { filter: "drop-shadow(0px 2px 4px rgba(0,0,0,0.5));" },
-  elevation3: { filter: "drop-shadow(0px 3px 9px " + colors.grey900 + ");" }
+  elevation1: { filter: "drop-shadow(0px 1px 2px rgba(0,0,0,0.5))" },
+  elevation2: { filter: "drop-shadow(0px 2px 4px rgba(0,0,0,0.5))" },
+  elevation3: { filter: "drop-shadow(0px 3px 9px " + colors.grey900 + ")" }
 };


### PR DESCRIPTION
## What

There was a bug in the filter that I added for shadows in JS. The semicolon caused it to be ignored by react. Now removed!

