### PR TITLE
Fall back to system font if unspecified for iOS text styles

### DIFF
--- a/compiler/core/src/static/swift/TextStyle.uikit.swift
+++ b/compiler/core/src/static/swift/TextStyle.uikit.swift
@@ -63,6 +63,11 @@ public class TextStyle {
 
   public lazy var uiFontDescriptor: UIFontDescriptor = {
     var attributes: [UIFontDescriptor.AttributeName: Any] = [:]
+    var family = self.family
+
+    if family == nil && name == nil {
+      family = UIFont.systemFont(ofSize: UIFont.systemFontSize).familyName
+    }
 
     if let family = family {
       attributes[UIFontDescriptor.AttributeName.family] = family

--- a/examples/generated/test/swift/TextStyle.swift
+++ b/examples/generated/test/swift/TextStyle.swift
@@ -63,6 +63,11 @@ public class TextStyle {
 
   public lazy var uiFontDescriptor: UIFontDescriptor = {
     var attributes: [UIFontDescriptor.AttributeName: Any] = [:]
+    var family = self.family
+
+    if family == nil && name == nil {
+      family = UIFont.systemFont(ofSize: UIFont.systemFontSize).familyName
+    }
 
     if let family = family {
       attributes[UIFontDescriptor.AttributeName.family] = family


### PR DESCRIPTION
## What

If font family and name are nil, use the system font family. I added this for macOS ages ago, but never did for iOS.

## Testing Plan

- [X] Tested this change locally
- [X] Checked that existing features work
