### PR TITLE
Turn numberOflines into maxheight for react-dom

### DIFF
--- a/compiler/core/src/core/layer.re
+++ b/compiler/core/src/core/layer.re
@@ -47,6 +47,7 @@ let getParameterCategory = (x: ParameterKey.t) =>
   | MarginRight => Style
   | MarginBottom => Style
   | MarginLeft => Style
+  | Overflow => Style
   | PaddingTop => Style
   | PaddingRight => Style
   | PaddingBottom => Style

--- a/compiler/core/src/core/parameterKey.re
+++ b/compiler/core/src/core/parameterKey.re
@@ -23,6 +23,7 @@ type t =
   | MarginRight
   | MarginBottom
   | MarginLeft
+  | Overflow
   | PaddingTop
   | PaddingRight
   | PaddingBottom
@@ -64,6 +65,7 @@ let fromString = string =>
   | "marginRight" => MarginRight
   | "marginBottom" => MarginBottom
   | "marginLeft" => MarginLeft
+  | "overflow" => Overflow
   | "paddingTop" => PaddingTop
   | "paddingRight" => PaddingRight
   | "paddingBottom" => PaddingBottom
@@ -107,6 +109,7 @@ let toString = key =>
   | MarginRight => "marginRight"
   | MarginBottom => "marginBottom"
   | MarginLeft => "marginLeft"
+  | Overflow => "overflow"
   | PaddingTop => "paddingTop"
   | PaddingRight => "paddingRight"
   | PaddingBottom => "paddingBottom"

