### PR TITLE
Fix nested swift component fill/fit layouts

### DIFF
--- a/compiler/core/src/containers/parameterMap.re
+++ b/compiler/core/src/containers/parameterMap.re
@@ -29,3 +29,11 @@ let assign = (base, extender) =>
     base,
     extender,
   );
+
+let toString = parameterMap =>
+  parameterMap
+  |> bindings
+  |> List.map(((key, value)) =>
+       (key |> ParameterKey.toString) ++ ": " ++ Js.String.make(value)
+     )
+  |> Format.joinWith("\n");

--- a/compiler/core/src/core/layer.re
+++ b/compiler/core/src/core/layer.re
@@ -451,7 +451,7 @@ let getTypeNames = rootLayer => {
    use the parameters of the custom component's root layer, since these
    determine layout. We should still use the type, name, and children of
    the custom component layer. */
-let getRootLayerForComponentName =
+let getProxyLayerForComponentName =
     (getComponent: string => Js.Json.t, layer: Types.layer, name): Types.layer => {
   let component = getComponent(name);
   let rootLayer = component |> Decode.Component.rootLayer(getComponent);
@@ -472,6 +472,6 @@ let getRootLayerForComponentName =
 let getProxyLayer = (getComponent: string => Js.Json.t, layer: Types.layer) =>
   switch (layer.typeName) {
   | Types.Component(name) =>
-    getRootLayerForComponentName(getComponent, layer, name)
+    getProxyLayerForComponentName(getComponent, layer, name)
   | _ => layer
   };

--- a/compiler/core/src/core/layout.re
+++ b/compiler/core/src/core/layout.re
@@ -52,4 +52,11 @@ module ToString = {
     | End => "flex-end"
     | Unspecified => "flex-start"
     };
+
+  let sizingRule = (value: sizingRule) =>
+    switch (value) {
+    | Fill => "fill"
+    | FitContent => "fitContent"
+    | Fixed(number) => "fixed(" ++ string_of_float(number) ++ ")"
+    };
 };

--- a/compiler/core/src/swift/swiftHelperClass.re
+++ b/compiler/core/src/swift/swiftHelperClass.re
@@ -110,7 +110,17 @@ let generateBackgroundImage =
           "block":
             Some(
               GetterBlock([
-                ReturnStatement(Some(SwiftIdentifier(".zero"))),
+                ReturnStatement(
+                  Some(
+                    SwiftAst.Builders.functionCall(
+                      ["CGSize"],
+                      [
+                        (Some("width"), ["UIViewNoIntrinsicMetric"]),
+                        (Some("height"), ["UIViewNoIntrinsicMetric"]),
+                      ],
+                    ),
+                  ),
+                ),
               ]),
             ),
         }),

--- a/examples/LonaViewer/LonaViewer.xcodeproj/project.pbxproj
+++ b/examples/LonaViewer/LonaViewer.xcodeproj/project.pbxproj
@@ -71,6 +71,12 @@
 		6B6D442D218F56B60016262C /* ImageCropping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6D442C218F56B60016262C /* ImageCropping.swift */; };
 		6B6D442F218F5D430016262C /* NSImage+Resizing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6D442E218F5D430016262C /* NSImage+Resizing.swift */; };
 		6B6D4431218F67840016262C /* LNAImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6D4430218F67840016262C /* LNAImageView.swift */; };
+		6B6D44372190B76B0016262C /* PrimaryAxisFillSiblings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6D44362190B76A0016262C /* PrimaryAxisFillSiblings.swift */; };
+		6B6D44392190C9C10016262C /* FillWidthFitHeightCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6D44382190C9C10016262C /* FillWidthFitHeightCard.swift */; };
+		6B6D443B2190D9860016262C /* PrimaryAxisFillNestedSiblings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6D443A2190D9860016262C /* PrimaryAxisFillNestedSiblings.swift */; };
+		6B6D443E2190EDC50016262C /* PrimaryAxisFillNestedSiblings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6D443C2190EDC50016262C /* PrimaryAxisFillNestedSiblings.swift */; };
+		6B6D443F2190EDC50016262C /* PrimaryAxisFillSiblings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6D443D2190EDC50016262C /* PrimaryAxisFillSiblings.swift */; };
+		6B6D44412190EE090016262C /* FillWidthFitHeightCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6D44402190EE090016262C /* FillWidthFitHeightCard.swift */; };
 		6BA5BBCF216D4A7D00F086A7 /* VisibilityTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA5BBCE216D4A7D00F086A7 /* VisibilityTest.swift */; };
 		6BA5BBD1216D4B6700F086A7 /* VisibilityTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA5BBD0216D4B6700F086A7 /* VisibilityTest.swift */; };
 		6BA5BBD3217017AC00F086A7 /* Optionals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA5BBD2217017AC00F086A7 /* Optionals.swift */; };
