### PR TITLE
LNAImageView update

### DIFF
--- a/compiler/core/src/static/swift/LNAImageView.appkit.swift
+++ b/compiler/core/src/static/swift/LNAImageView.appkit.swift
@@ -3,7 +3,7 @@ import AppKit
 // An image view that supports image resizing modes
 public class LNAImageView: NSImageView {
   override public var intrinsicContentSize: CGSize {
-    return .zero
+    return CGSize(width: NSView.noIntrinsicMetric, height: NSView.noIntrinsicMetric)
   }
 
   private var originalImage: NSImage?

--- a/examples/generated/test/appkit/LNAImageView.swift
+++ b/examples/generated/test/appkit/LNAImageView.swift
@@ -3,7 +3,7 @@ import AppKit
 // An image view that supports image resizing modes
 public class LNAImageView: NSImageView {
   override public var intrinsicContentSize: CGSize {
-    return .zero
+    return CGSize(width: NSView.noIntrinsicMetric, height: NSView.noIntrinsicMetric)
   }
 
   private var originalImage: NSImage?


### PR DESCRIPTION
## What

Use `noIntrinsicMetric` instead of 0.

## Testing Plan

- [X] Tested this change locally
- [X] Checked that existing features work