--- a/compiler/core/src/javaScript/javaScriptComponent.re
+++ b/compiler/core/src/javaScript/javaScriptComponent.re
@@ -227,11 +227,13 @@ let rec layerToJavaScriptAST =
   let removeSpecialParams = params =>
     params
     |> ParameterMap.filter((key: ParameterKey.t, _) =>
-         switch (key) {
-         | ParameterKey.Text => false
-         | ParameterKey.Visible => false
-         | ParameterKey.Image when layer.typeName == VectorGraphic => false
-         | _ => true
+         switch (key, framework) {
+         | (ParameterKey.NumberOfLines, JavaScriptOptions.ReactDOM) => false
+         | (ParameterKey.Text, _) => false
+         | (ParameterKey.Visible, _) => false
+         | (ParameterKey.Image, _) when layer.typeName == VectorGraphic =>
+           false
+         | (_, _) => true
          }
        );
   let (_, mainParams) =

--- a/compiler/core/src/javaScript/javaScriptStyles.re
+++ b/compiler/core/src/javaScript/javaScriptStyles.re
@@ -376,7 +376,7 @@ let handleNumberOfLines =
     ParameterMap.find_opt(ParameterKey.NumberOfLines, parameters),
   ) {
   | (JavaScriptOptions.ReactDOM, Some(lineCount)) =>
-    open Monads;
+    open Monad;
     let lineHeight =
       switch (
         ParameterMap.find_opt(ParameterKey.TextStyle, parameters)

--- a/compiler/core/src/javaScript/javaScriptStyles.re
+++ b/compiler/core/src/javaScript/javaScriptStyles.re
@@ -95,7 +95,9 @@ let defaultStyles =
     switch (framework, layerType) {
     | (JavaScriptOptions.ReactDOM, Types.Text) =>
       ParameterMap.(
-        defaults |> add(ParameterKey.Display, LonaValue.string("block"))
+        defaults
+        |> add(ParameterKey.Display, LonaValue.string("block"))
+        |> add(ParameterKey.TextAlign, LonaValue.string("left"))
       )
     | (JavaScriptOptions.ReactDOM, _) =>
       ParameterMap.(

--- a/compiler/core/src/javaScript/javaScriptStyles.re
+++ b/compiler/core/src/javaScript/javaScriptStyles.re
@@ -93,7 +93,10 @@ let defaultStyles =
 
   let defaults =
     switch (framework, layerType) {
-    | (JavaScriptOptions.ReactDOM, Types.Text) => defaults
+    | (JavaScriptOptions.ReactDOM, Types.Text) =>
+      ParameterMap.(
+        defaults |> add(ParameterKey.Display, LonaValue.string("block"))
+      )
     | (JavaScriptOptions.ReactDOM, _) =>
       ParameterMap.(
         defaults |> add(ParameterKey.Display, LonaValue.string("flex"))
@@ -395,10 +398,6 @@ let handleNumberOfLines =
 
     parameters
     |> ParameterMap.remove(ParameterKey.NumberOfLines)
-    |> ParameterMap.add(
-         ParameterKey.Display,
-         LonaValue.string("inline-block"),
-       )
     |> ParameterMap.add(ParameterKey.Overflow, LonaValue.string("hidden"))
     |> ParameterMap.add(
          ParameterKey.MaxHeight,

--- a/compiler/core/src/javaScript/utils/reactDomTranslators.re
+++ b/compiler/core/src/javaScript/utils/reactDomTranslators.re
@@ -8,6 +8,8 @@ let isUnitNumberParameter = key =>
   | ParameterKey.MarginTop => true
   | ParameterKey.MarginRight => true
   | ParameterKey.MarginBottom => true
+  | ParameterKey.MaxHeight => true
+  | ParameterKey.MaxWidth => true
   | ParameterKey.MarginLeft => true
   | ParameterKey.PaddingTop => true
   | ParameterKey.PaddingRight => true

--- a/compiler/core/src/utils/monad.re
+++ b/compiler/core/src/utils/monad.re
@@ -4,4 +4,4 @@ let bindOption = (f: 'a => option('b), value: option('a)): option('b) =>
   | Some(a) => f(a)
   };
 
-let (>>=) = (x, y) => x |> (y |> bindOption);
+let (>>=) = (x, y) => bindOption(y, x);

--- a/compiler/core/src/utils/monads.re
+++ b/compiler/core/src/utils/monads.re
@@ -1,0 +1,7 @@
+let bindOption = (f: 'a => option('b), value: option('a)): option('b) =>
+  switch (value) {
+  | None => None
+  | Some(a) => f(a)
+  };
+
+let (>>=) = (x, y) => x |> (y |> bindOption);

--- a/examples/generated/test/appkit/style/TextAlignment.swift
+++ b/examples/generated/test/appkit/style/TextAlignment.swift
@@ -119,6 +119,7 @@ public class TextAlignment: NSBox {
     textView.attributedStringValue = textViewTextStyle.apply(to: "Welcome to Lona Studio")
     textViewTextStyle = TextStyles.display1.with(alignment: .center)
     textView.attributedStringValue = textViewTextStyle.apply(to: textView.attributedStringValue)
+    textView.maximumNumberOfLines = 2
     text1View.attributedStringValue = text1ViewTextStyle.apply(to: "Centered - Width: Fit")
     text1ViewTextStyle = TextStyles.subheading2.with(alignment: .center)
     text1View.attributedStringValue = text1ViewTextStyle.apply(to: text1View.attributedStringValue)

--- a/examples/generated/test/react-dom/components/NestedComponent.js
+++ b/examples/generated/test/react-dom/components/NestedComponent.js
@@ -48,6 +48,7 @@ let styles = {
   text: {
     ...textStyles.subheading2,
     alignItems: "flex-start",
+    display: "block",
     flex: "0 0 auto",
     flexDirection: "column",
     justifyContent: "flex-start",
@@ -64,6 +65,7 @@ let styles = {
   text1: {
     ...textStyles.body1,
     alignItems: "flex-start",
+    display: "block",
     flex: "0 0 auto",
     flexDirection: "column",
     justifyContent: "flex-start",
@@ -80,6 +82,7 @@ let styles = {
   text2: {
     ...textStyles.body1,
     alignItems: "flex-start",
+    display: "block",
     flex: "0 0 auto",
     flexDirection: "column",
     justifyContent: "flex-start"

--- a/examples/generated/test/react-dom/components/NestedComponent.js
+++ b/examples/generated/test/react-dom/components/NestedComponent.js
@@ -46,6 +46,7 @@ let styles = {
     paddingLeft: "10px"
   },
   text: {
+    textAlign: "left",
     ...textStyles.subheading2,
     alignItems: "flex-start",
     display: "block",
@@ -63,6 +64,7 @@ let styles = {
     justifyContent: "flex-start"
   },
   text1: {
+    textAlign: "left",
     ...textStyles.body1,
     alignItems: "flex-start",
     display: "block",
@@ -80,6 +82,7 @@ let styles = {
     justifyContent: "flex-start"
   },
   text2: {
+    textAlign: "left",
     ...textStyles.body1,
     alignItems: "flex-start",
     display: "block",

--- a/examples/generated/test/react-dom/interactivity/Button.js
+++ b/examples/generated/test/react-dom/interactivity/Button.js
@@ -56,6 +56,7 @@ let styles = {
   text: {
     ...textStyles.button,
     alignItems: "flex-start",
+    display: "block",
     flex: "0 0 auto",
     flexDirection: "column",
     justifyContent: "flex-start"

--- a/examples/generated/test/react-dom/interactivity/Button.js
+++ b/examples/generated/test/react-dom/interactivity/Button.js
@@ -54,6 +54,7 @@ let styles = {
     paddingLeft: "16px"
   },
   text: {
+    textAlign: "left",
     ...textStyles.button,
     alignItems: "flex-start",
     display: "block",

--- a/examples/generated/test/react-dom/interactivity/PressableRootView.js
+++ b/examples/generated/test/react-dom/interactivity/PressableRootView.js
@@ -86,6 +86,7 @@ let styles = {
     height: "100px"
   },
   innerText: {
+    textAlign: "left",
     ...textStyles.headline,
     alignItems: "flex-start",
     display: "block",

--- a/examples/generated/test/react-dom/interactivity/PressableRootView.js
+++ b/examples/generated/test/react-dom/interactivity/PressableRootView.js
@@ -88,6 +88,7 @@ let styles = {
   innerText: {
     ...textStyles.headline,
     alignItems: "flex-start",
+    display: "block",
     flex: "0 0 auto",
     flexDirection: "column",
     justifyContent: "flex-start"

--- a/examples/generated/test/react-dom/layouts/MultipleFlexText.js
+++ b/examples/generated/test/react-dom/layouts/MultipleFlexText.js
@@ -64,6 +64,7 @@ let styles = {
     justifyContent: "flex-start"
   },
   text: {
+    textAlign: "left",
     ...textStyles.body1,
     alignItems: "flex-start",
     alignSelf: "stretch",
@@ -81,6 +82,7 @@ let styles = {
     justifyContent: "flex-start"
   },
   text1: {
+    textAlign: "left",
     ...textStyles.body1,
     alignItems: "flex-start",
     alignSelf: "stretch",

--- a/examples/generated/test/react-dom/layouts/MultipleFlexText.js
+++ b/examples/generated/test/react-dom/layouts/MultipleFlexText.js
@@ -67,6 +67,7 @@ let styles = {
     ...textStyles.body1,
     alignItems: "flex-start",
     alignSelf: "stretch",
+    display: "block",
     flex: "0 0 auto",
     flexDirection: "column",
     justifyContent: "flex-start"
@@ -83,6 +84,7 @@ let styles = {
     ...textStyles.body1,
     alignItems: "flex-start",
     alignSelf: "stretch",
+    display: "block",
     flex: "0 0 auto",
     flexDirection: "column",
     justifyContent: "flex-start"

--- a/examples/generated/test/react-dom/layouts/PrimaryAxis.js
+++ b/examples/generated/test/react-dom/layouts/PrimaryAxis.js
@@ -75,6 +75,7 @@ let styles = {
     width: "100px"
   },
   text: {
+    textAlign: "left",
     ...textStyles.body1,
     alignItems: "flex-start",
     display: "block",

--- a/examples/generated/test/react-dom/layouts/PrimaryAxis.js
+++ b/examples/generated/test/react-dom/layouts/PrimaryAxis.js
@@ -77,6 +77,7 @@ let styles = {
   text: {
     ...textStyles.body1,
     alignItems: "flex-start",
+    display: "block",
     flex: "0 0 auto",
     flexDirection: "column",
     justifyContent: "flex-start"

--- a/examples/generated/test/react-dom/layouts/SecondaryAxis.js
+++ b/examples/generated/test/react-dom/layouts/SecondaryAxis.js
@@ -67,6 +67,7 @@ let styles = {
     height: "100px"
   },
   text: {
+    textAlign: "left",
     ...textStyles.body1,
     alignItems: "flex-start",
     display: "block",

--- a/examples/generated/test/react-dom/layouts/SecondaryAxis.js
+++ b/examples/generated/test/react-dom/layouts/SecondaryAxis.js
@@ -69,6 +69,7 @@ let styles = {
   text: {
     ...textStyles.body1,
     alignItems: "flex-start",
+    display: "block",
     flex: "0 0 auto",
     flexDirection: "column",
     justifyContent: "flex-start"

--- a/examples/generated/test/react-dom/logic/Assign.js
+++ b/examples/generated/test/react-dom/logic/Assign.js
@@ -31,6 +31,7 @@ let styles = {
   text: {
     ...textStyles.body1,
     alignItems: "flex-start",
+    display: "block",
     flex: "0 0 auto",
     flexDirection: "column",
     justifyContent: "flex-start"

--- a/examples/generated/test/react-dom/logic/Assign.js
+++ b/examples/generated/test/react-dom/logic/Assign.js
@@ -29,6 +29,7 @@ let styles = {
     justifyContent: "flex-start"
   },
   text: {
+    textAlign: "left",
     ...textStyles.body1,
     alignItems: "flex-start",
     display: "block",

--- a/examples/generated/test/react-dom/logic/Optionals.js
+++ b/examples/generated/test/react-dom/logic/Optionals.js
@@ -59,6 +59,7 @@ let styles = {
   label: {
     ...textStyles.body1,
     alignItems: "flex-start",
+    display: "block",
     flex: "0 0 auto",
     flexDirection: "column",
     justifyContent: "flex-start"
@@ -66,6 +67,7 @@ let styles = {
   stringParam: {
     ...textStyles.body1,
     alignItems: "flex-start",
+    display: "block",
     flex: "0 0 auto",
     flexDirection: "column",
     justifyContent: "flex-start"

--- a/examples/generated/test/react-dom/logic/Optionals.js
+++ b/examples/generated/test/react-dom/logic/Optionals.js
@@ -57,6 +57,7 @@ let styles = {
     justifyContent: "flex-start"
   },
   label: {
+    textAlign: "left",
     ...textStyles.body1,
     alignItems: "flex-start",
     display: "block",
@@ -65,6 +66,7 @@ let styles = {
     justifyContent: "flex-start"
   },
   stringParam: {
+    textAlign: "left",
     ...textStyles.body1,
     alignItems: "flex-start",
     display: "block",

--- a/examples/generated/test/react-dom/style/TextAlignment.js
+++ b/examples/generated/test/react-dom/style/TextAlignment.js
@@ -164,10 +164,13 @@ let styles = {
     ...textStyles.display1,
     alignItems: "flex-start",
     alignSelf: "stretch",
+    display: "inline-block",
     flex: "0 0 auto",
     flexDirection: "column",
     justifyContent: "flex-start",
-    marginTop: "16px"
+    marginTop: "16px",
+    overflow: "hidden",
+    maxHeight: "80px"
   },
   text1: {
     textAlign: "center",

--- a/examples/generated/test/react-dom/style/TextAlignment.js
+++ b/examples/generated/test/react-dom/style/TextAlignment.js
@@ -164,7 +164,7 @@ let styles = {
     ...textStyles.display1,
     alignItems: "flex-start",
     alignSelf: "stretch",
-    display: "inline-block",
+    display: "block",
     flex: "0 0 auto",
     flexDirection: "column",
     justifyContent: "flex-start",
@@ -176,6 +176,7 @@ let styles = {
     textAlign: "center",
     ...textStyles.subheading2,
     alignItems: "flex-start",
+    display: "block",
     flex: "0 0 auto",
     flexDirection: "column",
     justifyContent: "flex-start",
@@ -185,6 +186,7 @@ let styles = {
     ...textStyles.body1,
     alignItems: "flex-start",
     alignSelf: "stretch",
+    display: "block",
     flex: "0 0 auto",
     flexDirection: "column",
     justifyContent: "flex-start",
@@ -195,6 +197,7 @@ let styles = {
     ...textStyles.body1,
     alignItems: "flex-start",
     alignSelf: "stretch",
+    display: "block",
     flex: "0 0 auto",
     flexDirection: "column",
     justifyContent: "flex-start"
@@ -203,6 +206,7 @@ let styles = {
     textAlign: "center",
     ...textStyles.body1,
     alignItems: "flex-start",
+    display: "block",
     flex: "0 0 auto",
     flexDirection: "column",
     justifyContent: "flex-start",
@@ -211,6 +215,7 @@ let styles = {
   text5: {
     ...textStyles.body1,
     alignItems: "flex-start",
+    display: "block",
     flex: "0 0 auto",
     flexDirection: "column",
     justifyContent: "flex-start"
@@ -218,6 +223,7 @@ let styles = {
   text6: {
     ...textStyles.body1,
     alignItems: "flex-start",
+    display: "block",
     flex: "0 0 auto",
     flexDirection: "column",
     justifyContent: "flex-start"
@@ -226,6 +232,7 @@ let styles = {
     textAlign: "center",
     ...textStyles.body1,
     alignItems: "flex-start",
+    display: "block",
     flex: "0 0 auto",
     flexDirection: "column",
     justifyContent: "flex-start"
@@ -235,6 +242,7 @@ let styles = {
     ...textStyles.body1,
     alignItems: "flex-start",
     alignSelf: "stretch",
+    display: "block",
     flex: "0 0 auto",
     flexDirection: "column",
     justifyContent: "flex-start"
@@ -242,6 +250,7 @@ let styles = {
   text9: {
     ...textStyles.body1,
     alignItems: "flex-start",
+    display: "block",
     flex: "0 0 auto",
     flexDirection: "column",
     justifyContent: "flex-start"
@@ -251,6 +260,7 @@ let styles = {
     ...textStyles.body1,
     alignItems: "flex-start",
     alignSelf: "stretch",
+    display: "block",
     flex: "0 0 auto",
     flexDirection: "column",
     justifyContent: "flex-start"

--- a/examples/generated/test/react-dom/style/TextAlignment.js
+++ b/examples/generated/test/react-dom/style/TextAlignment.js
@@ -183,6 +183,7 @@ let styles = {
     marginTop: "16px"
   },
   text2: {
+    textAlign: "left",
     ...textStyles.body1,
     alignItems: "flex-start",
     alignSelf: "stretch",
@@ -213,6 +214,7 @@ let styles = {
     width: "80px"
   },
   text5: {
+    textAlign: "left",
     ...textStyles.body1,
     alignItems: "flex-start",
     display: "block",
@@ -221,6 +223,7 @@ let styles = {
     justifyContent: "flex-start"
   },
   text6: {
+    textAlign: "left",
     ...textStyles.body1,
     alignItems: "flex-start",
     display: "block",
@@ -248,6 +251,7 @@ let styles = {
     justifyContent: "flex-start"
   },
   text9: {
+    textAlign: "left",
     ...textStyles.body1,
     alignItems: "flex-start",
     display: "block",

--- a/examples/generated/test/react-dom/style/TextStyleConditional.js
+++ b/examples/generated/test/react-dom/style/TextStyleConditional.js
@@ -34,6 +34,7 @@ let styles = {
   text: {
     ...textStyles.headline,
     alignItems: "flex-start",
+    display: "block",
     flex: "0 0 auto",
     flexDirection: "column",
     justifyContent: "flex-start"

--- a/examples/generated/test/react-dom/style/TextStyleConditional.js
+++ b/examples/generated/test/react-dom/style/TextStyleConditional.js
@@ -32,6 +32,7 @@ let styles = {
     justifyContent: "flex-start"
   },
   text: {
+    textAlign: "left",
     ...textStyles.headline,
     alignItems: "flex-start",
     display: "block",

--- a/examples/generated/test/react-dom/style/TextStylesTest.js
+++ b/examples/generated/test/react-dom/style/TextStylesTest.js
@@ -59,6 +59,7 @@ let styles = {
     justifyContent: "flex-start"
   },
   text1: {
+    textAlign: "left",
     ...textStyles.display3,
     alignItems: "flex-start",
     display: "block",
@@ -67,6 +68,7 @@ let styles = {
     justifyContent: "flex-start"
   },
   text2: {
+    textAlign: "left",
     ...textStyles.display2,
     alignItems: "flex-start",
     display: "block",
@@ -75,6 +77,7 @@ let styles = {
     justifyContent: "flex-start"
   },
   text3: {
+    textAlign: "left",
     ...textStyles.display1,
     alignItems: "flex-start",
     display: "block",
@@ -110,6 +113,7 @@ let styles = {
     justifyContent: "flex-start"
   },
   text7: {
+    textAlign: "left",
     ...textStyles.body2,
     alignItems: "flex-start",
     display: "block",
@@ -118,6 +122,7 @@ let styles = {
     justifyContent: "flex-start"
   },
   text8: {
+    textAlign: "left",
     ...textStyles.body1,
     alignItems: "flex-start",
     display: "block",
@@ -126,6 +131,7 @@ let styles = {
     justifyContent: "flex-start"
   },
   text9: {
+    textAlign: "left",
     ...textStyles.caption,
     alignItems: "flex-start",
     display: "block",
@@ -134,6 +140,7 @@ let styles = {
     justifyContent: "flex-start"
   },
   text4: {
+    textAlign: "left",
     ...textStyles.headline,
     alignItems: "flex-start",
     display: "block",
@@ -142,6 +149,7 @@ let styles = {
     justifyContent: "flex-start"
   },
   text5: {
+    textAlign: "left",
     ...textStyles.subheading2,
     alignItems: "flex-start",
     display: "block",
@@ -150,6 +158,7 @@ let styles = {
     justifyContent: "flex-start"
   },
   text6: {
+    textAlign: "left",
     ...textStyles.subheading1,
     alignItems: "flex-start",
     display: "block",

--- a/examples/generated/test/react-dom/style/TextStylesTest.js
+++ b/examples/generated/test/react-dom/style/TextStylesTest.js
@@ -61,6 +61,7 @@ let styles = {
   text1: {
     ...textStyles.display3,
     alignItems: "flex-start",
+    display: "block",
     flex: "0 0 auto",
     flexDirection: "column",
     justifyContent: "flex-start"
@@ -68,6 +69,7 @@ let styles = {
   text2: {
     ...textStyles.display2,
     alignItems: "flex-start",
+    display: "block",
     flex: "0 0 auto",
     flexDirection: "column",
     justifyContent: "flex-start"
@@ -75,6 +77,7 @@ let styles = {
   text3: {
     ...textStyles.display1,
     alignItems: "flex-start",
+    display: "block",
     flex: "0 0 auto",
     flexDirection: "column",
     justifyContent: "flex-start"
@@ -109,6 +112,7 @@ let styles = {
   text7: {
     ...textStyles.body2,
     alignItems: "flex-start",
+    display: "block",
     flex: "0 0 auto",
     flexDirection: "column",
     justifyContent: "flex-start"
@@ -116,6 +120,7 @@ let styles = {
   text8: {
     ...textStyles.body1,
     alignItems: "flex-start",
+    display: "block",
     flex: "0 0 auto",
     flexDirection: "column",
     justifyContent: "flex-start"
@@ -123,6 +128,7 @@ let styles = {
   text9: {
     ...textStyles.caption,
     alignItems: "flex-start",
+    display: "block",
     flex: "0 0 auto",
     flexDirection: "column",
     justifyContent: "flex-start"
@@ -130,6 +136,7 @@ let styles = {
   text4: {
     ...textStyles.headline,
     alignItems: "flex-start",
+    display: "block",
     flex: "0 0 auto",
     flexDirection: "column",
     justifyContent: "flex-start"
@@ -137,6 +144,7 @@ let styles = {
   text5: {
     ...textStyles.subheading2,
     alignItems: "flex-start",
+    display: "block",
     flex: "0 0 auto",
     flexDirection: "column",
     justifyContent: "flex-start"
@@ -144,6 +152,7 @@ let styles = {
   text6: {
     ...textStyles.subheading1,
     alignItems: "flex-start",
+    display: "block",
     flex: "0 0 auto",
     flexDirection: "column",
     justifyContent: "flex-start"

--- a/examples/generated/test/react-dom/style/VisibilityTest.js
+++ b/examples/generated/test/react-dom/style/VisibilityTest.js
@@ -40,6 +40,7 @@ let styles = {
   title: {
     ...textStyles.body1,
     alignItems: "flex-start",
+    display: "block",
     flex: "0 0 auto",
     flexDirection: "column",
     justifyContent: "flex-start"

--- a/examples/generated/test/react-dom/style/VisibilityTest.js
+++ b/examples/generated/test/react-dom/style/VisibilityTest.js
@@ -38,6 +38,7 @@ let styles = {
     height: "100px"
   },
   title: {
+    textAlign: "left",
     ...textStyles.body1,
     alignItems: "flex-start",
     display: "block",

--- a/examples/generated/test/react-native/style/TextAlignment.js
+++ b/examples/generated/test/react-native/style/TextAlignment.js
@@ -18,7 +18,7 @@ export default class TextAlignment extends React.Component {
 
           />
           <View style={styles.view2} />
-          <Text style={styles.text}>
+          <Text style={styles.text} numberOfLines={2}>
             {"Welcome to Lona Studio"}
           </Text>
           <Text style={styles.text1}>

--- a/examples/generated/test/sketchJs/style/TextAlignment.js
+++ b/examples/generated/test/sketchJs/style/TextAlignment.js
@@ -19,7 +19,7 @@ export default class TextAlignment extends React.Component {
 
           />
           <View style={styles.view2} />
-          <Text style={styles.text}>
+          <Text style={styles.text} numberOfLines={2}>
             {"Welcome to Lona Studio"}
           </Text>
           <Text style={styles.text1}>

--- a/examples/generated/test/swift/style/TextAlignment.swift
+++ b/examples/generated/test/swift/style/TextAlignment.swift
@@ -56,7 +56,6 @@ public class TextAlignment: UIView {
   private var text10ViewTextStyle = TextStyles.body1.with(alignment: .center)
 
   private func setUpViews() {
-    textView.numberOfLines = 0
     text1View.numberOfLines = 0
     text2View.numberOfLines = 0
     text3View.numberOfLines = 0
@@ -95,6 +94,7 @@ public class TextAlignment: UIView {
     textView.attributedText = textViewTextStyle.apply(to: "Welcome to Lona Studio")
     textViewTextStyle = TextStyles.display1.with(alignment: .center)
     textView.attributedText = textViewTextStyle.apply(to: textView.attributedText ?? NSAttributedString())
+    textView.numberOfLines = 2
     text1View.attributedText = text1ViewTextStyle.apply(to: "Centered - Width: Fit")
     text1ViewTextStyle = TextStyles.subheading2.with(alignment: .center)
     text1View.attributedText = text1ViewTextStyle.apply(to: text1View.attributedText ?? NSAttributedString())

--- a/examples/test/style/TextAlignment.component
+++ b/examples/test/style/TextAlignment.component
@@ -45,7 +45,8 @@
               "alignSelf" : "stretch",
               "text" : "Welcome to Lona Studio",
               "textAlign" : "center",
-              "font" : "display1"
+              "font" : "display1",
+              "numberOfLines" : 2
             }
           },
           {


### PR DESCRIPTION
## What

Since react-dom doesn't know what to do with numberOfLines, for now we're going to use max-height to cut off the remaining text. Maxheight is calculated off of the line-height of the text style.