### PR TITLE
Fixes issue where numbers were sometimes decoded as strings

### DIFF
--- a/compiler/core/src/javaScript/utils/reactDomTranslators.re
+++ b/compiler/core/src/javaScript/utils/reactDomTranslators.re
@@ -1,7 +1,13 @@
 let styleUnit = "px";
 
-let convertUnitlessStyle = value =>
-  string_of_int(value |> Json.Decode.int) ++ styleUnit;
+let convertUnitlessStyle = (value: Js.Json.t) =>
+  switch (value |> Js.Json.classify) {
+  | Js.Json.JSONString(string) => string
+  | Js.Json.JSONNumber(float) => Format.floatToString(float) ++ "px"
+  | _ =>
+    Js.log("Invalid unitless value");
+    raise(Not_found);
+  };
 
 let isUnitNumberParameter = key =>
   switch (key) {

--- a/compiler/core/src/swift/swiftRender.re
+++ b/compiler/core/src/swift/swiftRender.re
@@ -1,12 +1,6 @@
 open Prettier.Doc.Builders;
 
-let renderFloat = value => {
-  let string = string_of_float(value);
-  let cleaned =
-    string |> Js.String.endsWith(".") ?
-      string |> Js.String.slice(~from=0, ~to_=-1) : string;
-  s(cleaned);
-};
+let renderFloat = value => s(Format.floatToString(value));
 
 let reservedWords = ["true", "false"];
 


### PR DESCRIPTION
## What

lonaValue.data was being decoded as a number in cases where it was a string, due to adding `width: "100%"` for images.

## Testing Plan

- [X] Tested this change locally
- [X] Checked that existing features work