@@ -156,6 +162,12 @@
 		6B6D442C218F56B60016262C /* ImageCropping.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageCropping.swift; sourceTree = "<group>"; };
 		6B6D442E218F5D430016262C /* NSImage+Resizing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSImage+Resizing.swift"; sourceTree = "<group>"; };
 		6B6D4430218F67840016262C /* LNAImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LNAImageView.swift; sourceTree = "<group>"; };
+		6B6D44362190B76A0016262C /* PrimaryAxisFillSiblings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrimaryAxisFillSiblings.swift; sourceTree = "<group>"; };
+		6B6D44382190C9C10016262C /* FillWidthFitHeightCard.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FillWidthFitHeightCard.swift; sourceTree = "<group>"; };
+		6B6D443A2190D9860016262C /* PrimaryAxisFillNestedSiblings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrimaryAxisFillNestedSiblings.swift; sourceTree = "<group>"; };
+		6B6D443C2190EDC50016262C /* PrimaryAxisFillNestedSiblings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrimaryAxisFillNestedSiblings.swift; sourceTree = "<group>"; };
+		6B6D443D2190EDC50016262C /* PrimaryAxisFillSiblings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrimaryAxisFillSiblings.swift; sourceTree = "<group>"; };
+		6B6D44402190EE090016262C /* FillWidthFitHeightCard.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FillWidthFitHeightCard.swift; sourceTree = "<group>"; };
 		6BA5BBCE216D4A7D00F086A7 /* VisibilityTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VisibilityTest.swift; sourceTree = "<group>"; };
 		6BA5BBD0216D4B6700F086A7 /* VisibilityTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VisibilityTest.swift; sourceTree = "<group>"; };
 		6BA5BBD2217017AC00F086A7 /* Optionals.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Optionals.swift; sourceTree = "<group>"; };
@@ -310,11 +322,14 @@
 		12BBFDD1206B02720041620C /* layouts */ = {
 			isa = PBXGroup;
 			children = (
+				6B6D44402190EE090016262C /* FillWidthFitHeightCard.swift */,
 				12BBFDD2206B02720041620C /* FixedParentFillAndFitChildren.swift */,
 				12BBFDD3206B02720041620C /* FixedParentFitChild.swift */,
 				12BBFDD4206B02720041620C /* SecondaryAxis.swift */,
 				12BBFDD5206B02720041620C /* FitContentParentSecondaryChildren.swift */,
 				12BBFDD6206B02720041620C /* PrimaryAxis.swift */,
+				6B6D443C2190EDC50016262C /* PrimaryAxisFillNestedSiblings.swift */,
+				6B6D443D2190EDC50016262C /* PrimaryAxisFillSiblings.swift */,
 			);
 			path = layouts;
 			sourceTree = "<group>";
@@ -396,11 +411,14 @@
 		12BBFDF9206B02AC0041620C /* layouts */ = {
 			isa = PBXGroup;
 			children = (
+				6B6D44382190C9C10016262C /* FillWidthFitHeightCard.swift */,
 				12BBFDFA206B02AC0041620C /* FixedParentFillAndFitChildren.swift */,
 				12BBFDFB206B02AC0041620C /* FixedParentFitChild.swift */,
 				12BBFDFC206B02AC0041620C /* SecondaryAxis.swift */,
 				12BBFDFD206B02AC0041620C /* FitContentParentSecondaryChildren.swift */,
 				12BBFDFE206B02AC0041620C /* PrimaryAxis.swift */,
+				6B6D44362190B76A0016262C /* PrimaryAxisFillSiblings.swift */,
+				6B6D443A2190D9860016262C /* PrimaryAxisFillNestedSiblings.swift */,
 			);
 			path = layouts;
 			sourceTree = "<group>";
@@ -539,6 +557,7 @@
 				6B39170821643EF300B20F9E /* ShadowsTest.swift in Sources */,
 				12BBFE02206B02AC0041620C /* TextStyles.swift in Sources */,
 				6BA5BBD1216D4B6700F086A7 /* VisibilityTest.swift in Sources */,
+				6B6D44392190C9C10016262C /* FillWidthFitHeightCard.swift in Sources */,
 				12BBFE09206B02AC0041620C /* TextStylesTest.swift in Sources */,
 				12BBFE05206B02AC0041620C /* Assign.swift in Sources */,
 				6B39170A2164492600B20F9E /* Shadow.swift in Sources */,
@@ -550,6 +569,7 @@
 				12BBFE0A206B02AC0041620C /* TextStyleConditional.swift in Sources */,
 				6BFE720B21821A7300F8BEA0 /* RepeatedVector.swift in Sources */,
 				1296255E204B2DC20057CDFF /* DetailVC.swift in Sources */,
+				6B6D44372190B76B0016262C /* PrimaryAxisFillSiblings.swift in Sources */,
 				6BA69406208439DB0090CA74 /* NestedComponent.swift in Sources */,
 				12BBFE0E206B02AC0041620C /* SecondaryAxis.swift in Sources */,
 				6BA5BBD5217021A000F086A7 /* Optionals.swift in Sources */,
@@ -563,6 +583,7 @@
 				12BBFE06206B02AC0041620C /* If.swift in Sources */,
 				30F870BB20864AEE007ADA5B /* Button.swift in Sources */,
 				12BBFE08206B02AC0041620C /* BorderWidthColor.swift in Sources */,
+				6B6D443B2190D9860016262C /* PrimaryAxisFillNestedSiblings.swift in Sources */,
 				1286937B204A1AAA00E5E26F /* AppDelegate.swift in Sources */,
 				6B39170621643C7C00B20F9E /* Shadows.swift in Sources */,
 				12BBFE0C206B02AC0041620C /* FixedParentFillAndFitChildren.swift in Sources */,
@@ -580,6 +601,7 @@
 				12BBFDDC206B02720041620C /* LocalAsset.swift in Sources */,
 				6B391704216423A000B20F9E /* ShadowsTest.swift in Sources */,
 				6B6D4431218F67840016262C /* LNAImageView.swift in Sources */,
+				6B6D443E2190EDC50016262C /* PrimaryAxisFillNestedSiblings.swift in Sources */,
 				6B391702216422D400B20F9E /* Shadows.swift in Sources */,
 				6B6D4423218BCF150016262C /* LNATextField.swift in Sources */,
 				12BBFDE8206B02720041620C /* Colors.swift in Sources */,
@@ -591,6 +613,7 @@
 				12BBFDE5206B02720041620C /* SecondaryAxis.swift in Sources */,
 				12BBFDDE206B02720041620C /* If.swift in Sources */,
 				12BBFDE0206B02720041620C /* TextStylesTest.swift in Sources */,
+				6B6D443F2190EDC50016262C /* PrimaryAxisFillSiblings.swift in Sources */,
 				6BFE720F21821CFF00F8BEA0 /* RepeatedVector.swift in Sources */,
 				6BFE720D21821CF100F8BEA0 /* VectorLogic.swift in Sources */,
 				12BBFE14206B03FB0041620C /* LayoutExtension.swift in Sources */,
@@ -605,6 +628,7 @@
 				12BBFDE6206B02720041620C /* FitContentParentSecondaryChildren.swift in Sources */,
 				6BA5BBD3217017AC00F086A7 /* Optionals.swift in Sources */,
 				6B6D442B218F566B0016262C /* CGSize+Resizing.swift in Sources */,
+				6B6D44412190EE090016262C /* FillWidthFitHeightCard.swift in Sources */,
 				12BBFDE1206B02720041620C /* TextStyleConditional.swift in Sources */,
 				12BBFCF0206A8BCD0041620C /* Generated.swift in Sources */,
 				6BA694032082E4420090CA74 /* NestedComponent.swift in Sources */,
@@ -755,7 +779,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = iOS/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.Lona.app.iOS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -770,7 +794,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = iOS/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.Lona.app.iOS;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/examples/LonaViewer/MacOS/Generated.swift
+++ b/examples/LonaViewer/MacOS/Generated.swift
@@ -23,6 +23,8 @@ enum Generated: String {
     case fixedParentFillAndFitChildren = "Fixed Parent Fill and Fit Children"
     case fixedParentFitChild = "Fixed Parent Fit Child"
     case primaryAxis = "Primary Axis"
+    case primaryAxisFillSiblings = "Primary Fill Siblings"
+    case primaryAxisFillNestedSiblings = "Primary Fill Nested Siblings"
     case secondaryAxis = "Secondary Axis"
     case assign = "Assign"
     case ifEnabled = "If - Enabled"
@@ -54,6 +56,8 @@ enum Generated: String {
             fixedParentFillAndFitChildren,
             fixedParentFitChild,
             primaryAxis,
+            primaryAxisFillSiblings,
+            primaryAxisFillNestedSiblings,
             secondaryAxis,
             assign,
             ifEnabled,
@@ -135,6 +139,10 @@ enum Generated: String {
             return RepeatedVector(active: true)
         case .imageCropping:
             return ImageCropping()
+        case .primaryAxisFillSiblings:
+            return PrimaryAxisFillSiblings()
+        case .primaryAxisFillNestedSiblings:
+            return PrimaryAxisFillNestedSiblings()
         }
     }
 
@@ -152,6 +160,8 @@ enum Generated: String {
              .fixedParentFillAndFitChildren,
              .fixedParentFitChild,
              .primaryAxis,
+             .primaryAxisFillSiblings,
+             .primaryAxisFillNestedSiblings,
              .secondaryAxis,
              .borderWidthColor,
              .textAlignment,

--- a/examples/LonaViewer/iOS/Generated.swift
+++ b/examples/LonaViewer/iOS/Generated.swift
@@ -23,6 +23,8 @@ enum Generated: String {
     case fixedParentFillAndFitChildren = "Fixed Parent Fill and Fit Children"
     case fixedParentFitChild = "Fixed Parent Fit Child"
     case primaryAxis = "Primary Axis"
+    case primaryAxisFillSiblings = "Primary Fill Siblings"
+    case primaryAxisFillNestedSiblings = "Primary Fill Nested Siblings"
     case secondaryAxis = "Secondary Axis"
     case assign = "Assign"
     case ifEnabled = "If - Enabled"
@@ -54,6 +56,8 @@ enum Generated: String {
             fixedParentFillAndFitChildren,
             fixedParentFitChild,
             primaryAxis,
+            primaryAxisFillSiblings,
+            primaryAxisFillNestedSiblings,
             secondaryAxis,
             assign,
             ifEnabled,
@@ -135,6 +139,10 @@ enum Generated: String {
             return RepeatedVector(active: true)
         case .imageCropping:
             return ImageCropping()
+        case .primaryAxisFillSiblings:
+            return PrimaryAxisFillSiblings()
+        case .primaryAxisFillNestedSiblings:
+            return PrimaryAxisFillNestedSiblings()
         }
     }
 
@@ -151,6 +159,8 @@ enum Generated: String {
              .fixedParentFillAndFitChildren,
              .fixedParentFitChild,
              .primaryAxis,
+             .primaryAxisFillSiblings,
+             .primaryAxisFillNestedSiblings,
              .secondaryAxis,
              .borderWidthColor,
              .textAlignment,

--- a/examples/generated/test/appkit/layouts/FillWidthFitHeightCard.swift
+++ b/examples/generated/test/appkit/layouts/FillWidthFitHeightCard.swift
@@ -1,0 +1,98 @@
+import AppKit
+import Foundation
+
+// MARK: - ImageWithBackgroundColor
+
+private class ImageWithBackgroundColor: LNAImageView {
+  var fillColor = NSColor.clear
+
+  override func draw(_ dirtyRect: NSRect) {
+    fillColor.set()
+    bounds.fill()
+    super.draw(dirtyRect)
+  }
+}
+
+
+// MARK: - FillWidthFitHeightCard
+
+public class FillWidthFitHeightCard: NSBox {
+
+  // MARK: Lifecycle
+
+  public init() {
+    super.init(frame: .zero)
+
+    setUpViews()
+    setUpConstraints()
+
+    update()
+  }
+
+  public required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: Private
+
+  private var imageView = ImageWithBackgroundColor()
+  private var text1View = LNATextField(labelWithString: "")
+  private var textView = LNATextField(labelWithString: "")
+
+  private var text1ViewTextStyle = TextStyles.body2
+  private var textViewTextStyle = TextStyles.body1
+
+  private func setUpViews() {
+    boxType = .custom
+    borderType = .noBorder
+    contentViewMargins = .zero
+    text1View.lineBreakMode = .byWordWrapping
+    textView.lineBreakMode = .byWordWrapping
+
+    addSubview(imageView)
+    addSubview(text1View)
+    addSubview(textView)
+
+    imageView.image = #imageLiteral(resourceName: "icon_128x128")
+    imageView.fillColor = Colors.blue200
+    text1View.attributedStringValue = text1ViewTextStyle.apply(to: "Title")
+    text1ViewTextStyle = TextStyles.body2
+    text1View.attributedStringValue = text1ViewTextStyle.apply(to: text1View.attributedStringValue)
+    textView.attributedStringValue = textViewTextStyle.apply(to: "Subtitle")
+  }
+
+  private func setUpConstraints() {
+    translatesAutoresizingMaskIntoConstraints = false
+    imageView.translatesAutoresizingMaskIntoConstraints = false
+    text1View.translatesAutoresizingMaskIntoConstraints = false
+    textView.translatesAutoresizingMaskIntoConstraints = false
+
+    let imageViewTopAnchorConstraint = imageView.topAnchor.constraint(equalTo: topAnchor)
+    let imageViewLeadingAnchorConstraint = imageView.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let imageViewTrailingAnchorConstraint = imageView.trailingAnchor.constraint(equalTo: trailingAnchor)
+    let text1ViewTopAnchorConstraint = text1View.topAnchor.constraint(equalTo: imageView.bottomAnchor)
+    let text1ViewLeadingAnchorConstraint = text1View.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let text1ViewTrailingAnchorConstraint = text1View.trailingAnchor.constraint(equalTo: trailingAnchor)
+    let textViewBottomAnchorConstraint = textView.bottomAnchor.constraint(equalTo: bottomAnchor)
+    let textViewTopAnchorConstraint = textView.topAnchor.constraint(equalTo: text1View.bottomAnchor)
+    let textViewLeadingAnchorConstraint = textView.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let textViewTrailingAnchorConstraint = textView.trailingAnchor.constraint(equalTo: trailingAnchor)
+    let imageViewHeightAnchorConstraint = imageView.heightAnchor.constraint(equalToConstant: 100)
+
+    NSLayoutConstraint.activate([
+      imageViewTopAnchorConstraint,
+      imageViewLeadingAnchorConstraint,
+      imageViewTrailingAnchorConstraint,
+      text1ViewTopAnchorConstraint,
+      text1ViewLeadingAnchorConstraint,
+      text1ViewTrailingAnchorConstraint,
+      textViewBottomAnchorConstraint,
+      textViewTopAnchorConstraint,
+      textViewLeadingAnchorConstraint,
+      textViewTrailingAnchorConstraint,
+      imageViewHeightAnchorConstraint
+    ])
+  }
+
+  private func update() {}
+}

--- a/examples/generated/test/appkit/layouts/PrimaryAxisFillNestedSiblings.swift
+++ b/examples/generated/test/appkit/layouts/PrimaryAxisFillNestedSiblings.swift
@@ -1,0 +1,127 @@
+import AppKit
+import Foundation
+
+// MARK: - PrimaryAxisFillNestedSiblings
+
+public class PrimaryAxisFillNestedSiblings: NSBox {
+
+  // MARK: Lifecycle
+
+  public init() {
+    super.init(frame: .zero)
+
+    setUpViews()
+    setUpConstraints()
+
+    update()
+  }
+
+  public required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: Private
+
+  private var horizontalView = NSBox()
+  private var leftCardView = FillWidthFitHeightCard()
+  private var spacerView = NSBox()
+  private var rightCardView = FillWidthFitHeightCard()
+
+  private func setUpViews() {
+    boxType = .custom
+    borderType = .noBorder
+    contentViewMargins = .zero
+    horizontalView.boxType = .custom
+    horizontalView.borderType = .noBorder
+    horizontalView.contentViewMargins = .zero
+    spacerView.boxType = .custom
+    spacerView.borderType = .noBorder
+    spacerView.contentViewMargins = .zero
+
+    addSubview(horizontalView)
+    horizontalView.addSubview(leftCardView)
+    horizontalView.addSubview(spacerView)
+    horizontalView.addSubview(rightCardView)
+
+    fillColor = Colors.teal50
+    horizontalView.fillColor = Colors.teal100
+  }
+
+  private func setUpConstraints() {
+    translatesAutoresizingMaskIntoConstraints = false
+    horizontalView.translatesAutoresizingMaskIntoConstraints = false
+    leftCardView.translatesAutoresizingMaskIntoConstraints = false
+    spacerView.translatesAutoresizingMaskIntoConstraints = false
+    rightCardView.translatesAutoresizingMaskIntoConstraints = false
+
+    let horizontalViewTopAnchorConstraint = horizontalView.topAnchor.constraint(equalTo: topAnchor, constant: 10)
+    let horizontalViewBottomAnchorConstraint = horizontalView
+      .bottomAnchor
+      .constraint(equalTo: bottomAnchor, constant: -10)
+    let horizontalViewLeadingAnchorConstraint = horizontalView
+      .leadingAnchor
+      .constraint(equalTo: leadingAnchor, constant: 10)
+    let horizontalViewTrailingAnchorConstraint = horizontalView
+      .trailingAnchor
+      .constraint(equalTo: trailingAnchor, constant: -10)
+    let leftCardViewRightCardViewWidthAnchorSiblingConstraint = leftCardView
+      .widthAnchor
+      .constraint(equalTo: rightCardView.widthAnchor)
+    let leftCardViewHeightAnchorParentConstraint = leftCardView
+      .heightAnchor
+      .constraint(lessThanOrEqualTo: horizontalView.heightAnchor)
+    let spacerViewHeightAnchorParentConstraint = spacerView
+      .heightAnchor
+      .constraint(lessThanOrEqualTo: horizontalView.heightAnchor)
+    let rightCardViewHeightAnchorParentConstraint = rightCardView
+      .heightAnchor
+      .constraint(lessThanOrEqualTo: horizontalView.heightAnchor)
+    let leftCardViewLeadingAnchorConstraint = leftCardView
+      .leadingAnchor
+      .constraint(equalTo: horizontalView.leadingAnchor)
+    let leftCardViewTopAnchorConstraint = leftCardView.topAnchor.constraint(equalTo: horizontalView.topAnchor)
+    let leftCardViewBottomAnchorConstraint = leftCardView.bottomAnchor.constraint(equalTo: horizontalView.bottomAnchor)
+    let spacerViewLeadingAnchorConstraint = spacerView.leadingAnchor.constraint(equalTo: leftCardView.trailingAnchor)
+    let spacerViewTopAnchorConstraint = spacerView.topAnchor.constraint(equalTo: horizontalView.topAnchor)
+    let rightCardViewTrailingAnchorConstraint = rightCardView
+      .trailingAnchor
+      .constraint(equalTo: horizontalView.trailingAnchor)
+    let rightCardViewLeadingAnchorConstraint = rightCardView
+      .leadingAnchor
+      .constraint(equalTo: spacerView.trailingAnchor)
+    let rightCardViewTopAnchorConstraint = rightCardView.topAnchor.constraint(equalTo: horizontalView.topAnchor)
+    let rightCardViewBottomAnchorConstraint = rightCardView
+      .bottomAnchor
+      .constraint(equalTo: horizontalView.bottomAnchor)
+    let spacerViewHeightAnchorConstraint = spacerView.heightAnchor.constraint(equalToConstant: 0)
+    let spacerViewWidthAnchorConstraint = spacerView.widthAnchor.constraint(equalToConstant: 8)
+
+    leftCardViewHeightAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
+    spacerViewHeightAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
+    rightCardViewHeightAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
+
+    NSLayoutConstraint.activate([
+      horizontalViewTopAnchorConstraint,
+      horizontalViewBottomAnchorConstraint,
+      horizontalViewLeadingAnchorConstraint,
+      horizontalViewTrailingAnchorConstraint,
+      leftCardViewRightCardViewWidthAnchorSiblingConstraint,
+      leftCardViewHeightAnchorParentConstraint,
+      spacerViewHeightAnchorParentConstraint,
+      rightCardViewHeightAnchorParentConstraint,
+      leftCardViewLeadingAnchorConstraint,
+      leftCardViewTopAnchorConstraint,
+      leftCardViewBottomAnchorConstraint,
+      spacerViewLeadingAnchorConstraint,
+      spacerViewTopAnchorConstraint,
+      rightCardViewTrailingAnchorConstraint,
+      rightCardViewLeadingAnchorConstraint,
+      rightCardViewTopAnchorConstraint,
+      rightCardViewBottomAnchorConstraint,
+      spacerViewHeightAnchorConstraint,
+      spacerViewWidthAnchorConstraint
+    ])
+  }
+
+  private func update() {}
+}

--- a/examples/generated/test/appkit/layouts/PrimaryAxisFillSiblings.swift
+++ b/examples/generated/test/appkit/layouts/PrimaryAxisFillSiblings.swift
@@ -1,0 +1,240 @@
+import AppKit
+import Foundation
+
+// MARK: - ImageWithBackgroundColor
+
+private class ImageWithBackgroundColor: LNAImageView {
+  var fillColor = NSColor.clear
+
+  override func draw(_ dirtyRect: NSRect) {
+    fillColor.set()
+    bounds.fill()
+    super.draw(dirtyRect)
+  }
+}
+
+
+// MARK: - PrimaryAxisFillSiblings
+
+public class PrimaryAxisFillSiblings: NSBox {
+
+  // MARK: Lifecycle
+
+  public init() {
+    super.init(frame: .zero)
+
+    setUpViews()
+    setUpConstraints()
+
+    update()
+  }
+
+  public required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: Private
+
+  private var horizontalView = NSBox()
+  private var leftCardView = NSBox()
+  private var imageView = ImageWithBackgroundColor()
+  private var titleView = LNATextField(labelWithString: "")
+  private var subtitleView = LNATextField(labelWithString: "")
+  private var spacerView = NSBox()
+  private var rightCardView = NSBox()
+  private var image1View = ImageWithBackgroundColor()
+  private var title1View = LNATextField(labelWithString: "")
+  private var subtitle1View = LNATextField(labelWithString: "")
+
+  private var titleViewTextStyle = TextStyles.body2
+  private var subtitleViewTextStyle = TextStyles.body1
+  private var title1ViewTextStyle = TextStyles.body2
+  private var subtitle1ViewTextStyle = TextStyles.body1
+
+  private func setUpViews() {
+    boxType = .custom
+    borderType = .noBorder
+    contentViewMargins = .zero
+    horizontalView.boxType = .custom
+    horizontalView.borderType = .noBorder
+    horizontalView.contentViewMargins = .zero
+    leftCardView.boxType = .custom
+    leftCardView.borderType = .noBorder
+    leftCardView.contentViewMargins = .zero
+    spacerView.boxType = .custom
+    spacerView.borderType = .noBorder
+    spacerView.contentViewMargins = .zero
+    rightCardView.boxType = .custom
+    rightCardView.borderType = .noBorder
+    rightCardView.contentViewMargins = .zero
+    titleView.lineBreakMode = .byWordWrapping
+    subtitleView.lineBreakMode = .byWordWrapping
+    title1View.lineBreakMode = .byWordWrapping
+    subtitle1View.lineBreakMode = .byWordWrapping
+
+    addSubview(horizontalView)
+    horizontalView.addSubview(leftCardView)
+    horizontalView.addSubview(spacerView)
+    horizontalView.addSubview(rightCardView)
+    leftCardView.addSubview(imageView)
+    leftCardView.addSubview(titleView)
+    leftCardView.addSubview(subtitleView)
+    rightCardView.addSubview(image1View)
+    rightCardView.addSubview(title1View)
+    rightCardView.addSubview(subtitle1View)
+
+    fillColor = Colors.teal50
+    horizontalView.fillColor = Colors.teal100
+    imageView.image = #imageLiteral(resourceName: "icon_128x128")
+    imageView.fillColor = Colors.teal200
+    titleView.attributedStringValue = titleViewTextStyle.apply(to: "Title")
+    titleViewTextStyle = TextStyles.body2
+    titleView.attributedStringValue = titleViewTextStyle.apply(to: titleView.attributedStringValue)
+    subtitleView.attributedStringValue = subtitleViewTextStyle.apply(to: "Subtitle")
+    subtitleViewTextStyle = TextStyles.body1
+    subtitleView.attributedStringValue = subtitleViewTextStyle.apply(to: subtitleView.attributedStringValue)
+    spacerView.fillColor = #colorLiteral(red: 0.847058823529, green: 0.847058823529, blue: 0.847058823529, alpha: 1)
+    image1View.image = #imageLiteral(resourceName: "icon_128x128")
+    image1View.fillColor = Colors.teal200
+    title1View.attributedStringValue = title1ViewTextStyle.apply(to: "Title")
+    title1ViewTextStyle = TextStyles.body2
+    title1View.attributedStringValue = title1ViewTextStyle.apply(to: title1View.attributedStringValue)
+    subtitle1View.attributedStringValue = subtitle1ViewTextStyle.apply(to: "Subtitle")
+    subtitle1ViewTextStyle = TextStyles.body1
+    subtitle1View.attributedStringValue = subtitle1ViewTextStyle.apply(to: subtitle1View.attributedStringValue)
+  }
+
+  private func setUpConstraints() {
+    translatesAutoresizingMaskIntoConstraints = false
+    horizontalView.translatesAutoresizingMaskIntoConstraints = false
+    leftCardView.translatesAutoresizingMaskIntoConstraints = false
+    spacerView.translatesAutoresizingMaskIntoConstraints = false
+    rightCardView.translatesAutoresizingMaskIntoConstraints = false
+    imageView.translatesAutoresizingMaskIntoConstraints = false
+    titleView.translatesAutoresizingMaskIntoConstraints = false
+    subtitleView.translatesAutoresizingMaskIntoConstraints = false
+    image1View.translatesAutoresizingMaskIntoConstraints = false
+    title1View.translatesAutoresizingMaskIntoConstraints = false
+    subtitle1View.translatesAutoresizingMaskIntoConstraints = false
+
+    let horizontalViewTopAnchorConstraint = horizontalView.topAnchor.constraint(equalTo: topAnchor, constant: 10)
+    let horizontalViewBottomAnchorConstraint = horizontalView
+      .bottomAnchor
+      .constraint(equalTo: bottomAnchor, constant: -10)
+    let horizontalViewLeadingAnchorConstraint = horizontalView
+      .leadingAnchor
+      .constraint(equalTo: leadingAnchor, constant: 10)
+    let horizontalViewTrailingAnchorConstraint = horizontalView
+      .trailingAnchor
+      .constraint(equalTo: trailingAnchor, constant: -10)
+    let leftCardViewRightCardViewWidthAnchorSiblingConstraint = leftCardView
+      .widthAnchor
+      .constraint(equalTo: rightCardView.widthAnchor)
+    let leftCardViewHeightAnchorParentConstraint = leftCardView
+      .heightAnchor
+      .constraint(lessThanOrEqualTo: horizontalView.heightAnchor)
+    let spacerViewHeightAnchorParentConstraint = spacerView
+      .heightAnchor
+      .constraint(lessThanOrEqualTo: horizontalView.heightAnchor)
+    let rightCardViewHeightAnchorParentConstraint = rightCardView
+      .heightAnchor
+      .constraint(lessThanOrEqualTo: horizontalView.heightAnchor)
+    let leftCardViewLeadingAnchorConstraint = leftCardView
+      .leadingAnchor
+      .constraint(equalTo: horizontalView.leadingAnchor)
+    let leftCardViewTopAnchorConstraint = leftCardView.topAnchor.constraint(equalTo: horizontalView.topAnchor)
+    let leftCardViewBottomAnchorConstraint = leftCardView.bottomAnchor.constraint(equalTo: horizontalView.bottomAnchor)
+    let spacerViewLeadingAnchorConstraint = spacerView.leadingAnchor.constraint(equalTo: leftCardView.trailingAnchor)
+    let spacerViewTopAnchorConstraint = spacerView.topAnchor.constraint(equalTo: horizontalView.topAnchor)
+    let rightCardViewTrailingAnchorConstraint = rightCardView
+      .trailingAnchor
+      .constraint(equalTo: horizontalView.trailingAnchor)
+    let rightCardViewLeadingAnchorConstraint = rightCardView
+      .leadingAnchor
+      .constraint(equalTo: spacerView.trailingAnchor)
+    let rightCardViewTopAnchorConstraint = rightCardView.topAnchor.constraint(equalTo: horizontalView.topAnchor)
+    let rightCardViewBottomAnchorConstraint = rightCardView
+      .bottomAnchor
+      .constraint(equalTo: horizontalView.bottomAnchor)
+    let imageViewTopAnchorConstraint = imageView.topAnchor.constraint(equalTo: leftCardView.topAnchor)
+    let imageViewLeadingAnchorConstraint = imageView.leadingAnchor.constraint(equalTo: leftCardView.leadingAnchor)
+    let imageViewTrailingAnchorConstraint = imageView.trailingAnchor.constraint(equalTo: leftCardView.trailingAnchor)
+    let titleViewTopAnchorConstraint = titleView.topAnchor.constraint(equalTo: imageView.bottomAnchor)
+    let titleViewLeadingAnchorConstraint = titleView.leadingAnchor.constraint(equalTo: leftCardView.leadingAnchor)
+    let titleViewTrailingAnchorConstraint = titleView.trailingAnchor.constraint(equalTo: leftCardView.trailingAnchor)
+    let subtitleViewBottomAnchorConstraint = subtitleView.bottomAnchor.constraint(equalTo: leftCardView.bottomAnchor)
+    let subtitleViewTopAnchorConstraint = subtitleView.topAnchor.constraint(equalTo: titleView.bottomAnchor)
+    let subtitleViewLeadingAnchorConstraint = subtitleView.leadingAnchor.constraint(equalTo: leftCardView.leadingAnchor)
+    let subtitleViewTrailingAnchorConstraint = subtitleView
+      .trailingAnchor
+      .constraint(equalTo: leftCardView.trailingAnchor)
+    let spacerViewHeightAnchorConstraint = spacerView.heightAnchor.constraint(equalToConstant: 0)
+    let spacerViewWidthAnchorConstraint = spacerView.widthAnchor.constraint(equalToConstant: 8)
+    let image1ViewTopAnchorConstraint = image1View.topAnchor.constraint(equalTo: rightCardView.topAnchor)
+    let image1ViewLeadingAnchorConstraint = image1View.leadingAnchor.constraint(equalTo: rightCardView.leadingAnchor)
+    let image1ViewTrailingAnchorConstraint = image1View.trailingAnchor.constraint(equalTo: rightCardView.trailingAnchor)
+    let title1ViewTopAnchorConstraint = title1View.topAnchor.constraint(equalTo: image1View.bottomAnchor)
+    let title1ViewLeadingAnchorConstraint = title1View.leadingAnchor.constraint(equalTo: rightCardView.leadingAnchor)
+    let title1ViewTrailingAnchorConstraint = title1View.trailingAnchor.constraint(equalTo: rightCardView.trailingAnchor)
+    let subtitle1ViewBottomAnchorConstraint = subtitle1View.bottomAnchor.constraint(equalTo: rightCardView.bottomAnchor)
+    let subtitle1ViewTopAnchorConstraint = subtitle1View.topAnchor.constraint(equalTo: title1View.bottomAnchor)
+    let subtitle1ViewLeadingAnchorConstraint = subtitle1View
+      .leadingAnchor
+      .constraint(equalTo: rightCardView.leadingAnchor)
+    let subtitle1ViewTrailingAnchorConstraint = subtitle1View
+      .trailingAnchor
+      .constraint(equalTo: rightCardView.trailingAnchor)
+    let imageViewHeightAnchorConstraint = imageView.heightAnchor.constraint(equalToConstant: 100)
+    let image1ViewHeightAnchorConstraint = image1View.heightAnchor.constraint(equalToConstant: 100)
+
+    leftCardViewHeightAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
+    spacerViewHeightAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
+    rightCardViewHeightAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
+
+    NSLayoutConstraint.activate([
+      horizontalViewTopAnchorConstraint,
+      horizontalViewBottomAnchorConstraint,
+      horizontalViewLeadingAnchorConstraint,
+      horizontalViewTrailingAnchorConstraint,
+      leftCardViewRightCardViewWidthAnchorSiblingConstraint,
+      leftCardViewHeightAnchorParentConstraint,
+      spacerViewHeightAnchorParentConstraint,
+      rightCardViewHeightAnchorParentConstraint,
+      leftCardViewLeadingAnchorConstraint,
+      leftCardViewTopAnchorConstraint,
+      leftCardViewBottomAnchorConstraint,
+      spacerViewLeadingAnchorConstraint,
+      spacerViewTopAnchorConstraint,
+      rightCardViewTrailingAnchorConstraint,
+      rightCardViewLeadingAnchorConstraint,
+      rightCardViewTopAnchorConstraint,
+      rightCardViewBottomAnchorConstraint,
+      imageViewTopAnchorConstraint,
+      imageViewLeadingAnchorConstraint,
+      imageViewTrailingAnchorConstraint,
+      titleViewTopAnchorConstraint,
+      titleViewLeadingAnchorConstraint,
+      titleViewTrailingAnchorConstraint,
+      subtitleViewBottomAnchorConstraint,
+      subtitleViewTopAnchorConstraint,
+      subtitleViewLeadingAnchorConstraint,
+      subtitleViewTrailingAnchorConstraint,
+      spacerViewHeightAnchorConstraint,
+      spacerViewWidthAnchorConstraint,
+      image1ViewTopAnchorConstraint,
+      image1ViewLeadingAnchorConstraint,
+      image1ViewTrailingAnchorConstraint,
+      title1ViewTopAnchorConstraint,
+      title1ViewLeadingAnchorConstraint,
+      title1ViewTrailingAnchorConstraint,
+      subtitle1ViewBottomAnchorConstraint,
+      subtitle1ViewTopAnchorConstraint,
+      subtitle1ViewLeadingAnchorConstraint,
+      subtitle1ViewTrailingAnchorConstraint,
+      imageViewHeightAnchorConstraint,
+      image1ViewHeightAnchorConstraint
+    ])
+  }
+
+  private func update() {}
+}

--- a/examples/generated/test/react-dom/layouts/FillWidthFitHeightCard.js
+++ b/examples/generated/test/react-dom/layouts/FillWidthFitHeightCard.js
@@ -1,0 +1,76 @@
+import React from "react"
+
+import colors from "../colors"
+import shadows from "../shadows"
+import textStyles from "../textStyles"
+
+export default class FillWidthFitHeightCard extends React.Component {
+  render() {
+
+
+    return (
+      <div style={styles.view}>
+        <div style={styles.image}>
+          <img
+            style={styles.imageResizeModeCover}
+            src={require("../assets/icon_128x128.png")}
+
+          />
+        </div>
+        <span style={styles.text1}>
+          {"Title"}
+        </span>
+        <span style={styles.text}>
+          {"Subtitle"}
+        </span>
+      </div>
+    );
+  }
+};
+
+let styles = {
+  view: {
+    alignItems: "flex-start",
+    display: "flex",
+    flex: "1 1 0%",
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  image: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    backgroundColor: colors.blue200,
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    overflow: "hidden",
+    height: "100px",
+    position: "relative"
+  },
+  text1: {
+    textAlign: "left",
+    ...textStyles.body2,
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    display: "block",
+    flex: "0 0 auto",
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  text: {
+    textAlign: "left",
+    ...textStyles.body1,
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    display: "block",
+    flex: "0 0 auto",
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  imageResizeModeCover: {
+    width: "100%",
+    height: "100%",
+    objectFit: "cover",
+    position: "absolute"
+  }
+}

--- a/examples/generated/test/react-dom/layouts/PrimaryAxisFillNestedSiblings.js
+++ b/examples/generated/test/react-dom/layouts/PrimaryAxisFillNestedSiblings.js
@@ -1,0 +1,70 @@
+import React from "react"
+
+import colors from "../colors"
+import shadows from "../shadows"
+import textStyles from "../textStyles"
+import FillWidthFitHeightCard from "./FillWidthFitHeightCard"
+
+export default class PrimaryAxisFillNestedSiblings extends React.Component {
+  render() {
+
+
+    return (
+      <div style={styles.container}>
+        <div style={styles.horizontal}>
+          <FillWidthFitHeightCard />
+          <div style={styles.spacer} />
+          <FillWidthFitHeightCard />
+        </div>
+      </div>
+    );
+  }
+};
+
+let styles = {
+  container: {
+    alignItems: "flex-start",
+    backgroundColor: colors.teal50,
+    display: "flex",
+    flex: "1 1 0%",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    paddingTop: "10px",
+    paddingRight: "10px",
+    paddingBottom: "10px",
+    paddingLeft: "10px"
+  },
+  horizontal: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    backgroundColor: colors.teal100,
+    display: "flex",
+    flex: "0 0 auto",
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  },
+  leftCard: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    display: "flex",
+    flex: "1 1 auto",
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  },
+  spacer: {
+    alignItems: "flex-start",
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: "8px",
+    height: "0px"
+  },
+  rightCard: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    display: "flex",
+    flex: "1 1 auto",
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  }
+}

--- a/examples/generated/test/react-dom/layouts/PrimaryAxisFillSiblings.js
+++ b/examples/generated/test/react-dom/layouts/PrimaryAxisFillSiblings.js
@@ -1,0 +1,164 @@
+import React from "react"
+
+import colors from "../colors"
+import shadows from "../shadows"
+import textStyles from "../textStyles"
+
+export default class PrimaryAxisFillSiblings extends React.Component {
+  render() {
+
+
+    return (
+      <div style={styles.container}>
+        <div style={styles.horizontal}>
+          <div style={styles.leftCard}>
+            <div style={styles.image}>
+              <img
+                style={styles.imageResizeModeCover}
+                src={require("../assets/icon_128x128.png")}
+
+              />
+            </div>
+            <span style={styles.title}>
+              {"Title"}
+            </span>
+            <span style={styles.subtitle}>
+              {"Subtitle"}
+            </span>
+          </div>
+          <div style={styles.spacer} />
+          <div style={styles.rightCard}>
+            <div style={styles.image1}>
+              <img
+                style={styles.imageResizeModeCover}
+                src={require("../assets/icon_128x128.png")}
+
+              />
+            </div>
+            <span style={styles.title1}>
+              {"Title"}
+            </span>
+            <span style={styles.subtitle1}>
+              {"Subtitle"}
+            </span>
+          </div>
+        </div>
+      </div>
+    );
+  }
+};
+
+let styles = {
+  container: {
+    alignItems: "flex-start",
+    backgroundColor: colors.teal50,
+    display: "flex",
+    flex: "1 1 0%",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    paddingTop: "10px",
+    paddingRight: "10px",
+    paddingBottom: "10px",
+    paddingLeft: "10px"
+  },
+  horizontal: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    backgroundColor: colors.teal100,
+    display: "flex",
+    flex: "0 0 auto",
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  },
+  leftCard: {
+    alignItems: "flex-start",
+    display: "flex",
+    flex: "1 1 0%",
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  spacer: {
+    alignItems: "flex-start",
+    backgroundColor: "#D8D8D8",
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: "8px",
+    height: "0px"
+  },
+  rightCard: {
+    alignItems: "flex-start",
+    display: "flex",
+    flex: "1 1 0%",
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  image: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    backgroundColor: colors.teal200,
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    overflow: "hidden",
+    height: "100px",
+    position: "relative"
+  },
+  title: {
+    textAlign: "left",
+    ...textStyles.body2,
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    display: "block",
+    flex: "0 0 auto",
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  subtitle: {
+    textAlign: "left",
+    ...textStyles.body1,
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    display: "block",
+    flex: "0 0 auto",
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  image1: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    backgroundColor: colors.teal200,
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    overflow: "hidden",
+    height: "100px",
+    position: "relative"
+  },
+  title1: {
+    textAlign: "left",
+    ...textStyles.body2,
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    display: "block",
+    flex: "0 0 auto",
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  subtitle1: {
+    textAlign: "left",
+    ...textStyles.body1,
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    display: "block",
+    flex: "0 0 auto",
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  imageResizeModeCover: {
+    width: "100%",
+    height: "100%",
+    objectFit: "cover",
+    position: "absolute"
+  }
+}

--- a/examples/generated/test/react-native/layouts/FillWidthFitHeightCard.js
+++ b/examples/generated/test/react-native/layouts/FillWidthFitHeightCard.js
@@ -1,0 +1,70 @@
+import React from "react"
+import { Text, Image, View, StyleSheet } from "react-native"
+
+import colors from "../colors"
+import shadows from "../shadows"
+import textStyles from "../textStyles"
+
+export default class FillWidthFitHeightCard extends React.Component {
+  render() {
+
+
+    return (
+      <View style={styles.view}>
+        <View style={styles.image}>
+          <Image
+            style={styles.imageResizeModeCover}
+            source={require("../assets/icon_128x128.png")}
+
+          />
+        </View>
+        <Text style={styles.text1}>
+          {"Title"}
+        </Text>
+        <Text style={styles.text}>
+          {"Subtitle"}
+        </Text>
+      </View>
+    );
+  }
+};
+
+let styles = StyleSheet.create({
+  view: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  image: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    backgroundColor: colors.blue200,
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    height: 100
+  },
+  text1: {
+    ...textStyles.body2,
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  text: {
+    ...textStyles.body1,
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  imageResizeModeCover: {
+    width: "100%",
+    height: "100%",
+    resizeMode: "cover",
+    position: "absolute"
+  }
+})

--- a/examples/generated/test/react-native/layouts/PrimaryAxisFillNestedSiblings.js
+++ b/examples/generated/test/react-native/layouts/PrimaryAxisFillNestedSiblings.js
@@ -1,0 +1,71 @@
+import React from "react"
+import { View, StyleSheet } from "react-native"
+
+import colors from "../colors"
+import shadows from "../shadows"
+import textStyles from "../textStyles"
+import FillWidthFitHeightCard from "./FillWidthFitHeightCard"
+
+export default class PrimaryAxisFillNestedSiblings extends React.Component {
+  render() {
+
+
+    return (
+      <View style={styles.container}>
+        <View style={styles.horizontal}>
+          <View style={styles.leftCard}>
+            <FillWidthFitHeightCard />
+          </View>
+          <View style={styles.spacer} />
+          <View style={styles.rightCard}>
+            <FillWidthFitHeightCard />
+          </View>
+        </View>
+      </View>
+    );
+  }
+};
+
+let styles = StyleSheet.create({
+  container: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    backgroundColor: colors.teal50,
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    paddingTop: 10,
+    paddingRight: 10,
+    paddingBottom: 10,
+    paddingLeft: 10
+  },
+  horizontal: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    backgroundColor: colors.teal100,
+    flex: 0,
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  },
+  leftCard: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  },
+  spacer: {
+    alignItems: "flex-start",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: 8,
+    height: 0
+  },
+  rightCard: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  }
+})

--- a/examples/generated/test/react-native/layouts/PrimaryAxisFillSiblings.js
+++ b/examples/generated/test/react-native/layouts/PrimaryAxisFillSiblings.js
@@ -1,0 +1,147 @@
+import React from "react"
+import { Text, Image, View, StyleSheet } from "react-native"
+
+import colors from "../colors"
+import shadows from "../shadows"
+import textStyles from "../textStyles"
+
+export default class PrimaryAxisFillSiblings extends React.Component {
+  render() {
+
+
+    return (
+      <View style={styles.container}>
+        <View style={styles.horizontal}>
+          <View style={styles.leftCard}>
+            <View style={styles.image}>
+              <Image
+                style={styles.imageResizeModeCover}
+                source={require("../assets/icon_128x128.png")}
+
+              />
+            </View>
+            <Text style={styles.title}>
+              {"Title"}
+            </Text>
+            <Text style={styles.subtitle}>
+              {"Subtitle"}
+            </Text>
+          </View>
+          <View style={styles.spacer} />
+          <View style={styles.rightCard}>
+            <View style={styles.image1}>
+              <Image
+                style={styles.imageResizeModeCover}
+                source={require("../assets/icon_128x128.png")}
+
+              />
+            </View>
+            <Text style={styles.title1}>
+              {"Title"}
+            </Text>
+            <Text style={styles.subtitle1}>
+              {"Subtitle"}
+            </Text>
+          </View>
+        </View>
+      </View>
+    );
+  }
+};
+
+let styles = StyleSheet.create({
+  container: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    backgroundColor: colors.teal50,
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    paddingTop: 10,
+    paddingRight: 10,
+    paddingBottom: 10,
+    paddingLeft: 10
+  },
+  horizontal: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    backgroundColor: colors.teal100,
+    flex: 0,
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  },
+  leftCard: {
+    alignItems: "flex-start",
+    flex: 1,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  spacer: {
+    alignItems: "flex-start",
+    backgroundColor: "#D8D8D8",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: 8,
+    height: 0
+  },
+  rightCard: {
+    alignItems: "flex-start",
+    flex: 1,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  image: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    backgroundColor: colors.teal200,
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    height: 100
+  },
+  title: {
+    ...textStyles.body2,
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  subtitle: {
+    ...textStyles.body1,
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  image1: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    backgroundColor: colors.teal200,
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    height: 100
+  },
+  title1: {
+    ...textStyles.body2,
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  subtitle1: {
+    ...textStyles.body1,
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  imageResizeModeCover: {
+    width: "100%",
+    height: "100%",
+    resizeMode: "cover",
+    position: "absolute"
+  }
+})

--- a/examples/generated/test/sketchJs/layouts/FillWidthFitHeightCard.js
+++ b/examples/generated/test/sketchJs/layouts/FillWidthFitHeightCard.js
@@ -1,0 +1,71 @@
+import React from "react"
+import { Text, Image, View, StyleSheet, TextStyles } from
+  "@mathieudutour/react-sketchapp"
+
+import colors from "../colors"
+import shadows from "../shadows"
+import textStyles from "../textStyles"
+
+export default class FillWidthFitHeightCard extends React.Component {
+  render() {
+
+
+    return (
+      <View style={styles.view}>
+        <View style={styles.image}>
+          <Image
+            style={styles.imageResizeModeCover}
+            source={require("../assets/icon_128x128.png")}
+
+          />
+        </View>
+        <Text style={styles.text1}>
+          {"Title"}
+        </Text>
+        <Text style={styles.text}>
+          {"Subtitle"}
+        </Text>
+      </View>
+    );
+  }
+};
+
+let styles = StyleSheet.create({
+  view: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  image: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    backgroundColor: colors.blue200,
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    height: 100
+  },
+  text1: {
+    ...TextStyles.get("body2"),
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  text: {
+    ...TextStyles.get("body1"),
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  imageResizeModeCover: {
+    width: "100%",
+    height: "100%",
+    resizeMode: "cover",
+    position: "absolute"
+  }
+})

--- a/examples/generated/test/sketchJs/layouts/PrimaryAxisFillNestedSiblings.js
+++ b/examples/generated/test/sketchJs/layouts/PrimaryAxisFillNestedSiblings.js
@@ -1,0 +1,71 @@
+import React from "react"
+import { View, StyleSheet, TextStyles } from "@mathieudutour/react-sketchapp"
+
+import colors from "../colors"
+import shadows from "../shadows"
+import textStyles from "../textStyles"
+import FillWidthFitHeightCard from "./FillWidthFitHeightCard"
+
+export default class PrimaryAxisFillNestedSiblings extends React.Component {
+  render() {
+
+
+    return (
+      <View style={styles.container}>
+        <View style={styles.horizontal}>
+          <View style={styles.leftCard}>
+            <FillWidthFitHeightCard />
+          </View>
+          <View style={styles.spacer} />
+          <View style={styles.rightCard}>
+            <FillWidthFitHeightCard />
+          </View>
+        </View>
+      </View>
+    );
+  }
+};
+
+let styles = StyleSheet.create({
+  container: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    backgroundColor: colors.teal50,
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    paddingTop: 10,
+    paddingRight: 10,
+    paddingBottom: 10,
+    paddingLeft: 10
+  },
+  horizontal: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    backgroundColor: colors.teal100,
+    flex: 0,
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  },
+  leftCard: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  },
+  spacer: {
+    alignItems: "flex-start",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: 8,
+    height: 0
+  },
+  rightCard: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  }
+})

--- a/examples/generated/test/sketchJs/layouts/PrimaryAxisFillSiblings.js
+++ b/examples/generated/test/sketchJs/layouts/PrimaryAxisFillSiblings.js
@@ -1,0 +1,148 @@
+import React from "react"
+import { Text, Image, View, StyleSheet, TextStyles } from
+  "@mathieudutour/react-sketchapp"
+
+import colors from "../colors"
+import shadows from "../shadows"
+import textStyles from "../textStyles"
+
+export default class PrimaryAxisFillSiblings extends React.Component {
+  render() {
+
+
+    return (
+      <View style={styles.container}>
+        <View style={styles.horizontal}>
+          <View style={styles.leftCard}>
+            <View style={styles.image}>
+              <Image
+                style={styles.imageResizeModeCover}
+                source={require("../assets/icon_128x128.png")}
+
+              />
+            </View>
+            <Text style={styles.title}>
+              {"Title"}
+            </Text>
+            <Text style={styles.subtitle}>
+              {"Subtitle"}
+            </Text>
+          </View>
+          <View style={styles.spacer} />
+          <View style={styles.rightCard}>
+            <View style={styles.image1}>
+              <Image
+                style={styles.imageResizeModeCover}
+                source={require("../assets/icon_128x128.png")}
+
+              />
+            </View>
+            <Text style={styles.title1}>
+              {"Title"}
+            </Text>
+            <Text style={styles.subtitle1}>
+              {"Subtitle"}
+            </Text>
+          </View>
+        </View>
+      </View>
+    );
+  }
+};
+
+let styles = StyleSheet.create({
+  container: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    backgroundColor: colors.teal50,
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    paddingTop: 10,
+    paddingRight: 10,
+    paddingBottom: 10,
+    paddingLeft: 10
+  },
+  horizontal: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    backgroundColor: colors.teal100,
+    flex: 0,
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  },
+  leftCard: {
+    alignItems: "flex-start",
+    flex: 1,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  spacer: {
+    alignItems: "flex-start",
+    backgroundColor: "#D8D8D8",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: 8,
+    height: 0
+  },
+  rightCard: {
+    alignItems: "flex-start",
+    flex: 1,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  image: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    backgroundColor: colors.teal200,
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    height: 100
+  },
+  title: {
+    ...TextStyles.get("body2"),
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  subtitle: {
+    ...TextStyles.get("body1"),
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  image1: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    backgroundColor: colors.teal200,
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    height: 100
+  },
+  title1: {
+    ...TextStyles.get("body2"),
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  subtitle1: {
+    ...TextStyles.get("body1"),
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  imageResizeModeCover: {
+    width: "100%",
+    height: "100%",
+    resizeMode: "cover",
+    position: "absolute"
+  }
+})

--- a/examples/generated/test/swift/images/ImageCropping.swift
+++ b/examples/generated/test/swift/images/ImageCropping.swift
@@ -5,7 +5,7 @@ import Foundation
 
 private class BackgroundImageView: UIImageView {
   override var intrinsicContentSize: CGSize {
-    return .zero
+    return CGSize(width: UIViewNoIntrinsicMetric, height: UIViewNoIntrinsicMetric)
   }
 }
 

--- a/examples/generated/test/swift/images/LocalAsset.swift
+++ b/examples/generated/test/swift/images/LocalAsset.swift
@@ -5,7 +5,7 @@ import Foundation
 
 private class BackgroundImageView: UIImageView {
   override var intrinsicContentSize: CGSize {
-    return .zero
+    return CGSize(width: UIViewNoIntrinsicMetric, height: UIViewNoIntrinsicMetric)
   }
 }
 

--- a/examples/generated/test/swift/layouts/FillWidthFitHeightCard.swift
+++ b/examples/generated/test/swift/layouts/FillWidthFitHeightCard.swift
@@ -1,0 +1,92 @@
+import UIKit
+import Foundation
+
+// MARK: - BackgroundImageView
+
+private class BackgroundImageView: UIImageView {
+  override var intrinsicContentSize: CGSize {
+    return CGSize(width: UIViewNoIntrinsicMetric, height: UIViewNoIntrinsicMetric)
+  }
+}
+
+// MARK: - FillWidthFitHeightCard
+
+public class FillWidthFitHeightCard: UIView {
+
+  // MARK: Lifecycle
+
+  public init() {
+    super.init(frame: .zero)
+
+    setUpViews()
+    setUpConstraints()
+
+    update()
+  }
+
+  public required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: Private
+
+  private var imageView = BackgroundImageView(frame: .zero)
+  private var text1View = UILabel()
+  private var textView = UILabel()
+
+  private var text1ViewTextStyle = TextStyles.body2
+  private var textViewTextStyle = TextStyles.body1
+
+  private func setUpViews() {
+    imageView.contentMode = .scaleAspectFill
+    imageView.layer.masksToBounds = true
+    text1View.numberOfLines = 0
+    textView.numberOfLines = 0
+
+    addSubview(imageView)
+    addSubview(text1View)
+    addSubview(textView)
+
+    imageView.image = #imageLiteral(resourceName: "icon_128x128")
+    imageView.backgroundColor = Colors.blue200
+    text1View.attributedText = text1ViewTextStyle.apply(to: "Title")
+    text1ViewTextStyle = TextStyles.body2
+    text1View.attributedText = text1ViewTextStyle.apply(to: text1View.attributedText ?? NSAttributedString())
+    textView.attributedText = textViewTextStyle.apply(to: "Subtitle")
+  }
+
+  private func setUpConstraints() {
+    translatesAutoresizingMaskIntoConstraints = false
+    imageView.translatesAutoresizingMaskIntoConstraints = false
+    text1View.translatesAutoresizingMaskIntoConstraints = false
+    textView.translatesAutoresizingMaskIntoConstraints = false
+
+    let imageViewTopAnchorConstraint = imageView.topAnchor.constraint(equalTo: topAnchor)
+    let imageViewLeadingAnchorConstraint = imageView.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let imageViewTrailingAnchorConstraint = imageView.trailingAnchor.constraint(equalTo: trailingAnchor)
+    let text1ViewTopAnchorConstraint = text1View.topAnchor.constraint(equalTo: imageView.bottomAnchor)
+    let text1ViewLeadingAnchorConstraint = text1View.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let text1ViewTrailingAnchorConstraint = text1View.trailingAnchor.constraint(equalTo: trailingAnchor)
+    let textViewBottomAnchorConstraint = textView.bottomAnchor.constraint(equalTo: bottomAnchor)
+    let textViewTopAnchorConstraint = textView.topAnchor.constraint(equalTo: text1View.bottomAnchor)
+    let textViewLeadingAnchorConstraint = textView.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let textViewTrailingAnchorConstraint = textView.trailingAnchor.constraint(equalTo: trailingAnchor)
+    let imageViewHeightAnchorConstraint = imageView.heightAnchor.constraint(equalToConstant: 100)
+
+    NSLayoutConstraint.activate([
+      imageViewTopAnchorConstraint,
+      imageViewLeadingAnchorConstraint,
+      imageViewTrailingAnchorConstraint,
+      text1ViewTopAnchorConstraint,
+      text1ViewLeadingAnchorConstraint,
+      text1ViewTrailingAnchorConstraint,
+      textViewBottomAnchorConstraint,
+      textViewTopAnchorConstraint,
+      textViewLeadingAnchorConstraint,
+      textViewTrailingAnchorConstraint,
+      imageViewHeightAnchorConstraint
+    ])
+  }
+
+  private func update() {}
+}

--- a/examples/generated/test/swift/layouts/PrimaryAxisFillNestedSiblings.swift
+++ b/examples/generated/test/swift/layouts/PrimaryAxisFillNestedSiblings.swift
@@ -1,0 +1,117 @@
+import UIKit
+import Foundation
+
+// MARK: - PrimaryAxisFillNestedSiblings
+
+public class PrimaryAxisFillNestedSiblings: UIView {
+
+  // MARK: Lifecycle
+
+  public init() {
+    super.init(frame: .zero)
+
+    setUpViews()
+    setUpConstraints()
+
+    update()
+  }
+
+  public required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: Private
+
+  private var horizontalView = UIView(frame: .zero)
+  private var leftCardView = FillWidthFitHeightCard()
+  private var spacerView = UIView(frame: .zero)
+  private var rightCardView = FillWidthFitHeightCard()
+
+  private func setUpViews() {
+    addSubview(horizontalView)
+    horizontalView.addSubview(leftCardView)
+    horizontalView.addSubview(spacerView)
+    horizontalView.addSubview(rightCardView)
+
+    backgroundColor = Colors.teal50
+    horizontalView.backgroundColor = Colors.teal100
+  }
+
+  private func setUpConstraints() {
+    translatesAutoresizingMaskIntoConstraints = false
+    horizontalView.translatesAutoresizingMaskIntoConstraints = false
+    leftCardView.translatesAutoresizingMaskIntoConstraints = false
+    spacerView.translatesAutoresizingMaskIntoConstraints = false
+    rightCardView.translatesAutoresizingMaskIntoConstraints = false
+
+    let horizontalViewTopAnchorConstraint = horizontalView.topAnchor.constraint(equalTo: topAnchor, constant: 10)
+    let horizontalViewBottomAnchorConstraint = horizontalView
+      .bottomAnchor
+      .constraint(equalTo: bottomAnchor, constant: -10)
+    let horizontalViewLeadingAnchorConstraint = horizontalView
+      .leadingAnchor
+      .constraint(equalTo: leadingAnchor, constant: 10)
+    let horizontalViewTrailingAnchorConstraint = horizontalView
+      .trailingAnchor
+      .constraint(equalTo: trailingAnchor, constant: -10)
+    let leftCardViewRightCardViewWidthAnchorSiblingConstraint = leftCardView
+      .widthAnchor
+      .constraint(equalTo: rightCardView.widthAnchor)
+    let leftCardViewHeightAnchorParentConstraint = leftCardView
+      .heightAnchor
+      .constraint(lessThanOrEqualTo: horizontalView.heightAnchor)
+    let spacerViewHeightAnchorParentConstraint = spacerView
+      .heightAnchor
+      .constraint(lessThanOrEqualTo: horizontalView.heightAnchor)
+    let rightCardViewHeightAnchorParentConstraint = rightCardView
+      .heightAnchor
+      .constraint(lessThanOrEqualTo: horizontalView.heightAnchor)
+    let leftCardViewLeadingAnchorConstraint = leftCardView
+      .leadingAnchor
+      .constraint(equalTo: horizontalView.leadingAnchor)
+    let leftCardViewTopAnchorConstraint = leftCardView.topAnchor.constraint(equalTo: horizontalView.topAnchor)
+    let leftCardViewBottomAnchorConstraint = leftCardView.bottomAnchor.constraint(equalTo: horizontalView.bottomAnchor)
+    let spacerViewLeadingAnchorConstraint = spacerView.leadingAnchor.constraint(equalTo: leftCardView.trailingAnchor)
+    let spacerViewTopAnchorConstraint = spacerView.topAnchor.constraint(equalTo: horizontalView.topAnchor)
+    let rightCardViewTrailingAnchorConstraint = rightCardView
+      .trailingAnchor
+      .constraint(equalTo: horizontalView.trailingAnchor)
+    let rightCardViewLeadingAnchorConstraint = rightCardView
+      .leadingAnchor
+      .constraint(equalTo: spacerView.trailingAnchor)
+    let rightCardViewTopAnchorConstraint = rightCardView.topAnchor.constraint(equalTo: horizontalView.topAnchor)
+    let rightCardViewBottomAnchorConstraint = rightCardView
+      .bottomAnchor
+      .constraint(equalTo: horizontalView.bottomAnchor)
+    let spacerViewHeightAnchorConstraint = spacerView.heightAnchor.constraint(equalToConstant: 0)
+    let spacerViewWidthAnchorConstraint = spacerView.widthAnchor.constraint(equalToConstant: 8)
+
+    leftCardViewHeightAnchorParentConstraint.priority = UILayoutPriority.defaultLow
+    spacerViewHeightAnchorParentConstraint.priority = UILayoutPriority.defaultLow
+    rightCardViewHeightAnchorParentConstraint.priority = UILayoutPriority.defaultLow
+
+    NSLayoutConstraint.activate([
+      horizontalViewTopAnchorConstraint,
+      horizontalViewBottomAnchorConstraint,
+      horizontalViewLeadingAnchorConstraint,
+      horizontalViewTrailingAnchorConstraint,
+      leftCardViewRightCardViewWidthAnchorSiblingConstraint,
+      leftCardViewHeightAnchorParentConstraint,
+      spacerViewHeightAnchorParentConstraint,
+      rightCardViewHeightAnchorParentConstraint,
+      leftCardViewLeadingAnchorConstraint,
+      leftCardViewTopAnchorConstraint,
+      leftCardViewBottomAnchorConstraint,
+      spacerViewLeadingAnchorConstraint,
+      spacerViewTopAnchorConstraint,
+      rightCardViewTrailingAnchorConstraint,
+      rightCardViewLeadingAnchorConstraint,
+      rightCardViewTopAnchorConstraint,
+      rightCardViewBottomAnchorConstraint,
+      spacerViewHeightAnchorConstraint,
+      spacerViewWidthAnchorConstraint
+    ])
+  }
+
+  private func update() {}
+}

--- a/examples/generated/test/swift/layouts/PrimaryAxisFillSiblings.swift
+++ b/examples/generated/test/swift/layouts/PrimaryAxisFillSiblings.swift
@@ -1,0 +1,225 @@
+import UIKit
+import Foundation
+
+// MARK: - BackgroundImageView
+
+private class BackgroundImageView: UIImageView {
+  override var intrinsicContentSize: CGSize {
+    return CGSize(width: UIViewNoIntrinsicMetric, height: UIViewNoIntrinsicMetric)
+  }
+}
+
+// MARK: - PrimaryAxisFillSiblings
+
+public class PrimaryAxisFillSiblings: UIView {
+
+  // MARK: Lifecycle
+
+  public init() {
+    super.init(frame: .zero)
+
+    setUpViews()
+    setUpConstraints()
+
+    update()
+  }
+
+  public required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: Private
+
+  private var horizontalView = UIView(frame: .zero)
+  private var leftCardView = UIView(frame: .zero)
+  private var imageView = BackgroundImageView(frame: .zero)
+  private var titleView = UILabel()
+  private var subtitleView = UILabel()
+  private var spacerView = UIView(frame: .zero)
+  private var rightCardView = UIView(frame: .zero)
+  private var image1View = BackgroundImageView(frame: .zero)
+  private var title1View = UILabel()
+  private var subtitle1View = UILabel()
+
+  private var titleViewTextStyle = TextStyles.body2
+  private var subtitleViewTextStyle = TextStyles.body1
+  private var title1ViewTextStyle = TextStyles.body2
+  private var subtitle1ViewTextStyle = TextStyles.body1
+
+  private func setUpViews() {
+    imageView.contentMode = .scaleAspectFill
+    imageView.layer.masksToBounds = true
+    titleView.numberOfLines = 0
+    subtitleView.numberOfLines = 0
+    image1View.contentMode = .scaleAspectFill
+    image1View.layer.masksToBounds = true
+    title1View.numberOfLines = 0
+    subtitle1View.numberOfLines = 0
+
+    addSubview(horizontalView)
+    horizontalView.addSubview(leftCardView)
+    horizontalView.addSubview(spacerView)
+    horizontalView.addSubview(rightCardView)
+    leftCardView.addSubview(imageView)
+    leftCardView.addSubview(titleView)
+    leftCardView.addSubview(subtitleView)
+    rightCardView.addSubview(image1View)
+    rightCardView.addSubview(title1View)
+    rightCardView.addSubview(subtitle1View)
+
+    backgroundColor = Colors.teal50
+    horizontalView.backgroundColor = Colors.teal100
+    imageView.image = #imageLiteral(resourceName: "icon_128x128")
+    imageView.backgroundColor = Colors.teal200
+    titleView.attributedText = titleViewTextStyle.apply(to: "Title")
+    titleViewTextStyle = TextStyles.body2
+    titleView.attributedText = titleViewTextStyle.apply(to: titleView.attributedText ?? NSAttributedString())
+    subtitleView.attributedText = subtitleViewTextStyle.apply(to: "Subtitle")
+    subtitleViewTextStyle = TextStyles.body1
+    subtitleView.attributedText = subtitleViewTextStyle.apply(to: subtitleView.attributedText ?? NSAttributedString())
+    spacerView.backgroundColor = #colorLiteral(red: 0.847058823529, green: 0.847058823529, blue: 0.847058823529, alpha: 1)
+    image1View.image = #imageLiteral(resourceName: "icon_128x128")
+    image1View.backgroundColor = Colors.teal200
+    title1View.attributedText = title1ViewTextStyle.apply(to: "Title")
+    title1ViewTextStyle = TextStyles.body2
+    title1View.attributedText = title1ViewTextStyle.apply(to: title1View.attributedText ?? NSAttributedString())
+    subtitle1View.attributedText = subtitle1ViewTextStyle.apply(to: "Subtitle")
+    subtitle1ViewTextStyle = TextStyles.body1
+    subtitle1View.attributedText =
+      subtitle1ViewTextStyle.apply(to: subtitle1View.attributedText ?? NSAttributedString())
+  }
+
+  private func setUpConstraints() {
+    translatesAutoresizingMaskIntoConstraints = false
+    horizontalView.translatesAutoresizingMaskIntoConstraints = false
+    leftCardView.translatesAutoresizingMaskIntoConstraints = false
+    spacerView.translatesAutoresizingMaskIntoConstraints = false
+    rightCardView.translatesAutoresizingMaskIntoConstraints = false
+    imageView.translatesAutoresizingMaskIntoConstraints = false
+    titleView.translatesAutoresizingMaskIntoConstraints = false
+    subtitleView.translatesAutoresizingMaskIntoConstraints = false
+    image1View.translatesAutoresizingMaskIntoConstraints = false
+    title1View.translatesAutoresizingMaskIntoConstraints = false
+    subtitle1View.translatesAutoresizingMaskIntoConstraints = false
+
+    let horizontalViewTopAnchorConstraint = horizontalView.topAnchor.constraint(equalTo: topAnchor, constant: 10)
+    let horizontalViewBottomAnchorConstraint = horizontalView
+      .bottomAnchor
+      .constraint(equalTo: bottomAnchor, constant: -10)
+    let horizontalViewLeadingAnchorConstraint = horizontalView
+      .leadingAnchor
+      .constraint(equalTo: leadingAnchor, constant: 10)
+    let horizontalViewTrailingAnchorConstraint = horizontalView
+      .trailingAnchor
+      .constraint(equalTo: trailingAnchor, constant: -10)
+    let leftCardViewRightCardViewWidthAnchorSiblingConstraint = leftCardView
+      .widthAnchor
+      .constraint(equalTo: rightCardView.widthAnchor)
+    let leftCardViewHeightAnchorParentConstraint = leftCardView
+      .heightAnchor
+      .constraint(lessThanOrEqualTo: horizontalView.heightAnchor)
+    let spacerViewHeightAnchorParentConstraint = spacerView
+      .heightAnchor
+      .constraint(lessThanOrEqualTo: horizontalView.heightAnchor)
+    let rightCardViewHeightAnchorParentConstraint = rightCardView
+      .heightAnchor
+      .constraint(lessThanOrEqualTo: horizontalView.heightAnchor)
+    let leftCardViewLeadingAnchorConstraint = leftCardView
+      .leadingAnchor
+      .constraint(equalTo: horizontalView.leadingAnchor)
+    let leftCardViewTopAnchorConstraint = leftCardView.topAnchor.constraint(equalTo: horizontalView.topAnchor)
+    let leftCardViewBottomAnchorConstraint = leftCardView.bottomAnchor.constraint(equalTo: horizontalView.bottomAnchor)
+    let spacerViewLeadingAnchorConstraint = spacerView.leadingAnchor.constraint(equalTo: leftCardView.trailingAnchor)
+    let spacerViewTopAnchorConstraint = spacerView.topAnchor.constraint(equalTo: horizontalView.topAnchor)
+    let rightCardViewTrailingAnchorConstraint = rightCardView
+      .trailingAnchor
+      .constraint(equalTo: horizontalView.trailingAnchor)
+    let rightCardViewLeadingAnchorConstraint = rightCardView
+      .leadingAnchor
+      .constraint(equalTo: spacerView.trailingAnchor)
+    let rightCardViewTopAnchorConstraint = rightCardView.topAnchor.constraint(equalTo: horizontalView.topAnchor)
+    let rightCardViewBottomAnchorConstraint = rightCardView
+      .bottomAnchor
+      .constraint(equalTo: horizontalView.bottomAnchor)
+    let imageViewTopAnchorConstraint = imageView.topAnchor.constraint(equalTo: leftCardView.topAnchor)
+    let imageViewLeadingAnchorConstraint = imageView.leadingAnchor.constraint(equalTo: leftCardView.leadingAnchor)
+    let imageViewTrailingAnchorConstraint = imageView.trailingAnchor.constraint(equalTo: leftCardView.trailingAnchor)
+    let titleViewTopAnchorConstraint = titleView.topAnchor.constraint(equalTo: imageView.bottomAnchor)
+    let titleViewLeadingAnchorConstraint = titleView.leadingAnchor.constraint(equalTo: leftCardView.leadingAnchor)
+    let titleViewTrailingAnchorConstraint = titleView.trailingAnchor.constraint(equalTo: leftCardView.trailingAnchor)
+    let subtitleViewBottomAnchorConstraint = subtitleView.bottomAnchor.constraint(equalTo: leftCardView.bottomAnchor)
+    let subtitleViewTopAnchorConstraint = subtitleView.topAnchor.constraint(equalTo: titleView.bottomAnchor)
+    let subtitleViewLeadingAnchorConstraint = subtitleView.leadingAnchor.constraint(equalTo: leftCardView.leadingAnchor)
+    let subtitleViewTrailingAnchorConstraint = subtitleView
+      .trailingAnchor
+      .constraint(equalTo: leftCardView.trailingAnchor)
+    let spacerViewHeightAnchorConstraint = spacerView.heightAnchor.constraint(equalToConstant: 0)
+    let spacerViewWidthAnchorConstraint = spacerView.widthAnchor.constraint(equalToConstant: 8)
+    let image1ViewTopAnchorConstraint = image1View.topAnchor.constraint(equalTo: rightCardView.topAnchor)
+    let image1ViewLeadingAnchorConstraint = image1View.leadingAnchor.constraint(equalTo: rightCardView.leadingAnchor)
+    let image1ViewTrailingAnchorConstraint = image1View.trailingAnchor.constraint(equalTo: rightCardView.trailingAnchor)
+    let title1ViewTopAnchorConstraint = title1View.topAnchor.constraint(equalTo: image1View.bottomAnchor)
+    let title1ViewLeadingAnchorConstraint = title1View.leadingAnchor.constraint(equalTo: rightCardView.leadingAnchor)
+    let title1ViewTrailingAnchorConstraint = title1View.trailingAnchor.constraint(equalTo: rightCardView.trailingAnchor)
+    let subtitle1ViewBottomAnchorConstraint = subtitle1View.bottomAnchor.constraint(equalTo: rightCardView.bottomAnchor)
+    let subtitle1ViewTopAnchorConstraint = subtitle1View.topAnchor.constraint(equalTo: title1View.bottomAnchor)
+    let subtitle1ViewLeadingAnchorConstraint = subtitle1View
+      .leadingAnchor
+      .constraint(equalTo: rightCardView.leadingAnchor)
+    let subtitle1ViewTrailingAnchorConstraint = subtitle1View
+      .trailingAnchor
+      .constraint(equalTo: rightCardView.trailingAnchor)
+    let imageViewHeightAnchorConstraint = imageView.heightAnchor.constraint(equalToConstant: 100)
+    let image1ViewHeightAnchorConstraint = image1View.heightAnchor.constraint(equalToConstant: 100)
+
+    leftCardViewHeightAnchorParentConstraint.priority = UILayoutPriority.defaultLow
+    spacerViewHeightAnchorParentConstraint.priority = UILayoutPriority.defaultLow
+    rightCardViewHeightAnchorParentConstraint.priority = UILayoutPriority.defaultLow
+
+    NSLayoutConstraint.activate([
+      horizontalViewTopAnchorConstraint,
+      horizontalViewBottomAnchorConstraint,
+      horizontalViewLeadingAnchorConstraint,
+      horizontalViewTrailingAnchorConstraint,
+      leftCardViewRightCardViewWidthAnchorSiblingConstraint,
+      leftCardViewHeightAnchorParentConstraint,
+      spacerViewHeightAnchorParentConstraint,
+      rightCardViewHeightAnchorParentConstraint,
+      leftCardViewLeadingAnchorConstraint,
+      leftCardViewTopAnchorConstraint,
+      leftCardViewBottomAnchorConstraint,
+      spacerViewLeadingAnchorConstraint,
+      spacerViewTopAnchorConstraint,
+      rightCardViewTrailingAnchorConstraint,
+      rightCardViewLeadingAnchorConstraint,
+      rightCardViewTopAnchorConstraint,
+      rightCardViewBottomAnchorConstraint,
+      imageViewTopAnchorConstraint,
+      imageViewLeadingAnchorConstraint,
+      imageViewTrailingAnchorConstraint,
+      titleViewTopAnchorConstraint,
+      titleViewLeadingAnchorConstraint,
+      titleViewTrailingAnchorConstraint,
+      subtitleViewBottomAnchorConstraint,
+      subtitleViewTopAnchorConstraint,
+      subtitleViewLeadingAnchorConstraint,
+      subtitleViewTrailingAnchorConstraint,
+      spacerViewHeightAnchorConstraint,
+      spacerViewWidthAnchorConstraint,
+      image1ViewTopAnchorConstraint,
+      image1ViewLeadingAnchorConstraint,
+      image1ViewTrailingAnchorConstraint,
+      title1ViewTopAnchorConstraint,
+      title1ViewLeadingAnchorConstraint,
+      title1ViewTrailingAnchorConstraint,
+      subtitle1ViewBottomAnchorConstraint,
+      subtitle1ViewTopAnchorConstraint,
+      subtitle1ViewLeadingAnchorConstraint,
+      subtitle1ViewTrailingAnchorConstraint,
+      imageViewHeightAnchorConstraint,
+      image1ViewHeightAnchorConstraint
+    ])
+  }
+
+  private func update() {}
+}

--- a/examples/generated/test/swift/style/TextAlignment.swift
+++ b/examples/generated/test/swift/style/TextAlignment.swift
@@ -5,7 +5,7 @@ import Foundation
 
 private class BackgroundImageView: UIImageView {
   override var intrinsicContentSize: CGSize {
-    return .zero
+    return CGSize(width: UIViewNoIntrinsicMetric, height: UIViewNoIntrinsicMetric)
   }
 }
 

--- a/examples/test/layouts/FillWidthFitHeightCard.component
+++ b/examples/test/layouts/FillWidthFitHeightCard.component
@@ -1,0 +1,73 @@
+{
+  "devices" : [
+    {
+      "height" : 100,
+      "heightMode" : "At Least",
+      "name" : "iPhone SE",
+      "width" : 320
+    },
+    {
+      "height" : 100,
+      "heightMode" : "At Least",
+      "name" : "iPhone 7",
+      "width" : 375
+    },
+    {
+      "height" : 100,
+      "heightMode" : "At Least",
+      "name" : "iPhone 7+",
+      "width" : 414
+    }
+  ],
+  "examples" : [
+    {
+      "id" : "Default",
+      "name" : "Default",
+      "params" : {
+
+      }
+    }
+  ],
+  "logic" : [
+
+  ],
+  "params" : [
+
+  ],
+  "root" : {
+    "children" : [
+      {
+        "id" : "Image",
+        "params" : {
+          "alignSelf" : "stretch",
+          "backgroundColor" : "blue200",
+          "height" : 100,
+          "image" : "file:\/\/.\/assets\/icon_128x128.png"
+        },
+        "type" : "Lona:Image"
+      },
+      {
+        "id" : "Text 1",
+        "params" : {
+          "alignSelf" : "stretch",
+          "font" : "body2",
+          "text" : "Title"
+        },
+        "type" : "Lona:Text"
+      },
+      {
+        "id" : "Text",
+        "params" : {
+          "alignSelf" : "stretch",
+          "text" : "Subtitle"
+        },
+        "type" : "Lona:Text"
+      }
+    ],
+    "id" : "View",
+    "params" : {
+      "alignSelf" : "stretch"
+    },
+    "type" : "Lona:View"
+  }
+}

--- a/examples/test/layouts/PrimaryAxisFillNestedSiblings.component
+++ b/examples/test/layouts/PrimaryAxisFillNestedSiblings.component
@@ -1,0 +1,84 @@
+{
+  "devices" : [
+    {
+      "height" : 100,
+      "heightMode" : "At Least",
+      "name" : "iPhone SE",
+      "width" : 320
+    },
+    {
+      "height" : 100,
+      "heightMode" : "At Least",
+      "name" : "iPhone 7",
+      "width" : 375
+    },
+    {
+      "height" : 100,
+      "heightMode" : "At Least",
+      "name" : "iPhone 7+",
+      "width" : 414
+    }
+  ],
+  "examples" : [
+    {
+      "id" : "Default",
+      "name" : "Default",
+      "params" : {
+
+      }
+    }
+  ],
+  "logic" : [
+
+  ],
+  "params" : [
+
+  ],
+  "root" : {
+    "children" : [
+      {
+        "children" : [
+          {
+            "id" : "LeftCard",
+            "params" : {
+
+            },
+            "type" : "FillWidthFitHeightCard"
+          },
+          {
+            "id" : "Spacer",
+            "params" : {
+              "height" : 0,
+              "width" : 8
+            },
+            "type" : "Lona:View"
+          },
+          {
+            "id" : "RightCard",
+            "params" : {
+
+            },
+            "type" : "FillWidthFitHeightCard"
+          }
+        ],
+        "id" : "Horizontal",
+        "params" : {
+          "alignSelf" : "stretch",
+          "backgroundColor" : "teal100",
+          "flexDirection" : "row"
+        },
+        "type" : "Lona:View"
+      }
+    ],
+    "id" : "Container",
+    "params" : {
+      "alignSelf" : "stretch",
+      "backgroundColor" : "teal50",
+      "paddingBottom" : 10,
+      "paddingLeft" : 10,
+      "paddingRight" : 10,
+      "paddingTop" : 10
+    },
+    "type" : "Lona:View"
+  }
+}

--- a/examples/test/layouts/PrimaryAxisFillSiblings.component
+++ b/examples/test/layouts/PrimaryAxisFillSiblings.component
@@ -1,0 +1,145 @@
+{
+  "devices" : [
+    {
+      "height" : 100,
+      "heightMode" : "At Least",
+      "name" : "iPhone SE",
+      "width" : 320
+    },
+    {
+      "height" : 100,
+      "heightMode" : "At Least",
+      "name" : "iPhone 7",
+      "width" : 375
+    },
+    {
+      "height" : 100,
+      "heightMode" : "At Least",
+      "name" : "iPhone 7+",
+      "width" : 414
+    }
+  ],
+  "examples" : [
+    {
+      "id" : "Default",
+      "name" : "Default",
+      "params" : {
+
+      }
+    }
+  ],
+  "logic" : [
+
+  ],
+  "params" : [
+
+  ],
+  "root" : {
+    "children" : [
+      {
+        "children" : [
+          {
+            "children" : [
+              {
+                "id" : "Image",
+                "params" : {
+                  "alignSelf" : "stretch",
+                  "backgroundColor" : "teal200",
+                  "height" : 100,
+                  "image" : "file:\/\/.\/assets\/icon_128x128.png"
+                },
+                "type" : "Lona:Image"
+              },
+              {
+                "id" : "Title",
+                "params" : {
+                  "alignSelf" : "stretch",
+                  "font" : "body2",
+                  "text" : "Title"
+                },
+                "type" : "Lona:Text"
+              },
+              {
+                "id" : "Subtitle",
+                "params" : {
+                  "alignSelf" : "stretch",
+                  "font" : "body1",
+                  "text" : "Subtitle"
+                },
+                "type" : "Lona:Text"
+              }
+            ],
+            "id" : "LeftCard",
+            "params" : {
+              "flex" : 1
+            },
+            "type" : "Lona:View"
+          },
+          {
+            "id" : "Spacer",
+            "params" : {
+              "backgroundColor" : "#D8D8D8",
+              "height" : 0,
+              "width" : 8
+            },
+            "type" : "Lona:View"
+          },
+          {
+            "children" : [
+              {
+                "id" : "Image 1",
+                "params" : {
+                  "alignSelf" : "stretch",
+                  "backgroundColor" : "teal200",
+                  "height" : 100,
+                  "image" : "file:\/\/.\/assets\/icon_128x128.png"
+                },
+                "type" : "Lona:Image"
+              },
+              {
+                "id" : "Title 1",
+                "params" : {
+                  "alignSelf" : "stretch",
+                  "font" : "body2",
+                  "text" : "Title"
+                },
+                "type" : "Lona:Text"
+              },
+              {
+                "id" : "Subtitle 1",
+                "params" : {
+                  "alignSelf" : "stretch",
+                  "font" : "body1",
+                  "text" : "Subtitle"
+                },
+                "type" : "Lona:Text"
+              }
+            ],
+            "id" : "RightCard",
+            "params" : {
+              "flex" : 1
+            },
+            "type" : "Lona:View"
+          }
+        ],
+        "id" : "Horizontal",
+        "params" : {
+          "alignSelf" : "stretch",
+          "backgroundColor" : "teal100",
+          "flexDirection" : "row"
+        },
+        "type" : "Lona:View"
+      }
+    ],
+    "id" : "Container",
+    "params" : {
+      "alignSelf" : "stretch",
+      "backgroundColor" : "teal50",
+      "paddingBottom" : 10,
+      "paddingLeft" : 10,
+      "paddingRight" : 10,
+      "paddingTop" : 10
+    },
+    "type" : "Lona:View"
+  }
+}

--- a/studio/LonaStudio/Generated/LNAImageView.swift
+++ b/studio/LonaStudio/Generated/LNAImageView.swift
@@ -3,7 +3,7 @@ import AppKit
 // An image view that supports image resizing modes
 public class LNAImageView: NSImageView {
   override public var intrinsicContentSize: CGSize {
-    return .zero
+    return CGSize(width: NSView.noIntrinsicMetric, height: NSView.noIntrinsicMetric)
   }
 
   private var originalImage: NSImage?


### PR DESCRIPTION
## What

Fix/fit layouts now assume a column parent across component boundaries. Previously they used the direction of the actual parent, which is incorrect.

## Testing Plan

- [X] Tested this change locally
- [X] Checked that existing features work
