### PR TITLE
Add Unit-ed values to JSX Styling

### DIFF
--- a/compiler/core/src/javaScript/javaScriptComponent.re
+++ b/compiler/core/src/javaScript/javaScriptComponent.re
@@ -308,11 +308,7 @@ let rec layerToJavaScriptAST =
     |> Layer.mapBindings(((key, value)) => {
          let key =
            if (Layer.isPrimitiveTypeName(layer.typeName)) {
-             switch (framework) {
-             | JavaScriptOptions.ReactDOM =>
-               key |> ReactDomTranslators.variableNames
-             | _ => key |> ReactNativeTranslators.variableNames
-             };
+             ReactTranslators.variableNames(framework, key);
            } else {
              key |> ParameterKey.toString;
            };

--- a/compiler/core/src/javaScript/javaScriptStyles.re
+++ b/compiler/core/src/javaScript/javaScriptStyles.re
@@ -497,16 +497,25 @@ let createStyleAttributePropertyAST =
       key: ParameterKey.t,
       value: Logic.logicValue,
     ) =>
-  switch (key) {
-  | ParameterKey.TextStyle =>
+  switch (key, ReactTranslators.isUnitNumberParameter(framework, key)) {
+  | (ParameterKey.TextStyle, _) =>
     JavaScriptAst.SpreadElement(
       JavaScriptLogic.logicValueToJavaScriptAST(config, value),
     )
-  | ParameterKey.Shadow =>
+  | (ParameterKey.Shadow, _) =>
     JavaScriptAst.SpreadElement(
       JavaScriptLogic.logicValueToJavaScriptAST(config, value),
     )
-  | _ =>
+  | (_, true) =>
+    JavaScriptAst.Property({
+      key: Identifier([key |> styleNameKey(framework)]),
+      value:
+        ReactTranslators.convertUnitlessAstNode(
+          framework,
+          JavaScriptLogic.logicValueToJavaScriptAST(config, value),
+        ),
+    })
+  | (_, false) =>
     JavaScriptAst.Property({
       key: Identifier([key |> styleNameKey(framework)]),
       value: JavaScriptLogic.logicValueToJavaScriptAST(config, value),

--- a/compiler/core/src/javaScript/utils/reactTranslators.re
+++ b/compiler/core/src/javaScript/utils/reactTranslators.re
@@ -23,7 +23,7 @@ let convertUnitlessAstNode =
     switch (value) {
     | Ast.Identifier(path) =>
       Ast.BinaryExpression({
-        left: Ast.Identifier(path),
+        left: value,
         operator: Ast.Plus,
         right: Ast.StringLiteral(ReactDomTranslators.styleUnit),
       })

--- a/compiler/core/src/javaScript/utils/reactTranslators.re
+++ b/compiler/core/src/javaScript/utils/reactTranslators.re
@@ -1,0 +1,39 @@
+module Ast = JavaScriptAst;
+
+let isUnitNumberParameter = (framework, key) =>
+  switch (framework) {
+  | JavaScriptOptions.ReactDOM =>
+    ReactDomTranslators.isUnitNumberParameter(key)
+  | _ => false
+  };
+
+let variableNames = (framework, variable) =>
+  switch (framework) {
+  | JavaScriptOptions.ReactDOM => ReactDomTranslators.variableNames(variable)
+  | JavaScriptOptions.ReactSketchapp
+  | JavaScriptOptions.ReactNative =>
+    ReactNativeTranslators.variableNames(variable)
+  | _ => variable |> ParameterKey.toString
+  };
+
+let convertUnitlessAstNode =
+    (framework: JavaScriptOptions.framework, value: Ast.node) =>
+  switch (framework) {
+  | JavaScriptOptions.ReactDOM =>
+    switch (value) {
+    | Ast.Identifier(path) =>
+      Ast.BinaryExpression({
+        left: Ast.Identifier(path),
+        operator: Ast.Plus,
+        right: Ast.StringLiteral(ReactDomTranslators.styleUnit),
+      })
+    | Ast.Literal(lonaValue) =>
+      Ast.Literal(
+        LonaValue.string(
+          ReactDomTranslators.convertUnitlessStyle(lonaValue.data),
+        ),
+      )
+    | x => x
+    }
+  | _ => value
+  };

--- a/examples/generated/test/react-dom/style/BorderWidthColor.js
+++ b/examples/generated/test/react-dom/style/BorderWidthColor.js
@@ -23,8 +23,8 @@ export default class BorderWidthColor extends React.Component {
       <div style={styles.view}>
         <div
           style={Object.assign({}, styles.inner, {
-            borderRadius: Inner$borderRadius,
-            borderWidth: Inner$borderWidth,
+            borderRadius: Inner$borderRadius + "px",
+            borderWidth: Inner$borderWidth + "px",
             borderColor: Inner$borderColor
           })}
 

--- a/examples/generated/test/react-dom/style/BoxModelConditional.js
+++ b/examples/generated/test/react-dom/style/BoxModelConditional.js
@@ -24,12 +24,12 @@ export default class BoxModelConditional extends React.Component {
       <div style={styles.outer}>
         <div
           style={Object.assign({}, styles.inner, {
-            marginTop: Inner$marginTop,
-            marginRight: Inner$marginRight,
-            marginBottom: Inner$marginBottom,
-            marginLeft: Inner$marginLeft,
-            width: Inner$width,
-            height: Inner$height
+            marginTop: Inner$marginTop + "px",
+            marginRight: Inner$marginRight + "px",
+            marginBottom: Inner$marginBottom + "px",
+            marginLeft: Inner$marginLeft + "px",
+            width: Inner$width + "px",
+            height: Inner$height + "px"
           })}
 
         />


### PR DESCRIPTION
## What

When styles are generated, they look for framework specific units. However, there was nothing in the JSX styling that did the same. This adds that.