### PR TITLE
Fix image types and dimensions for web

### DIFF
--- a/compiler/core/src/core/decode.re
+++ b/compiler/core/src/core/decode.re
@@ -74,7 +74,17 @@ module Types = {
         };
       Function(arguments, returnType);
     };
-    let referenceType = json => json |> string |> (x => Reference(x));
+    let referenceType = json =>
+      json
+      |> string
+      |> (
+        x =>
+          switch (x) {
+          | "URL" => Types.urlType
+          | "Color" => Types.colorType
+          | _ => Reference(x)
+          }
+      );
     let otherType = json => {
       let name = field("name", string, json);
       switch (name) {

--- a/compiler/core/src/core/layer.re
+++ b/compiler/core/src/core/layer.re
@@ -52,7 +52,9 @@ let getParameterCategory = (x: ParameterKey.t) =>
   | PaddingBottom => Style
   | PaddingLeft => Style
   | Width => Style
+  | MaxWidth => Style
   | Height => Style
+  | MaxHeight => Style
   | BackgroundColor => Style
   | BorderColor => Style
   | BorderRadius => Style

--- a/compiler/core/src/core/parameterKey.re
+++ b/compiler/core/src/core/parameterKey.re
@@ -32,7 +32,9 @@ type t =
   | BorderColor
   | Shadow
   | Width
+  | MaxWidth
   | Height
+  | MaxHeight
   /* Interactivity */
   | Pressed
   | Hovered
@@ -71,7 +73,9 @@ let fromString = string =>
   | "borderColor" => BorderColor
   | "shadow" => Shadow
   | "width" => Width
+  | "maxWidth" => Width
   | "height" => Height
+  | "maxHeight" => Height
   /* Interactivity */
   | "pressed" => Pressed
   | "hovered" => Hovered
@@ -112,7 +116,9 @@ let toString = key =>
   | BorderColor => "borderColor"
   | Shadow => "shadow"
   | Width => "width"
+  | MaxWidth => "maxWidth"
   | Height => "height"
+  | MaxHeight => "maxHeight"
   /* Interactivity */
   | Pressed => "pressed"
   | Hovered => "hovered"

--- a/compiler/core/src/javaScript/javaScriptComponent.re
+++ b/compiler/core/src/javaScript/javaScriptComponent.re
@@ -260,10 +260,14 @@ let rec layerToJavaScriptAST =
     |> removeSpecialParams
     |> Layer.mapBindings(((key, value)) => {
          let key =
-           switch (framework) {
-           | JavaScriptOptions.ReactDOM =>
-             key |> ReactDomTranslators.variableNames
-           | _ => key |> ReactNativeTranslators.variableNames
+           if (Layer.isPrimitiveTypeName(layer.typeName)) {
+             switch (framework) {
+             | JavaScriptOptions.ReactDOM =>
+               key |> ReactDomTranslators.variableNames
+             | _ => key |> ReactNativeTranslators.variableNames
+             };
+           } else {
+             key |> ParameterKey.toString;
            };
 
          let attributeValue =

--- a/compiler/core/src/javaScript/javaScriptStyles.re
+++ b/compiler/core/src/javaScript/javaScriptStyles.re
@@ -319,6 +319,30 @@ let getLayoutParameters =
         )
       );
 
+    /* Images inherit width and height */
+    let parameters =
+      ParameterMap.(
+        if (framework == ReactDOM && layer.typeName == Image) {
+          let parameters =
+            switch (layout.width) {
+            | Fixed(_) => parameters
+            | Fill
+            | FitContent =>
+              parameters |> add(MaxWidth, LonaValue.string("100%"))
+            };
+          let parameters =
+            switch (layout.height) {
+            | Fixed(_) => parameters
+            | Fill
+            | FitContent =>
+              parameters |> add(MaxHeight, LonaValue.string("100%"))
+            };
+          parameters;
+        } else {
+          parameters;
+        }
+      );
+
     parameters;
   };
 };

--- a/compiler/core/src/javaScript/javaScriptStyles.re
+++ b/compiler/core/src/javaScript/javaScriptStyles.re
@@ -319,7 +319,8 @@ let getLayoutParameters =
         )
       );
 
-    /* Images inherit width and height */
+    /* Images should not expand outside their parent, even if their natural size
+       exceeds the size of their parent. */
     let parameters =
       ParameterMap.(
         if (framework == ReactDOM && layer.typeName == Image) {

--- a/studio/LonaStudio/Models/CSLayer.swift
+++ b/studio/LonaStudio/Models/CSLayer.swift
@@ -538,6 +538,7 @@ class CSLayer: CSDataDeserializable, CSDataSerializable, DataNode, NSCopying {
 
     static let defaultParameterValue: [String: CSData] = [
         "alignItems": CSData.String("flex-start"),
+        "aspectRatio": CSData.Number(-1),
         "borderRadius": CSData.Number(0),
         "borderWidth": CSData.Number(0),
         "flex": CSData.Number(0),

--- a/studio/LonaStudio/Workspace/Inspector View/CustomComponentInspectorView.swift
+++ b/studio/LonaStudio/Workspace/Inspector View/CustomComponentInspectorView.swift
@@ -77,6 +77,16 @@ final class CustomComponentInspectorView: NSStackView {
                 CSValueField.Options.usesYogaLayout: usesYogaLayout
                 ])
             valueField.onChangeData = {[unowned self] data in
+                var data = data
+
+                if case .named("URL", .string) = value.type, let url = URL(string: data.stringValue) {
+                    if let relativePath = url.path.pathRelativeTo(basePath: CSUserPreferences.workspaceURL.path) {
+                        data = ("file://" + relativePath).toData()
+                    } else {
+                        data = url.absoluteString.toData()
+                    }
+                }
+
                 self.onChangeData(data, parameter)
             }
             valueField.view.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
## What

- Image elements were sometimes expanding outside their parent element on web
- Images set as custom component parameters incorrectly used absolute paths instead of relative paths
- Parameter types were loaded inconsistently

## Testing Plan

- [X] Tested this change locally
- [X] Checked that existing features work

cc @outdooricon 
