### PR TITLE
Styled components

### DIFF
--- a/compiler/core/package.json
+++ b/compiler/core/package.json
@@ -4,11 +4,7 @@
   "description": "Lona cross-platform code compiler",
   "main": "build/index.js",
   "bin": "./build/index.js",
-  "files": [
-    "build/index.js",
-    "static",
-    "README.md"
-  ],
+  "files": ["build/index.js", "static", "README.md"],
   "scripts": {
     "build": "bsb -make-world",
     "start": "bsb -make-world -w",
@@ -16,24 +12,26 @@
     "bundle": "npm run clean && npm run build && webpack",
     "format": "bsrefmt --parse=re --print=re --in-place src/**/*.re",
     "prepublishOnly": "yarn clean && yarn build && yarn bundle",
-    "snapshotJsDom": "node src/main.bs.js workspace js ../../examples/test ../../examples/generated/test/react-dom --framework=reactdom",
+    "snapshotJsDom":
+      "node src/main.bs.js workspace js ../../examples/test ../../examples/generated/test/react-dom --framework=reactdom --styleFramework=styledcomponents",
     "snapshotJsDom:watch": "nodemon --exec \"yarn snapshotJsDom\"",
-    "snapshotJsNative": "node src/main.bs.js workspace js ../../examples/test ../../examples/generated/test/react-native --framework=reactnative",
+    "snapshotJsNative":
+      "node src/main.bs.js workspace js ../../examples/test ../../examples/generated/test/react-native --framework=reactnative",
     "snapshotJsNative:watch": "nodemon --exec \"yarn snapshotJsNative\"",
-    "snapshotSketch": "node src/main.bs.js workspace js ../../examples/test ../../examples/generated/test/sketchJs --framework=reactsketchapp",
+    "snapshotSketch":
+      "node src/main.bs.js workspace js ../../examples/test ../../examples/generated/test/sketchJs --framework=reactsketchapp",
     "snapshotSketch:watch": "nodemon --exec \"yarn snapshotSketch\"",
-    "snapshotSwift": "node src/main.bs.js workspace swift ../../examples/test ../../examples/generated/test/swift",
+    "snapshotSwift":
+      "node src/main.bs.js workspace swift ../../examples/test ../../examples/generated/test/swift",
     "snapshotSwift:watch": "nodemon --exec \"yarn snapshotSwift\"",
-    "snapshotAppkit": "node src/main.bs.js workspace swift ../../examples/test ../../examples/generated/test/appkit --framework=appkit",
+    "snapshotAppkit":
+      "node src/main.bs.js workspace swift ../../examples/test ../../examples/generated/test/appkit --framework=appkit",
     "snapshotAppkit:watch": "nodemon --exec \"yarn snapshotAppkit\"",
-    "snapshot": "yarn snapshotSwift && yarn snapshotAppkit && yarn snapshotJsDom && yarn snapshotJsNative && yarn snapshotSketch",
+    "snapshot":
+      "yarn snapshotSwift && yarn snapshotAppkit && yarn snapshotJsDom && yarn snapshotJsNative && yarn snapshotSketch",
     "snapshot:watch": "nodemon --exec \"yarn snapshot\""
   },
-  "keywords": [
-    "lona",
-    "compiler",
-    "react"
-  ],
+  "keywords": ["lona", "compiler", "react"],
   "author": "Devin Abbott <devinabbott@gmail.com>",
   "license": "MIT",
   "repository": {

--- a/compiler/core/src/core/layer.re
+++ b/compiler/core/src/core/layer.re
@@ -337,6 +337,18 @@ let vectorAssignments =
 let vectorGraphicLayers = (layer: Types.layer): list(Types.layer) =>
   layer |> flatten |> List.filter(isVectorGraphicLayer);
 
+let imageResizingModes = (rootLayer: Types.layer) =>
+  rootLayer
+  |> flatten
+  |> List.filter(isImageLayer)
+  |> List.map((layer: Types.layer) =>
+       switch (getStringParameterOpt(ResizeMode, layer.parameters)) {
+       | Some(value) => value
+       | None => "cover"
+       }
+     )
+  |> Sequence.dedupeMem;
+
 let parameterAssignmentsFromLogic = (layer, node) => {
   let identifiers = Logic.assignedIdentifiers(node);
   let updateAssignments = (layerName, propertyName, logicValue, acc) =>

--- a/compiler/core/src/javaScript/javaScriptComponent.re
+++ b/compiler/core/src/javaScript/javaScriptComponent.re
@@ -131,7 +131,8 @@ module StyledComponents = {
           left:
             Identifier([
               switch (layer.typeName) {
-              | Component(name) => JavaScriptFormat.wrapperElementName(name)
+              | Component(name) =>
+                JavaScriptFormat.wrapperElementName(name, layer.name)
               | _ => JavaScriptFormat.elementName(layer.name)
               },
             ]),
@@ -336,7 +337,7 @@ let createJSXElement =
     | (JavaScriptOptions.ReactSketchapp, "row") =>
       if (options.styleFramework == StyledComponents) {
         JSXElement({
-          tag: JavaScriptFormat.wrapperElementName(name),
+          tag: JavaScriptFormat.wrapperElementName(name, layer.name),
           attributes: styleAttribute,
           content: [customComponent],
         });

--- a/compiler/core/src/javaScript/javaScriptComponent.re
+++ b/compiler/core/src/javaScript/javaScriptComponent.re
@@ -38,7 +38,10 @@ let getElementTagString =
   switch (override, layer.typeName) {
   | (Some(value), _) => value
   | (None, VectorGraphic) =>
-    SwiftComponentParameter.getVectorAssetUrl(layer) |> Format.vectorClassName
+    Format.vectorClassName(
+      SwiftComponentParameter.getVectorAssetUrl(layer),
+      Some(layer.name),
+    )
   | _ =>
     switch (options.styleFramework) {
     | StyledComponents => JavaScriptFormat.elementName(layer.name)
@@ -787,8 +790,9 @@ let generate =
           ]
           @ relative,
           rootLayer
-          |> SwiftComponentParameter.allVectorAssets
-          |> List.map(asset =>
+          |> Layer.vectorGraphicLayers
+          |> List.map((layer: Types.layer) => {
+               let asset = SwiftComponentParameter.getVectorAssetUrl(layer);
                JavaScriptSvg.generateVectorGraphic(
                  config,
                  options,
@@ -798,8 +802,9 @@ let generate =
                    asset,
                  ),
                  asset,
-               )
-             ),
+                 Some(layer.name),
+               );
+             }),
           [
             ExportDefaultDeclaration(
               ClassDeclaration({

--- a/compiler/core/src/javaScript/javaScriptComponent.re
+++ b/compiler/core/src/javaScript/javaScriptComponent.re
@@ -61,6 +61,7 @@ module StyledComponents = {
     );
 
   let createStyledComponentAST = (layer: Types.layer) =>
+    /* let styleObject = JavaScriptStyles.Object.forLayer(layer); */
     JavaScriptAst.(
       VariableDeclaration(
         AssignmentExpression({
@@ -84,8 +85,8 @@ module StyledComponents = {
       )
     );
 
-  let createdAllStyledComponentsAST = (layer: Types.layer) =>
-    layer |> Layer.flatten |> List.map(createStyledComponentAST);
+  let createdAllStyledComponentsAST = (rootLayer: Types.layer) =>
+    rootLayer |> Layer.flatten |> List.map(createStyledComponentAST);
 };
 
 let createStyleAttributeAST =
@@ -631,8 +632,8 @@ let generate =
 
   let themeAST =
     JavaScriptStyles.StyleSet.layerToThemeAST(
+      config,
       options.framework,
-      config.colorsFile.contents,
       rootLayer,
     );
 
@@ -647,12 +648,7 @@ let generate =
     );
 
   let styleSheetAST =
-    JavaScriptStyles.StyleSheet.create(
-      config,
-      options.framework,
-      config.colorsFile.contents,
-      rootLayer,
-    );
+    JavaScriptStyles.StyleSheet.create(config, options.framework, rootLayer);
 
   let logicAST =
     logic

--- a/compiler/core/src/javaScript/javaScriptFormat.re
+++ b/compiler/core/src/javaScript/javaScriptFormat.re
@@ -1,7 +1,12 @@
 let styleVariableName = name => Format.camelCase(name);
 let elementName = name => Format.safeVariableName(name);
 
-let wrapperElementName = name => elementName(name) ++ "Wrapper";
+let wrapperElementName = (componentName, layerName) =>
+  elementName(componentName)
+  ++ Format.upperFirst(
+       Format.camelCase(Format.safeVariableName(layerName)),
+     )
+  ++ "Wrapper";
 
 let imageResizeModeHelperName = resizeMode =>
   styleVariableName("imageResizeMode" ++ Format.upperFirst(resizeMode));

--- a/compiler/core/src/javaScript/javaScriptFormat.re
+++ b/compiler/core/src/javaScript/javaScriptFormat.re
@@ -1,5 +1,7 @@
 let styleVariableName = name => Format.camelCase(name);
 let elementName = name => Format.safeVariableName(name);
 
+let wrapperElementName = name => elementName(name) ++ "Wrapper";
+
 let imageResizeModeHelperName = resizeMode =>
   styleVariableName("imageResizeMode" ++ Format.upperFirst(resizeMode));

--- a/compiler/core/src/javaScript/javaScriptOptions.re
+++ b/compiler/core/src/javaScript/javaScriptOptions.re
@@ -4,5 +4,12 @@ type framework =
   | ReactNative
   | ReactSketchapp;
 
+type styleFramework =
+  | None
+  | StyledComponents;
+
 [@bs.deriving jsConverter]
-type options = {framework};
+type options = {
+  framework,
+  styleFramework,
+};

--- a/compiler/core/src/javaScript/javaScriptSvg.re
+++ b/compiler/core/src/javaScript/javaScriptSvg.re
@@ -132,6 +132,7 @@ let rec convertNode =
         (
           jsOptions: JavaScriptOptions.options,
           vectorAssignments: list(Layer.vectorAssignment),
+          svgElementName: option(string),
           node: Svg.node,
         )
         : JavaScriptAst.node =>
@@ -139,7 +140,11 @@ let rec convertNode =
     switch (node) {
     | Svg(_, params, children) =>
       JSXElement({
-        tag: tagName(jsOptions, node),
+        tag:
+          switch (svgElementName) {
+          | Some(name) => name |> Format.safeVariableName |> Format.upperFirst
+          | None => tagName(jsOptions, node)
+          },
         attributes:
           [
             [
@@ -179,7 +184,10 @@ let rec convertNode =
           ]
           |> List.concat,
         content:
-          children |> List.map(convertNode(jsOptions, vectorAssignments)),
+          children
+          |> List.map(
+               convertNode(jsOptions, vectorAssignments, svgElementName),
+             ),
       })
     | Path(elementPath, params) =>
       let variableName = Svg.elementName(elementPath);
@@ -214,18 +222,28 @@ let generateVectorGraphic =
       jsOptions: JavaScriptOptions.options,
       vectorAssignments: list(Layer.vectorAssignment),
       assetUrl: string,
+      svgElementName: option(string),
     ) => {
   let svg = Config.Find.svg(config, assetUrl);
 
   JavaScriptAst.(
     VariableDeclaration(
       AssignmentExpression({
-        left: Identifier([Format.vectorClassName(assetUrl)]),
+        left: Identifier([Format.vectorClassName(assetUrl, svgElementName)]),
         right:
           ArrowFunctionExpression({
             id: None,
             params: ["props"],
-            body: [Return(convertNode(jsOptions, vectorAssignments, svg))],
+            body: [
+              Return(
+                convertNode(
+                  jsOptions,
+                  vectorAssignments,
+                  svgElementName,
+                  svg,
+                ),
+              ),
+            ],
           }),
       }),
     )

--- a/compiler/core/src/javaScript/javaScriptSvg.re
+++ b/compiler/core/src/javaScript/javaScriptSvg.re
@@ -141,9 +141,10 @@ let rec convertNode =
     | Svg(_, params, children) =>
       JSXElement({
         tag:
-          switch (svgElementName) {
-          | Some(name) => name |> Format.safeVariableName |> Format.upperFirst
-          | None => tagName(jsOptions, node)
+          switch (jsOptions.styleFramework, svgElementName) {
+          | (StyledComponents, Some(name)) =>
+            name |> Format.safeVariableName |> Format.upperFirst
+          | _ => tagName(jsOptions, node)
           },
         attributes:
           [

--- a/compiler/core/src/javaScript/utils/reactDomTranslators.re
+++ b/compiler/core/src/javaScript/utils/reactDomTranslators.re
@@ -33,10 +33,11 @@ let layerTypeTags = layerType =>
   | Types.View => "div"
   | Types.Text => "span"
   | Types.Image => "img"
+  | Types.VectorGraphic => "svg"
   | Types.Animation => "Animation"
   | Types.Children => "Children"
   | Types.Component(value) => value
-  | _ => "Unknown"
+  | _ => "UnknownLayerTypeTag"
   };
 
 let variableNames = variable =>

--- a/compiler/core/src/main.re
+++ b/compiler/core/src/main.re
@@ -55,6 +55,11 @@ let javaScriptOptions: JavaScriptOptions.options = {
     | Some("reactdom") => JavaScriptOptions.ReactDOM
     | _ => JavaScriptOptions.ReactNative
     },
+  styleFramework:
+    switch (getArgument("styleFramework")) {
+    | Some("styledcomponents") => JavaScriptOptions.StyledComponents
+    | _ => JavaScriptOptions.None
+    },
 };
 
 let exit = message => {

--- a/compiler/core/src/swift/swiftComponent.re
+++ b/compiler/core/src/swift/swiftComponent.re
@@ -24,8 +24,10 @@ module Naming = {
       | (AppKit, Text) => "LNATextField"
       | (AppKit, Image) => "LNAImageView"
       | (_, VectorGraphic) =>
-        SwiftComponentParameter.getVectorAssetUrl(layer)
-        |> Format.vectorClassName
+        Format.vectorClassName(
+          SwiftComponentParameter.getVectorAssetUrl(layer),
+          None,
+        )
       | (_, Component(name)) => name
       | _ => "TypeUnknown"
       };

--- a/compiler/core/src/swift/swiftHelperClass.re
+++ b/compiler/core/src/swift/swiftHelperClass.re
@@ -140,7 +140,7 @@ let generateVectorGraphic =
 
   SwiftAst.[
     ClassDeclaration({
-      "name": Format.vectorClassName(assetUrl),
+      "name": Format.vectorClassName(assetUrl, None),
       "inherits": [
         TypeName(swiftOptions.framework == UIKit ? "UIView" : "NSBox"),
       ],

--- a/compiler/core/src/utils/format.re
+++ b/compiler/core/src/utils/format.re
@@ -20,8 +20,17 @@ let floatToString = (float: float): string => {
     string |> Js.String.slice(~from=0, ~to_=-1) : string;
 };
 
-let vectorClassName = (assetUrl: string): string => {
+let vectorClassName = (assetUrl: string, elementName: option(string)): string => {
   let baseName = Node.Path.basename_ext(assetUrl, ".svg");
-  let formattedName = camelCase(baseName) |> upperFirst;
+  let formattedName =
+    (
+      switch (elementName) {
+      | Some(elementName) =>
+        camelCase(safeVariableName(elementName))
+        ++ upperFirst(camelCase(baseName))
+      | None => camelCase(baseName)
+      }
+    )
+    |> upperFirst;
   formattedName ++ "Vector";
 };

--- a/examples/generated/test/react-dom/components/ComponentParameterInstance.js
+++ b/examples/generated/test/react-dom/components/ComponentParameterInstance.js
@@ -1,4 +1,5 @@
 import React from "react"
+import styled from "styled-components"
 
 import colors from "../colors"
 import shadows from "../shadows"
@@ -10,33 +11,32 @@ export default class ComponentParameterInstance extends React.Component {
 
 
     return (
-      <div style={styles.view}>
-        <div style={styles.componentParameterTemplate}>
+      <View>
+        <ComponentParameterTemplateComponentParameterTemplateWrapper>
           <ComponentParameterTemplate
             subtitleComponent={{"parameters":{"text":"Subtitle","textStyle":"subheading2"},"type":"Lona:Text"}}
             titleComponent={{"parameters":{"text":"Title","textStyle":"headline"},"type":"Lona:Text"}}
 
           />
-        </div>
-      </div>
+        </ComponentParameterTemplateComponentParameterTemplateWrapper>
+      </View>
     );
   }
 };
 
-let styles = {
-  view: {
-    alignItems: "flex-start",
-    display: "flex",
-    flex: "1 1 0%",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  componentParameterTemplate: {
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    display: "flex",
-    flex: "1 1 auto",
-    flexDirection: "row",
-    justifyContent: "flex-start"
-  }
-}
+let View = styled.div({
+  alignItems: "flex-start",
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let ComponentParameterTemplateComponentParameterTemplateWrapper = styled.div({
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  display: "flex",
+  flex: "1 1 auto",
+  flexDirection: "row",
+  justifyContent: "flex-start"
+})

--- a/examples/generated/test/react-dom/components/NestedBottomLeftLayout.js
+++ b/examples/generated/test/react-dom/components/NestedBottomLeftLayout.js
@@ -1,4 +1,5 @@
 import React from "react"
+import styled from "styled-components"
 
 import colors from "../colors"
 import shadows from "../shadows"
@@ -9,39 +10,33 @@ export default class NestedBottomLeftLayout extends React.Component {
   render() {
 
 
-    return (
-      <div style={styles.view}>
-        <div style={styles.view1}>
-          <LocalAsset />
-        </div>
-      </div>
-    );
+    return <View> <View1> <LocalAsset /> </View1> </View>;
   }
 };
 
-let styles = {
-  view: {
-    alignItems: "flex-start",
-    display: "flex",
-    flex: "1 1 0%",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  view1: {
-    alignItems: "flex-end",
-    backgroundColor: colors.red100,
-    display: "flex",
-    flexDirection: "row",
-    justifyContent: "flex-start",
-    width: "150px",
-    height: "150px"
-  },
-  localAsset: {
-    alignItems: "flex-end",
-    alignSelf: "stretch",
-    display: "flex",
-    flex: "1 1 auto",
-    flexDirection: "row",
-    justifyContent: "flex-start"
-  }
-}
+let View = styled.div({
+  alignItems: "flex-start",
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let View1 = styled.div({
+  alignItems: "flex-end",
+  backgroundColor: colors.red100,
+  display: "flex",
+  flexDirection: "row",
+  justifyContent: "flex-start",
+  width: "150px",
+  height: "150px"
+})
+
+let LocalAssetLocalAssetWrapper = styled.div({
+  alignItems: "flex-end",
+  alignSelf: "stretch",
+  display: "flex",
+  flex: "1 1 auto",
+  flexDirection: "row",
+  justifyContent: "flex-start"
+})

--- a/examples/generated/test/react-dom/components/NestedBottomLeftLayout.js
+++ b/examples/generated/test/react-dom/components/NestedBottomLeftLayout.js
@@ -31,12 +31,3 @@ let View1 = styled.div({
   width: "150px",
   height: "150px"
 })
-
-let LocalAssetLocalAssetWrapper = styled.div({
-  alignItems: "flex-end",
-  alignSelf: "stretch",
-  display: "flex",
-  flex: "1 1 auto",
-  flexDirection: "row",
-  justifyContent: "flex-start"
-})

--- a/examples/generated/test/react-dom/components/NestedButtons.js
+++ b/examples/generated/test/react-dom/components/NestedButtons.js
@@ -1,4 +1,5 @@
 import React from "react"
+import styled from "styled-components"
 
 import colors from "../colors"
 import shadows from "../shadows"
@@ -10,53 +11,54 @@ export default class NestedButtons extends React.Component {
 
 
     return (
-      <div style={styles.view}>
-        <div style={styles.button}>
+      <View>
+        <ButtonButtonWrapper>
           <Button label={"Button 1"} />
-        </div>
-        <div style={styles.view1} />
-        <div style={styles.button2}>
+        </ButtonButtonWrapper>
+        <View1 />
+        <ButtonButton2Wrapper>
           <Button label={"Button 2"} />
-        </div>
-      </div>
+        </ButtonButton2Wrapper>
+      </View>
     );
   }
 };
 
-let styles = {
-  view: {
-    alignItems: "flex-start",
-    display: "flex",
-    flex: "1 1 0%",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    paddingTop: "24px",
-    paddingRight: "24px",
-    paddingBottom: "24px",
-    paddingLeft: "24px"
-  },
-  button: {
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    display: "flex",
-    flex: "1 1 auto",
-    flexDirection: "row",
-    justifyContent: "flex-start"
-  },
-  view1: {
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    height: "8px"
-  },
-  button2: {
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    display: "flex",
-    flex: "1 1 auto",
-    flexDirection: "row",
-    justifyContent: "flex-start"
-  }
-}
+let View = styled.div({
+  alignItems: "flex-start",
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  paddingTop: "24px",
+  paddingRight: "24px",
+  paddingBottom: "24px",
+  paddingLeft: "24px"
+})
+
+let ButtonButtonWrapper = styled.div({
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  display: "flex",
+  flex: "1 1 auto",
+  flexDirection: "row",
+  justifyContent: "flex-start"
+})
+
+let View1 = styled.div({
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  height: "8px"
+})
+
+let ButtonButton2Wrapper = styled.div({
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  display: "flex",
+  flex: "1 1 auto",
+  flexDirection: "row",
+  justifyContent: "flex-start"
+})

--- a/examples/generated/test/react-dom/components/NestedComponent.js
+++ b/examples/generated/test/react-dom/components/NestedComponent.js
@@ -1,4 +1,5 @@
 import React from "react"
+import styled from "styled-components"
 
 import colors from "../colors"
 import shadows from "../shadows"
@@ -12,82 +13,86 @@ export default class NestedComponent extends React.Component {
 
 
     return (
-      <div style={styles.view}>
-        <span style={styles.text}>
+      <View>
+        <Text>
           {"Example nested component"}
-        </span>
-        <div style={styles.fitContentParentSecondaryChildren}>
+        </Text>
+        <FitContentParentSecondaryChildrenFitContentParentSecondaryChildrenWrapper>
           <FitContentParentSecondaryChildren />
-        </div>
-        <span style={styles.text1}>
+        </FitContentParentSecondaryChildrenFitContentParentSecondaryChildrenWrapper>
+        <Text1>
           {"Text below"}
-        </span>
-        <div style={styles.localAsset}>
+        </Text1>
+        <LocalAssetLocalAssetWrapper>
           <LocalAsset />
-        </div>
-        <span style={styles.text2}>
+        </LocalAssetLocalAssetWrapper>
+        <Text2>
           {"Very bottom"}
-        </span>
-      </div>
+        </Text2>
+      </View>
     );
   }
 };
 
-let styles = {
-  view: {
-    alignItems: "flex-start",
-    display: "flex",
-    flex: "1 1 0%",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    paddingTop: "10px",
-    paddingRight: "10px",
-    paddingBottom: "10px",
-    paddingLeft: "10px"
-  },
-  text: {
-    textAlign: "left",
-    ...textStyles.subheading2,
-    alignItems: "flex-start",
-    display: "block",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    marginBottom: "8px"
-  },
-  fitContentParentSecondaryChildren: {
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    display: "flex",
-    flex: "1 1 auto",
-    flexDirection: "row",
-    justifyContent: "flex-start"
-  },
-  text1: {
-    textAlign: "left",
-    ...textStyles.body1,
-    alignItems: "flex-start",
-    display: "block",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    marginTop: "12px"
-  },
-  localAsset: {
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    display: "flex",
-    flex: "1 1 auto",
-    flexDirection: "row",
-    justifyContent: "flex-start"
-  },
-  text2: {
-    textAlign: "left",
-    ...textStyles.body1,
-    alignItems: "flex-start",
-    display: "block",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  }
-}
+let View = styled.div({
+  alignItems: "flex-start",
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  paddingTop: "10px",
+  paddingRight: "10px",
+  paddingBottom: "10px",
+  paddingLeft: "10px"
+})
+
+let Text = styled.span({
+  textAlign: "left",
+  ...textStyles.subheading2,
+  alignItems: "flex-start",
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  marginBottom: "8px"
+})
+
+let FitContentParentSecondaryChildrenFitContentParentSecondaryChildrenWrapper = styled
+.div({
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  display: "flex",
+  flex: "1 1 auto",
+  flexDirection: "row",
+  justifyContent: "flex-start"
+})
+
+let Text1 = styled.span({
+  textAlign: "left",
+  ...textStyles.body1,
+  alignItems: "flex-start",
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  marginTop: "12px"
+})
+
+let LocalAssetLocalAssetWrapper = styled.div({
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  display: "flex",
+  flex: "1 1 auto",
+  flexDirection: "row",
+  justifyContent: "flex-start"
+})
+
+let Text2 = styled.span({
+  textAlign: "left",
+  ...textStyles.body1,
+  alignItems: "flex-start",
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})

--- a/examples/generated/test/react-dom/components/NestedLayout.js
+++ b/examples/generated/test/react-dom/components/NestedLayout.js
@@ -339,15 +339,6 @@ let View10 = styled.div({
   height: "150px"
 })
 
-let LocalAssetLocalAsset10Wrapper = styled.div({
-  alignItems: "flex-start",
-  alignSelf: "stretch",
-  display: "flex",
-  flex: "1 1 auto",
-  flexDirection: "row",
-  justifyContent: "flex-start"
-})
-
 let View11 = styled.div({
   alignItems: "center",
   backgroundColor: "transparent",
@@ -358,15 +349,6 @@ let View11 = styled.div({
   height: "150px"
 })
 
-let LocalAssetLocalAsset11Wrapper = styled.div({
-  alignItems: "center",
-  alignSelf: "stretch",
-  display: "flex",
-  flex: "1 1 auto",
-  flexDirection: "row",
-  justifyContent: "flex-start"
-})
-
 let View12 = styled.div({
   alignItems: "flex-end",
   backgroundColor: colors.grey50,
@@ -375,15 +357,6 @@ let View12 = styled.div({
   justifyContent: "flex-start",
   width: "150px",
   height: "150px"
-})
-
-let LocalAssetLocalAsset12Wrapper = styled.div({
-  alignItems: "flex-end",
-  alignSelf: "stretch",
-  display: "flex",
-  flex: "1 1 auto",
-  flexDirection: "row",
-  justifyContent: "flex-start"
 })
 
 let Column5 = styled.div({
@@ -403,15 +376,6 @@ let View13 = styled.div({
   height: "150px"
 })
 
-let LocalAssetLocalAsset13Wrapper = styled.div({
-  alignItems: "flex-start",
-  alignSelf: "stretch",
-  display: "flex",
-  flex: "1 1 auto",
-  flexDirection: "row",
-  justifyContent: "center"
-})
-
 let View14 = styled.div({
   alignItems: "center",
   backgroundColor: colors.grey50,
@@ -422,15 +386,6 @@ let View14 = styled.div({
   height: "150px"
 })
 
-let LocalAssetLocalAsset14Wrapper = styled.div({
-  alignItems: "center",
-  alignSelf: "stretch",
-  display: "flex",
-  flex: "1 1 auto",
-  flexDirection: "row",
-  justifyContent: "center"
-})
-
 let View15 = styled.div({
   alignItems: "flex-end",
   display: "flex",
@@ -438,15 +393,6 @@ let View15 = styled.div({
   justifyContent: "center",
   width: "150px",
   height: "150px"
-})
-
-let LocalAssetLocalAsset15Wrapper = styled.div({
-  alignItems: "flex-end",
-  alignSelf: "stretch",
-  display: "flex",
-  flex: "1 1 auto",
-  flexDirection: "row",
-  justifyContent: "center"
 })
 
 let Column6 = styled.div({
@@ -467,15 +413,6 @@ let View16 = styled.div({
   height: "150px"
 })
 
-let LocalAssetLocalAsset16Wrapper = styled.div({
-  alignItems: "flex-start",
-  alignSelf: "stretch",
-  display: "flex",
-  flex: "1 1 auto",
-  flexDirection: "row",
-  justifyContent: "flex-end"
-})
-
 let View17 = styled.div({
   alignItems: "center",
   display: "flex",
@@ -483,15 +420,6 @@ let View17 = styled.div({
   justifyContent: "flex-end",
   width: "150px",
   height: "150px"
-})
-
-let LocalAssetLocalAsset17Wrapper = styled.div({
-  alignItems: "center",
-  alignSelf: "stretch",
-  display: "flex",
-  flex: "1 1 auto",
-  flexDirection: "row",
-  justifyContent: "flex-end"
 })
 
 let View18 = styled.div({
@@ -502,13 +430,4 @@ let View18 = styled.div({
   justifyContent: "flex-end",
   width: "150px",
   height: "150px"
-})
-
-let LocalAssetLocalAsset18Wrapper = styled.div({
-  alignItems: "flex-end",
-  alignSelf: "stretch",
-  display: "flex",
-  flex: "1 1 auto",
-  flexDirection: "row",
-  justifyContent: "flex-end"
 })

--- a/examples/generated/test/react-dom/components/NestedLayout.js
+++ b/examples/generated/test/react-dom/components/NestedLayout.js
@@ -1,4 +1,5 @@
 import React from "react"
+import styled from "styled-components"
 
 import colors from "../colors"
 import shadows from "../shadows"
@@ -10,462 +11,504 @@ export default class NestedLayout extends React.Component {
 
 
     return (
-      <div style={styles.view}>
-        <div style={styles.topRow}>
-          <div style={styles.column1}>
-            <div style={styles.view1}>
-              <div style={styles.localAsset}>
+      <View>
+        <TopRow>
+          <Column1>
+            <View1>
+              <LocalAssetLocalAssetWrapper>
                 <LocalAsset />
-              </div>
-            </div>
-            <div style={styles.view2}>
-              <div style={styles.localAsset2}>
+              </LocalAssetLocalAssetWrapper>
+            </View1>
+            <View2>
+              <LocalAssetLocalAsset2Wrapper>
                 <LocalAsset />
-              </div>
-            </div>
-            <div style={styles.view3}>
-              <div style={styles.localAsset3}>
+              </LocalAssetLocalAsset2Wrapper>
+            </View2>
+            <View3>
+              <LocalAssetLocalAsset3Wrapper>
                 <LocalAsset />
-              </div>
-            </div>
-          </div>
-          <div style={styles.column2}>
-            <div style={styles.view4}>
-              <div style={styles.localAsset4}>
+              </LocalAssetLocalAsset3Wrapper>
+            </View3>
+          </Column1>
+          <Column2>
+            <View4>
+              <LocalAssetLocalAsset4Wrapper>
                 <LocalAsset />
-              </div>
-            </div>
-            <div style={styles.view5}>
-              <div style={styles.localAsset5}>
+              </LocalAssetLocalAsset4Wrapper>
+            </View4>
+            <View5>
+              <LocalAssetLocalAsset5Wrapper>
                 <LocalAsset />
-              </div>
-            </div>
-            <div style={styles.view6}>
-              <div style={styles.localAsset6}>
+              </LocalAssetLocalAsset5Wrapper>
+            </View5>
+            <View6>
+              <LocalAssetLocalAsset6Wrapper>
                 <LocalAsset />
-              </div>
-            </div>
-          </div>
-          <div style={styles.column3}>
-            <div style={styles.view7}>
-              <div style={styles.localAsset7}>
+              </LocalAssetLocalAsset6Wrapper>
+            </View6>
+          </Column2>
+          <Column3>
+            <View7>
+              <LocalAssetLocalAsset7Wrapper>
                 <LocalAsset />
-              </div>
-            </div>
-            <div style={styles.view8}>
-              <div style={styles.localAsset8}>
+              </LocalAssetLocalAsset7Wrapper>
+            </View7>
+            <View8>
+              <LocalAssetLocalAsset8Wrapper>
                 <LocalAsset />
-              </div>
-            </div>
-            <div style={styles.view9}>
-              <div style={styles.localAsset9}>
+              </LocalAssetLocalAsset8Wrapper>
+            </View8>
+            <View9>
+              <LocalAssetLocalAsset9Wrapper>
                 <LocalAsset />
-              </div>
-            </div>
-          </div>
-        </div>
-        <div style={styles.bottomRow}>
-          <div style={styles.column4}>
-            <div style={styles.view10}>
+              </LocalAssetLocalAsset9Wrapper>
+            </View9>
+          </Column3>
+        </TopRow>
+        <BottomRow>
+          <Column4>
+            <View10>
               <LocalAsset />
-            </div>
-            <div style={styles.view11}>
+            </View10>
+            <View11>
               <LocalAsset />
-            </div>
-            <div style={styles.view12}>
+            </View11>
+            <View12>
               <LocalAsset />
-            </div>
-          </div>
-          <div style={styles.column5}>
-            <div style={styles.view13}>
+            </View12>
+          </Column4>
+          <Column5>
+            <View13>
               <LocalAsset />
-            </div>
-            <div style={styles.view14}>
+            </View13>
+            <View14>
               <LocalAsset />
-            </div>
-            <div style={styles.view15}>
+            </View14>
+            <View15>
               <LocalAsset />
-            </div>
-          </div>
-          <div style={styles.column6}>
-            <div style={styles.view16}>
+            </View15>
+          </Column5>
+          <Column6>
+            <View16>
               <LocalAsset />
-            </div>
-            <div style={styles.view17}>
+            </View16>
+            <View17>
               <LocalAsset />
-            </div>
-            <div style={styles.view18}>
+            </View17>
+            <View18>
               <LocalAsset />
-            </div>
-          </div>
-        </div>
-      </div>
+            </View18>
+          </Column6>
+        </BottomRow>
+      </View>
     );
   }
 };
 
-let styles = {
-  view: {
-    alignItems: "flex-start",
-    display: "flex",
-    flex: "1 1 0%",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  topRow: {
-    alignItems: "flex-start",
-    display: "flex",
-    flex: "0 0 auto",
-    flexDirection: "row",
-    justifyContent: "flex-start"
-  },
-  bottomRow: {
-    alignItems: "flex-start",
-    display: "flex",
-    flex: "0 0 auto",
-    flexDirection: "row",
-    justifyContent: "flex-start"
-  },
-  column1: {
-    alignItems: "flex-start",
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    width: "150px"
-  },
-  column2: {
-    alignItems: "flex-start",
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    width: "150px"
-  },
-  column3: {
-    alignItems: "flex-start",
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    width: "150px"
-  },
-  view1: {
-    alignItems: "flex-start",
-    backgroundColor: colors.grey50,
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    width: "150px",
-    height: "150px"
-  },
-  view2: {
-    alignItems: "flex-start",
-    backgroundColor: "transparent",
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "center",
-    width: "150px",
-    height: "150px"
-  },
-  view3: {
-    alignItems: "flex-start",
-    backgroundColor: colors.grey50,
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-end",
-    width: "150px",
-    height: "150px"
-  },
-  localAsset: {
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    display: "flex",
-    flex: "1 1 auto",
-    flexDirection: "row",
-    justifyContent: "flex-start"
-  },
-  localAsset2: {
-    alignItems: "center",
-    alignSelf: "stretch",
-    display: "flex",
-    flex: "1 1 auto",
-    flexDirection: "row",
-    justifyContent: "flex-start"
-  },
-  localAsset3: {
-    alignItems: "flex-end",
-    alignSelf: "stretch",
-    display: "flex",
-    flex: "1 1 auto",
-    flexDirection: "row",
-    justifyContent: "flex-start"
-  },
-  view4: {
-    alignItems: "center",
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    width: "150px",
-    height: "150px"
-  },
-  view5: {
-    alignItems: "center",
-    backgroundColor: colors.grey50,
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "center",
-    width: "150px",
-    height: "150px"
-  },
-  view6: {
-    alignItems: "center",
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-end",
-    width: "150px",
-    height: "150px"
-  },
-  localAsset4: {
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    display: "flex",
-    flex: "1 1 auto",
-    flexDirection: "row",
-    justifyContent: "center"
-  },
-  localAsset5: {
-    alignItems: "center",
-    alignSelf: "stretch",
-    display: "flex",
-    flex: "1 1 auto",
-    flexDirection: "row",
-    justifyContent: "center"
-  },
-  localAsset6: {
-    alignItems: "flex-end",
-    alignSelf: "stretch",
-    display: "flex",
-    flex: "1 1 auto",
-    flexDirection: "row",
-    justifyContent: "center"
-  },
-  view7: {
-    alignItems: "flex-end",
-    backgroundColor: colors.grey50,
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    width: "150px",
-    height: "150px"
-  },
-  view8: {
-    alignItems: "flex-end",
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "center",
-    width: "150px",
-    height: "150px"
-  },
-  view9: {
-    alignItems: "flex-end",
-    backgroundColor: colors.grey50,
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-end",
-    width: "150px",
-    height: "150px"
-  },
-  localAsset7: {
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    display: "flex",
-    flex: "1 1 auto",
-    flexDirection: "row",
-    justifyContent: "flex-end"
-  },
-  localAsset8: {
-    alignItems: "center",
-    alignSelf: "stretch",
-    display: "flex",
-    flex: "1 1 auto",
-    flexDirection: "row",
-    justifyContent: "flex-end"
-  },
-  localAsset9: {
-    alignItems: "flex-end",
-    alignSelf: "stretch",
-    display: "flex",
-    flex: "1 1 auto",
-    flexDirection: "row",
-    justifyContent: "flex-end"
-  },
-  column4: {
-    alignItems: "flex-start",
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    width: "150px"
-  },
-  column5: {
-    alignItems: "flex-start",
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    width: "150px"
-  },
-  column6: {
-    alignItems: "flex-start",
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    width: "150px"
-  },
-  view10: {
-    alignItems: "flex-start",
-    backgroundColor: colors.grey50,
-    display: "flex",
-    flexDirection: "row",
-    justifyContent: "flex-start",
-    width: "150px",
-    height: "150px"
-  },
-  view11: {
-    alignItems: "center",
-    backgroundColor: "transparent",
-    display: "flex",
-    flexDirection: "row",
-    justifyContent: "flex-start",
-    width: "150px",
-    height: "150px"
-  },
-  view12: {
-    alignItems: "flex-end",
-    backgroundColor: colors.grey50,
-    display: "flex",
-    flexDirection: "row",
-    justifyContent: "flex-start",
-    width: "150px",
-    height: "150px"
-  },
-  localAsset10: {
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    display: "flex",
-    flex: "1 1 auto",
-    flexDirection: "row",
-    justifyContent: "flex-start"
-  },
-  localAsset11: {
-    alignItems: "center",
-    alignSelf: "stretch",
-    display: "flex",
-    flex: "1 1 auto",
-    flexDirection: "row",
-    justifyContent: "flex-start"
-  },
-  localAsset12: {
-    alignItems: "flex-end",
-    alignSelf: "stretch",
-    display: "flex",
-    flex: "1 1 auto",
-    flexDirection: "row",
-    justifyContent: "flex-start"
-  },
-  view13: {
-    alignItems: "flex-start",
-    display: "flex",
-    flexDirection: "row",
-    justifyContent: "center",
-    width: "150px",
-    height: "150px"
-  },
-  view14: {
-    alignItems: "center",
-    backgroundColor: colors.grey50,
-    display: "flex",
-    flexDirection: "row",
-    justifyContent: "center",
-    width: "150px",
-    height: "150px"
-  },
-  view15: {
-    alignItems: "flex-end",
-    display: "flex",
-    flexDirection: "row",
-    justifyContent: "center",
-    width: "150px",
-    height: "150px"
-  },
-  localAsset13: {
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    display: "flex",
-    flex: "1 1 auto",
-    flexDirection: "row",
-    justifyContent: "center"
-  },
-  localAsset14: {
-    alignItems: "center",
-    alignSelf: "stretch",
-    display: "flex",
-    flex: "1 1 auto",
-    flexDirection: "row",
-    justifyContent: "center"
-  },
-  localAsset15: {
-    alignItems: "flex-end",
-    alignSelf: "stretch",
-    display: "flex",
-    flex: "1 1 auto",
-    flexDirection: "row",
-    justifyContent: "center"
-  },
-  view16: {
-    alignItems: "flex-start",
-    backgroundColor: colors.grey50,
-    display: "flex",
-    flexDirection: "row",
-    justifyContent: "flex-end",
-    width: "150px",
-    height: "150px"
-  },
-  view17: {
-    alignItems: "center",
-    display: "flex",
-    flexDirection: "row",
-    justifyContent: "flex-end",
-    width: "150px",
-    height: "150px"
-  },
-  view18: {
-    alignItems: "flex-end",
-    backgroundColor: colors.grey50,
-    display: "flex",
-    flexDirection: "row",
-    justifyContent: "flex-end",
-    width: "150px",
-    height: "150px"
-  },
-  localAsset16: {
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    display: "flex",
-    flex: "1 1 auto",
-    flexDirection: "row",
-    justifyContent: "flex-end"
-  },
-  localAsset17: {
-    alignItems: "center",
-    alignSelf: "stretch",
-    display: "flex",
-    flex: "1 1 auto",
-    flexDirection: "row",
-    justifyContent: "flex-end"
-  },
-  localAsset18: {
-    alignItems: "flex-end",
-    alignSelf: "stretch",
-    display: "flex",
-    flex: "1 1 auto",
-    flexDirection: "row",
-    justifyContent: "flex-end"
-  }
-}
+let View = styled.div({
+  alignItems: "flex-start",
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let TopRow = styled.div({
+  alignItems: "flex-start",
+  display: "flex",
+  flex: "0 0 auto",
+  flexDirection: "row",
+  justifyContent: "flex-start"
+})
+
+let Column1 = styled.div({
+  alignItems: "flex-start",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  width: "150px"
+})
+
+let View1 = styled.div({
+  alignItems: "flex-start",
+  backgroundColor: colors.grey50,
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  width: "150px",
+  height: "150px"
+})
+
+let LocalAssetLocalAssetWrapper = styled.div({
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  display: "flex",
+  flex: "1 1 auto",
+  flexDirection: "row",
+  justifyContent: "flex-start"
+})
+
+let View2 = styled.div({
+  alignItems: "flex-start",
+  backgroundColor: "transparent",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "center",
+  width: "150px",
+  height: "150px"
+})
+
+let LocalAssetLocalAsset2Wrapper = styled.div({
+  alignItems: "center",
+  alignSelf: "stretch",
+  display: "flex",
+  flex: "1 1 auto",
+  flexDirection: "row",
+  justifyContent: "flex-start"
+})
+
+let View3 = styled.div({
+  alignItems: "flex-start",
+  backgroundColor: colors.grey50,
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-end",
+  width: "150px",
+  height: "150px"
+})
+
+let LocalAssetLocalAsset3Wrapper = styled.div({
+  alignItems: "flex-end",
+  alignSelf: "stretch",
+  display: "flex",
+  flex: "1 1 auto",
+  flexDirection: "row",
+  justifyContent: "flex-start"
+})
+
+let Column2 = styled.div({
+  alignItems: "flex-start",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  width: "150px"
+})
+
+let View4 = styled.div({
+  alignItems: "center",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  width: "150px",
+  height: "150px"
+})
+
+let LocalAssetLocalAsset4Wrapper = styled.div({
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  display: "flex",
+  flex: "1 1 auto",
+  flexDirection: "row",
+  justifyContent: "center"
+})
+
+let View5 = styled.div({
+  alignItems: "center",
+  backgroundColor: colors.grey50,
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "center",
+  width: "150px",
+  height: "150px"
+})
+
+let LocalAssetLocalAsset5Wrapper = styled.div({
+  alignItems: "center",
+  alignSelf: "stretch",
+  display: "flex",
+  flex: "1 1 auto",
+  flexDirection: "row",
+  justifyContent: "center"
+})
+
+let View6 = styled.div({
+  alignItems: "center",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-end",
+  width: "150px",
+  height: "150px"
+})
+
+let LocalAssetLocalAsset6Wrapper = styled.div({
+  alignItems: "flex-end",
+  alignSelf: "stretch",
+  display: "flex",
+  flex: "1 1 auto",
+  flexDirection: "row",
+  justifyContent: "center"
+})
+
+let Column3 = styled.div({
+  alignItems: "flex-start",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  width: "150px"
+})
+
+let View7 = styled.div({
+  alignItems: "flex-end",
+  backgroundColor: colors.grey50,
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  width: "150px",
+  height: "150px"
+})
+
+let LocalAssetLocalAsset7Wrapper = styled.div({
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  display: "flex",
+  flex: "1 1 auto",
+  flexDirection: "row",
+  justifyContent: "flex-end"
+})
+
+let View8 = styled.div({
+  alignItems: "flex-end",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "center",
+  width: "150px",
+  height: "150px"
+})
+
+let LocalAssetLocalAsset8Wrapper = styled.div({
+  alignItems: "center",
+  alignSelf: "stretch",
+  display: "flex",
+  flex: "1 1 auto",
+  flexDirection: "row",
+  justifyContent: "flex-end"
+})
+
+let View9 = styled.div({
+  alignItems: "flex-end",
+  backgroundColor: colors.grey50,
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-end",
+  width: "150px",
+  height: "150px"
+})
+
+let LocalAssetLocalAsset9Wrapper = styled.div({
+  alignItems: "flex-end",
+  alignSelf: "stretch",
+  display: "flex",
+  flex: "1 1 auto",
+  flexDirection: "row",
+  justifyContent: "flex-end"
+})
+
+let BottomRow = styled.div({
+  alignItems: "flex-start",
+  display: "flex",
+  flex: "0 0 auto",
+  flexDirection: "row",
+  justifyContent: "flex-start"
+})
+
+let Column4 = styled.div({
+  alignItems: "flex-start",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  width: "150px"
+})
+
+let View10 = styled.div({
+  alignItems: "flex-start",
+  backgroundColor: colors.grey50,
+  display: "flex",
+  flexDirection: "row",
+  justifyContent: "flex-start",
+  width: "150px",
+  height: "150px"
+})
+
+let LocalAssetLocalAsset10Wrapper = styled.div({
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  display: "flex",
+  flex: "1 1 auto",
+  flexDirection: "row",
+  justifyContent: "flex-start"
+})
+
+let View11 = styled.div({
+  alignItems: "center",
+  backgroundColor: "transparent",
+  display: "flex",
+  flexDirection: "row",
+  justifyContent: "flex-start",
+  width: "150px",
+  height: "150px"
+})
+
+let LocalAssetLocalAsset11Wrapper = styled.div({
+  alignItems: "center",
+  alignSelf: "stretch",
+  display: "flex",
+  flex: "1 1 auto",
+  flexDirection: "row",
+  justifyContent: "flex-start"
+})
+
+let View12 = styled.div({
+  alignItems: "flex-end",
+  backgroundColor: colors.grey50,
+  display: "flex",
+  flexDirection: "row",
+  justifyContent: "flex-start",
+  width: "150px",
+  height: "150px"
+})
+
+let LocalAssetLocalAsset12Wrapper = styled.div({
+  alignItems: "flex-end",
+  alignSelf: "stretch",
+  display: "flex",
+  flex: "1 1 auto",
+  flexDirection: "row",
+  justifyContent: "flex-start"
+})
+
+let Column5 = styled.div({
+  alignItems: "flex-start",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  width: "150px"
+})
+
+let View13 = styled.div({
+  alignItems: "flex-start",
+  display: "flex",
+  flexDirection: "row",
+  justifyContent: "center",
+  width: "150px",
+  height: "150px"
+})
+
+let LocalAssetLocalAsset13Wrapper = styled.div({
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  display: "flex",
+  flex: "1 1 auto",
+  flexDirection: "row",
+  justifyContent: "center"
+})
+
+let View14 = styled.div({
+  alignItems: "center",
+  backgroundColor: colors.grey50,
+  display: "flex",
+  flexDirection: "row",
+  justifyContent: "center",
+  width: "150px",
+  height: "150px"
+})
+
+let LocalAssetLocalAsset14Wrapper = styled.div({
+  alignItems: "center",
+  alignSelf: "stretch",
+  display: "flex",
+  flex: "1 1 auto",
+  flexDirection: "row",
+  justifyContent: "center"
+})
+
+let View15 = styled.div({
+  alignItems: "flex-end",
+  display: "flex",
+  flexDirection: "row",
+  justifyContent: "center",
+  width: "150px",
+  height: "150px"
+})
+
+let LocalAssetLocalAsset15Wrapper = styled.div({
+  alignItems: "flex-end",
+  alignSelf: "stretch",
+  display: "flex",
+  flex: "1 1 auto",
+  flexDirection: "row",
+  justifyContent: "center"
+})
+
+let Column6 = styled.div({
+  alignItems: "flex-start",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  width: "150px"
+})
+
+let View16 = styled.div({
+  alignItems: "flex-start",
+  backgroundColor: colors.grey50,
+  display: "flex",
+  flexDirection: "row",
+  justifyContent: "flex-end",
+  width: "150px",
+  height: "150px"
+})
+
+let LocalAssetLocalAsset16Wrapper = styled.div({
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  display: "flex",
+  flex: "1 1 auto",
+  flexDirection: "row",
+  justifyContent: "flex-end"
+})
+
+let View17 = styled.div({
+  alignItems: "center",
+  display: "flex",
+  flexDirection: "row",
+  justifyContent: "flex-end",
+  width: "150px",
+  height: "150px"
+})
+
+let LocalAssetLocalAsset17Wrapper = styled.div({
+  alignItems: "center",
+  alignSelf: "stretch",
+  display: "flex",
+  flex: "1 1 auto",
+  flexDirection: "row",
+  justifyContent: "flex-end"
+})
+
+let View18 = styled.div({
+  alignItems: "flex-end",
+  backgroundColor: colors.grey50,
+  display: "flex",
+  flexDirection: "row",
+  justifyContent: "flex-end",
+  width: "150px",
+  height: "150px"
+})
+
+let LocalAssetLocalAsset18Wrapper = styled.div({
+  alignItems: "flex-end",
+  alignSelf: "stretch",
+  display: "flex",
+  flex: "1 1 auto",
+  flexDirection: "row",
+  justifyContent: "flex-end"
+})

--- a/examples/generated/test/react-dom/components/NestedOptionals.js
+++ b/examples/generated/test/react-dom/components/NestedOptionals.js
@@ -1,4 +1,5 @@
 import React from "react"
+import styled from "styled-components"
 
 import colors from "../colors"
 import shadows from "../shadows"
@@ -10,29 +11,28 @@ export default class NestedOptionals extends React.Component {
 
 
     return (
-      <div style={styles.view}>
-        <div style={styles.optionals}>
+      <View>
+        <OptionalsOptionalsWrapper>
           <Optionals boolParam={null} stringParam={"Text"} />
-        </div>
-      </div>
+        </OptionalsOptionalsWrapper>
+      </View>
     );
   }
 };
 
-let styles = {
-  view: {
-    alignItems: "flex-start",
-    display: "flex",
-    flex: "1 1 0%",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  optionals: {
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    display: "flex",
-    flex: "1 1 auto",
-    flexDirection: "row",
-    justifyContent: "flex-start"
-  }
-}
+let View = styled.div({
+  alignItems: "flex-start",
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let OptionalsOptionalsWrapper = styled.div({
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  display: "flex",
+  flex: "1 1 auto",
+  flexDirection: "row",
+  justifyContent: "flex-start"
+})

--- a/examples/generated/test/react-dom/images/ImageCropping.js
+++ b/examples/generated/test/react-dom/images/ImageCropping.js
@@ -1,4 +1,5 @@
 import React from "react"
+import styled from "styled-components"
 
 import colors from "../colors"
 import shadows from "../shadows"
@@ -9,119 +10,105 @@ export default class ImageCropping extends React.Component {
 
 
     return (
-      <div style={styles.view}>
-        <div style={styles.aspectFit}>
-          <img
-            style={styles.imageResizeModeContain}
-            src={require("../assets/icon_128x128.png")}
-
-          />
-        </div>
-        <div style={styles.aspectFill}>
-          <img
-            style={styles.imageResizeModeCover}
-            src={require("../assets/icon_128x128.png")}
-
-          />
-        </div>
-        <div style={styles.stretchFill}>
-          <img
-            style={styles.imageResizeModeStretch}
-            src={require("../assets/icon_128x128.png")}
-
-          />
-        </div>
-        <img
-          style={styles.fixedAspectFill}
-          src={require("../assets/icon_128x128.png")}
-
-        />
-        <img
-          style={styles.fixedStretch}
-          src={require("../assets/icon_128x128.png")}
-
-        />
-      </div>
+      <View>
+        <AspectFit>
+          <ImageResizeModeContain src={require("../assets/icon_128x128.png")} />
+        </AspectFit>
+        <AspectFill>
+          <ImageResizeModeCover src={require("../assets/icon_128x128.png")} />
+        </AspectFill>
+        <StretchFill>
+          <ImageResizeModeStretch src={require("../assets/icon_128x128.png")} />
+        </StretchFill>
+        <FixedAspectFill src={require("../assets/icon_128x128.png")} />
+        <FixedStretch src={require("../assets/icon_128x128.png")} />
+      </View>
     );
   }
 };
 
-let styles = {
-  view: {
-    alignItems: "flex-start",
-    display: "flex",
-    flex: "1 1 0%",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  aspectFit: {
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    overflow: "hidden",
-    height: "100px",
-    position: "relative"
-  },
-  aspectFill: {
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    overflow: "hidden",
-    height: "100px",
-    position: "relative"
-  },
-  stretchFill: {
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    overflow: "hidden",
-    height: "100px",
-    position: "relative"
-  },
-  fixedAspectFill: {
-    alignItems: "flex-start",
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    overflow: "hidden",
-    width: "200px",
-    height: "100px",
-    objectFit: "cover",
-    position: "relative"
-  },
-  fixedStretch: {
-    alignItems: "flex-start",
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    overflow: "hidden",
-    width: "200px",
-    height: "100px",
-    objectFit: "fill",
-    position: "relative"
-  },
-  imageResizeModeContain: {
-    width: "100%",
-    height: "100%",
-    objectFit: "contain",
-    position: "absolute"
-  },
-  imageResizeModeCover: {
-    width: "100%",
-    height: "100%",
-    objectFit: "cover",
-    position: "absolute"
-  },
-  imageResizeModeStretch: {
-    width: "100%",
-    height: "100%",
-    objectFit: "stretch",
-    position: "absolute"
-  }
-}
+let ImageResizeModeContain = styled.img({
+  width: "100%",
+  height: "100%",
+  objectFit: "contain",
+  position: "absolute"
+})
+
+let ImageResizeModeCover = styled.img({
+  width: "100%",
+  height: "100%",
+  objectFit: "cover",
+  position: "absolute"
+})
+
+let ImageResizeModeStretch = styled.img({
+  width: "100%",
+  height: "100%",
+  objectFit: "stretch",
+  position: "absolute"
+})
+
+let View = styled.div({
+  alignItems: "flex-start",
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let AspectFit = styled.div({
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  overflow: "hidden",
+  height: "100px",
+  position: "relative"
+})
+
+let AspectFill = styled.div({
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  overflow: "hidden",
+  height: "100px",
+  position: "relative"
+})
+
+let StretchFill = styled.div({
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  overflow: "hidden",
+  height: "100px",
+  position: "relative"
+})
+
+let FixedAspectFill = styled.img({
+  alignItems: "flex-start",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  overflow: "hidden",
+  width: "200px",
+  height: "100px",
+  objectFit: "cover",
+  position: "relative"
+})
+
+let FixedStretch = styled.img({
+  alignItems: "flex-start",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  overflow: "hidden",
+  width: "200px",
+  height: "100px",
+  objectFit: "fill",
+  position: "relative"
+})

--- a/examples/generated/test/react-dom/images/LocalAsset.js
+++ b/examples/generated/test/react-dom/images/LocalAsset.js
@@ -1,4 +1,5 @@
 import React from "react"
+import styled from "styled-components"
 
 import colors from "../colors"
 import shadows from "../shadows"
@@ -8,39 +9,35 @@ export default class LocalAsset extends React.Component {
   render() {
 
 
-    return (
-      <div style={styles.view}>
-        <img style={styles.image} src={require("../assets/icon_128x128.png")} />
-      </div>
-    );
+    return <View> <Image src={require("../assets/icon_128x128.png")} /> </View>;
   }
 };
 
-let styles = {
-  view: {
-    alignItems: "flex-start",
-    backgroundColor: colors.red400,
-    display: "flex",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  image: {
-    alignItems: "flex-start",
-    backgroundColor: "#D8D8D8",
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    overflow: "hidden",
-    width: "100px",
-    height: "100px",
-    objectFit: "cover",
-    position: "relative"
-  },
-  imageResizeModeCover: {
-    width: "100%",
-    height: "100%",
-    objectFit: "cover",
-    position: "absolute"
-  }
-}
+let ImageResizeModeCover = styled.img({
+  width: "100%",
+  height: "100%",
+  objectFit: "cover",
+  position: "absolute"
+})
+
+let View = styled.div({
+  alignItems: "flex-start",
+  backgroundColor: colors.red400,
+  display: "flex",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let Image = styled.img({
+  alignItems: "flex-start",
+  backgroundColor: "#D8D8D8",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  overflow: "hidden",
+  width: "100px",
+  height: "100px",
+  objectFit: "cover",
+  position: "relative"
+})

--- a/examples/generated/test/react-dom/images/VectorAsset.js
+++ b/examples/generated/test/react-dom/images/VectorAsset.js
@@ -1,12 +1,13 @@
 import React from "react"
+import styled from "styled-components"
 
 import colors from "../colors"
 import shadows from "../shadows"
 import textStyles from "../textStyles"
 
-let ToggleVector = (props) => {
+let VectorGraphic1ToggleVector = (props) => {
   return (
-    <svg
+    <VectorGraphic1
       style={props.style}
       preserveAspectRatio={props.preserveAspectRatio || "xMidYMid slice"}
       viewBox={"0 0 48 24"}
@@ -24,12 +25,12 @@ let ToggleVector = (props) => {
         fill={"#FFFFFF"}
 
       />
-    </svg>
+    </VectorGraphic1>
   );
 }
-let ToggleVerticalVector = (props) => {
+let VectorGraphic2ToggleVerticalVector = (props) => {
   return (
-    <svg
+    <VectorGraphic2
       style={props.style}
       preserveAspectRatio={props.preserveAspectRatio || "xMidYMid slice"}
       viewBox={"0 0 24 48"}
@@ -47,12 +48,12 @@ let ToggleVerticalVector = (props) => {
         fill={"#FFFFFF"}
 
       />
-    </svg>
+    </VectorGraphic2>
   );
 }
-let CheckCircleVector = (props) => {
+let VectorGraphic3CheckCircleVector = (props) => {
   return (
-    <svg
+    <VectorGraphic3
       style={props.style}
       preserveAspectRatio={props.preserveAspectRatio || "xMidYMid slice"}
       viewBox={"0 0 24 24"}
@@ -70,7 +71,7 @@ let CheckCircleVector = (props) => {
         strokeLinecap={"round"}
 
       />
-    </svg>
+    </VectorGraphic3>
   );
 }
 
@@ -79,56 +80,52 @@ export default class VectorAsset extends React.Component {
 
 
     return (
-      <div style={styles.view}>
-        <ToggleVector
-          style={styles.vectorGraphic1}
+      <View>
+        <VectorGraphic1ToggleVector preserveAspectRatio={"xMidYMid meet"} />
+        <VectorGraphic2ToggleVerticalVector
           preserveAspectRatio={"xMidYMid meet"}
 
         />
-        <ToggleVerticalVector
-          style={styles.vectorGraphic2}
-          preserveAspectRatio={"xMidYMid meet"}
-
-        />
-        <CheckCircleVector style={styles.vectorGraphic3} />
-      </div>
+        <VectorGraphic3CheckCircleVector />
+      </View>
     );
   }
 };
 
-let styles = {
-  view: {
-    alignItems: "flex-start",
-    display: "flex",
-    flex: "1 1 0%",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  vectorGraphic1: {
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    height: "100px",
-    objectFit: "contain"
-  },
-  vectorGraphic2: {
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    height: "100px",
-    objectFit: "contain"
-  },
-  vectorGraphic3: {
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    backgroundColor: colors.green50,
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    height: "200px"
-  }
-}
+let View = styled.div({
+  alignItems: "flex-start",
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let VectorGraphic1 = styled.svg({
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  height: "100px",
+  objectFit: "contain"
+})
+
+let VectorGraphic2 = styled.svg({
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  height: "100px",
+  objectFit: "contain"
+})
+
+let VectorGraphic3 = styled.svg({
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  backgroundColor: colors.green50,
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  height: "200px"
+})

--- a/examples/generated/test/react-dom/interactivity/Button.js
+++ b/examples/generated/test/react-dom/interactivity/Button.js
@@ -1,4 +1,5 @@
 import React from "react"
+import styled from "styled-components"
 
 import colors from "../colors"
 import shadows from "../shadows"
@@ -27,39 +28,36 @@ export default class Button extends React.Component {
     }
     return (
       <button
-        style={Object.assign({}, styles.view, {
-          backgroundColor: View$backgroundColor
-        })}
+        style={{ backgroundColor: View$backgroundColor }}
         onClick={View$onPress}
       >
-        <span style={styles.text}>
+        <Text>
           {Text$text}
-        </span>
+        </Text>
       </button>
     );
   }
 };
 
-let styles = {
-  view: {
-    alignItems: "flex-start",
-    backgroundColor: colors.blue100,
-    display: "flex",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    paddingTop: "12px",
-    paddingRight: "16px",
-    paddingBottom: "12px",
-    paddingLeft: "16px"
-  },
-  text: {
-    textAlign: "left",
-    ...textStyles.button,
-    alignItems: "flex-start",
-    display: "block",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  }
-}
+let View = styled.div({
+  alignItems: "flex-start",
+  backgroundColor: colors.blue100,
+  display: "flex",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  paddingTop: "12px",
+  paddingRight: "16px",
+  paddingBottom: "12px",
+  paddingLeft: "16px"
+})
+
+let Text = styled.span({
+  textAlign: "left",
+  ...textStyles.button,
+  alignItems: "flex-start",
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})

--- a/examples/generated/test/react-dom/interactivity/PressableRootView.js
+++ b/examples/generated/test/react-dom/interactivity/PressableRootView.js
@@ -1,4 +1,5 @@
 import React from "react"
+import styled from "styled-components"
 
 import colors from "../colors"
 import shadows from "../shadows"
@@ -42,56 +43,52 @@ export default class PressableRootView extends React.Component {
       }
     }
     return (
-      <div
-        style={Object.assign({}, styles.outer, {
-          backgroundColor: Outer$backgroundColor
-        })}
+      <Outer
+        style={{ backgroundColor: Outer$backgroundColor }}
         onClick={Outer$onPress}
       >
-        <div
-          style={Object.assign({}, styles.inner, {
-            backgroundColor: Inner$backgroundColor
-          })}
+        <Inner
+          style={{ backgroundColor: Inner$backgroundColor }}
           onClick={Inner$onPress}
         >
-          <span style={styles.innerText}>
+          <InnerText>
             {InnerText$text}
-          </span>
-        </div>
-      </div>
+          </InnerText>
+        </Inner>
+      </Outer>
     );
   }
 };
 
-let styles = {
-  outer: {
-    alignItems: "flex-start",
-    backgroundColor: colors.grey50,
-    display: "flex",
-    flex: "1 1 0%",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    paddingTop: "24px",
-    paddingRight: "24px",
-    paddingBottom: "24px",
-    paddingLeft: "24px"
-  },
-  inner: {
-    alignItems: "flex-start",
-    backgroundColor: colors.blue500,
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    width: "100px",
-    height: "100px"
-  },
-  innerText: {
-    textAlign: "left",
-    ...textStyles.headline,
-    alignItems: "flex-start",
-    display: "block",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  }
-}
+let Outer = styled.div({
+  alignItems: "flex-start",
+  backgroundColor: colors.grey50,
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  paddingTop: "24px",
+  paddingRight: "24px",
+  paddingBottom: "24px",
+  paddingLeft: "24px"
+})
+
+let Inner = styled.div({
+  alignItems: "flex-start",
+  backgroundColor: colors.blue500,
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  width: "100px",
+  height: "100px"
+})
+
+let InnerText = styled.span({
+  textAlign: "left",
+  ...textStyles.headline,
+  alignItems: "flex-start",
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})

--- a/examples/generated/test/react-dom/layouts/FillWidthFitHeightCard.js
+++ b/examples/generated/test/react-dom/layouts/FillWidthFitHeightCard.js
@@ -1,4 +1,5 @@
 import React from "react"
+import styled from "styled-components"
 
 import colors from "../colors"
 import shadows from "../shadows"
@@ -9,68 +10,66 @@ export default class FillWidthFitHeightCard extends React.Component {
 
 
     return (
-      <div style={styles.view}>
-        <div style={styles.image}>
-          <img
-            style={styles.imageResizeModeCover}
-            src={require("../assets/icon_128x128.png")}
-
-          />
-        </div>
-        <span style={styles.text1}>
+      <View>
+        <Image>
+          <ImageResizeModeCover src={require("../assets/icon_128x128.png")} />
+        </Image>
+        <Text1>
           {"Title"}
-        </span>
-        <span style={styles.text}>
+        </Text1>
+        <Text>
           {"Subtitle"}
-        </span>
-      </div>
+        </Text>
+      </View>
     );
   }
 };
 
-let styles = {
-  view: {
-    alignItems: "flex-start",
-    display: "flex",
-    flex: "1 1 0%",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  image: {
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    backgroundColor: colors.blue200,
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    overflow: "hidden",
-    height: "100px",
-    position: "relative"
-  },
-  text1: {
-    textAlign: "left",
-    ...textStyles.body2,
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    display: "block",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  text: {
-    textAlign: "left",
-    ...textStyles.body1,
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    display: "block",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  imageResizeModeCover: {
-    width: "100%",
-    height: "100%",
-    objectFit: "cover",
-    position: "absolute"
-  }
-}
+let ImageResizeModeCover = styled.img({
+  width: "100%",
+  height: "100%",
+  objectFit: "cover",
+  position: "absolute"
+})
+
+let View = styled.div({
+  alignItems: "flex-start",
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let Image = styled.div({
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  backgroundColor: colors.blue200,
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  overflow: "hidden",
+  height: "100px",
+  position: "relative"
+})
+
+let Text1 = styled.span({
+  textAlign: "left",
+  ...textStyles.body2,
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let Text = styled.span({
+  textAlign: "left",
+  ...textStyles.body1,
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})

--- a/examples/generated/test/react-dom/layouts/FitContentParentSecondaryChildren.js
+++ b/examples/generated/test/react-dom/layouts/FitContentParentSecondaryChildren.js
@@ -1,4 +1,5 @@
 import React from "react"
+import styled from "styled-components"
 
 import colors from "../colors"
 import shadows from "../shadows"
@@ -8,54 +9,49 @@ export default class FitContentParentSecondaryChildren extends React.Component {
   render() {
 
 
-    return (
-      <div style={styles.container}>
-        <div style={styles.view1} />
-        <div style={styles.view3} />
-        <div style={styles.view2} />
-      </div>
-    );
+    return <Container> <View1 /> <View3 /> <View2 /> </Container>;
   }
 };
 
-let styles = {
-  container: {
-    alignItems: "flex-start",
-    backgroundColor: colors.bluegrey50,
-    display: "flex",
-    flex: "1 1 0%",
-    flexDirection: "row",
-    justifyContent: "flex-start",
-    paddingTop: "24px",
-    paddingRight: "24px",
-    paddingBottom: "24px",
-    paddingLeft: "24px"
-  },
-  view1: {
-    alignItems: "flex-start",
-    backgroundColor: colors.blue500,
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    width: "60px",
-    height: "60px"
-  },
-  view3: {
-    alignItems: "flex-start",
-    backgroundColor: colors.lightblue500,
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    width: "100px",
-    height: "120px"
-  },
-  view2: {
-    alignItems: "flex-start",
-    backgroundColor: colors.cyan500,
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    width: "100px",
-    height: "180px"
-  }
-}
+let Container = styled.div({
+  alignItems: "flex-start",
+  backgroundColor: colors.bluegrey50,
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "row",
+  justifyContent: "flex-start",
+  paddingTop: "24px",
+  paddingRight: "24px",
+  paddingBottom: "24px",
+  paddingLeft: "24px"
+})
+
+let View1 = styled.div({
+  alignItems: "flex-start",
+  backgroundColor: colors.blue500,
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  width: "60px",
+  height: "60px"
+})
+
+let View3 = styled.div({
+  alignItems: "flex-start",
+  backgroundColor: colors.lightblue500,
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  width: "100px",
+  height: "120px"
+})
+
+let View2 = styled.div({
+  alignItems: "flex-start",
+  backgroundColor: colors.cyan500,
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  width: "100px",
+  height: "180px"
+})

--- a/examples/generated/test/react-dom/layouts/FixedParentFillAndFitChildren.js
+++ b/examples/generated/test/react-dom/layouts/FixedParentFillAndFitChildren.js
@@ -1,4 +1,5 @@
 import React from "react"
+import styled from "styled-components"
 
 import colors from "../colors"
 import shadows from "../shadows"
@@ -9,79 +10,82 @@ export default class FixedParentFillAndFitChildren extends React.Component {
 
 
     return (
-      <div style={styles.view}>
-        <div style={styles.view1}>
-          <div style={styles.view4} />
-          <div style={styles.view5} />
-        </div>
-        <div style={styles.view2} />
-        <div style={styles.view3} />
-      </div>
+      <View>
+        <View1>
+          <View4 />
+          <View5 />
+        </View1>
+        <View2 />
+        <View3 />
+      </View>
     );
   }
 };
 
-let styles = {
-  view: {
-    alignItems: "flex-start",
-    display: "flex",
-    flex: "1 1 0%",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    paddingTop: "24px",
-    paddingRight: "24px",
-    paddingBottom: "24px",
-    paddingLeft: "24px",
-    height: "600px"
-  },
-  view1: {
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    backgroundColor: colors.red50,
-    display: "flex",
-    flex: "0 0 auto",
-    flexDirection: "row",
-    justifyContent: "flex-start",
-    paddingTop: "24px",
-    paddingRight: "24px",
-    paddingBottom: "24px",
-    paddingLeft: "24px"
-  },
-  view2: {
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    backgroundColor: colors.indigo100,
-    display: "flex",
-    flex: "1 1 0%",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  view3: {
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    backgroundColor: colors.teal100,
-    display: "flex",
-    flex: "1 1 0%",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  view4: {
-    alignItems: "flex-start",
-    backgroundColor: colors.red200,
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    width: "60px",
-    height: "100px"
-  },
-  view5: {
-    alignItems: "flex-start",
-    backgroundColor: colors.deeporange200,
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    marginLeft: "12px",
-    width: "60px",
-    height: "60px"
-  }
-}
+let View = styled.div({
+  alignItems: "flex-start",
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  paddingTop: "24px",
+  paddingRight: "24px",
+  paddingBottom: "24px",
+  paddingLeft: "24px",
+  height: "600px"
+})
+
+let View1 = styled.div({
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  backgroundColor: colors.red50,
+  display: "flex",
+  flex: "0 0 auto",
+  flexDirection: "row",
+  justifyContent: "flex-start",
+  paddingTop: "24px",
+  paddingRight: "24px",
+  paddingBottom: "24px",
+  paddingLeft: "24px"
+})
+
+let View4 = styled.div({
+  alignItems: "flex-start",
+  backgroundColor: colors.red200,
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  width: "60px",
+  height: "100px"
+})
+
+let View5 = styled.div({
+  alignItems: "flex-start",
+  backgroundColor: colors.deeporange200,
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  marginLeft: "12px",
+  width: "60px",
+  height: "60px"
+})
+
+let View2 = styled.div({
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  backgroundColor: colors.indigo100,
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let View3 = styled.div({
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  backgroundColor: colors.teal100,
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})

--- a/examples/generated/test/react-dom/layouts/FixedParentFitChild.js
+++ b/examples/generated/test/react-dom/layouts/FixedParentFitChild.js
@@ -1,4 +1,5 @@
 import React from "react"
+import styled from "styled-components"
 
 import colors from "../colors"
 import shadows from "../shadows"
@@ -8,61 +9,55 @@ export default class FixedParentFitChild extends React.Component {
   render() {
 
 
-    return (
-      <div style={styles.view}>
-        <div style={styles.view1}>
-          <div style={styles.view4} />
-          <div style={styles.view5} />
-        </div>
-      </div>
-    );
+    return <View> <View1> <View4 /> <View5 /> </View1> </View>;
   }
 };
 
-let styles = {
-  view: {
-    alignItems: "flex-start",
-    backgroundColor: colors.bluegrey100,
-    display: "flex",
-    flex: "1 1 0%",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    paddingTop: "24px",
-    paddingRight: "24px",
-    paddingBottom: "24px",
-    paddingLeft: "24px",
-    height: "600px"
-  },
-  view1: {
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    backgroundColor: colors.red50,
-    display: "flex",
-    flex: "0 0 auto",
-    flexDirection: "row",
-    justifyContent: "flex-start",
-    paddingTop: "24px",
-    paddingRight: "24px",
-    paddingBottom: "24px",
-    paddingLeft: "24px"
-  },
-  view4: {
-    alignItems: "flex-start",
-    backgroundColor: colors.red200,
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    width: "60px",
-    height: "100px"
-  },
-  view5: {
-    alignItems: "flex-start",
-    backgroundColor: colors.deeporange200,
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    marginLeft: "12px",
-    width: "60px",
-    height: "60px"
-  }
-}
+let View = styled.div({
+  alignItems: "flex-start",
+  backgroundColor: colors.bluegrey100,
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  paddingTop: "24px",
+  paddingRight: "24px",
+  paddingBottom: "24px",
+  paddingLeft: "24px",
+  height: "600px"
+})
+
+let View1 = styled.div({
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  backgroundColor: colors.red50,
+  display: "flex",
+  flex: "0 0 auto",
+  flexDirection: "row",
+  justifyContent: "flex-start",
+  paddingTop: "24px",
+  paddingRight: "24px",
+  paddingBottom: "24px",
+  paddingLeft: "24px"
+})
+
+let View4 = styled.div({
+  alignItems: "flex-start",
+  backgroundColor: colors.red200,
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  width: "60px",
+  height: "100px"
+})
+
+let View5 = styled.div({
+  alignItems: "flex-start",
+  backgroundColor: colors.deeporange200,
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  marginLeft: "12px",
+  width: "60px",
+  height: "60px"
+})

--- a/examples/generated/test/react-dom/layouts/MultipleFlexText.js
+++ b/examples/generated/test/react-dom/layouts/MultipleFlexText.js
@@ -1,4 +1,5 @@
 import React from "react"
+import styled from "styled-components"
 
 import colors from "../colors"
 import shadows from "../shadows"
@@ -9,86 +10,90 @@ export default class MultipleFlexText extends React.Component {
 
 
     return (
-      <div style={styles.view}>
-        <div style={styles.view1}>
-          <div style={styles.view3}>
-            <span style={styles.text}>
+      <View>
+        <View1>
+          <View3>
+            <Text>
               {"Some long text (currently LS lays out incorrectly)"}
-            </span>
-          </div>
-        </div>
-        <div style={styles.view2}>
-          <div style={styles.view4}>
-            <span style={styles.text1}>
+            </Text>
+          </View3>
+        </View1>
+        <View2>
+          <View4>
+            <Text1>
               {"Short"}
-            </span>
-          </div>
-        </div>
-      </div>
+            </Text1>
+          </View4>
+        </View2>
+      </View>
     );
   }
 };
 
-let styles = {
-  view: {
-    alignItems: "flex-start",
-    display: "flex",
-    flex: "1 1 0%",
-    flexDirection: "row",
-    justifyContent: "flex-start"
-  },
-  view1: {
-    alignItems: "flex-start",
-    backgroundColor: colors.red50,
-    display: "flex",
-    flex: "1 1 0%",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    height: "100px"
-  },
-  view2: {
-    alignItems: "flex-start",
-    backgroundColor: colors.blue50,
-    display: "flex",
-    flex: "1 1 0%",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    height: "100px"
-  },
-  view3: {
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    display: "flex",
-    flex: "1 1 0%",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  text: {
-    textAlign: "left",
-    ...textStyles.body1,
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    display: "block",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  view4: {
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    display: "flex",
-    flex: "1 1 0%",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  text1: {
-    textAlign: "left",
-    ...textStyles.body1,
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    display: "block",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  }
-}
+let View = styled.div({
+  alignItems: "flex-start",
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "row",
+  justifyContent: "flex-start"
+})
+
+let View1 = styled.div({
+  alignItems: "flex-start",
+  backgroundColor: colors.red50,
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  height: "100px"
+})
+
+let View3 = styled.div({
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let Text = styled.span({
+  textAlign: "left",
+  ...textStyles.body1,
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let View2 = styled.div({
+  alignItems: "flex-start",
+  backgroundColor: colors.blue50,
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  height: "100px"
+})
+
+let View4 = styled.div({
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let Text1 = styled.span({
+  textAlign: "left",
+  ...textStyles.body1,
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})

--- a/examples/generated/test/react-dom/layouts/PrimaryAxis.js
+++ b/examples/generated/test/react-dom/layouts/PrimaryAxis.js
@@ -1,4 +1,5 @@
 import React from "react"
+import styled from "styled-components"
 
 import colors from "../colors"
 import shadows from "../shadows"
@@ -9,78 +10,81 @@ export default class PrimaryAxis extends React.Component {
 
 
     return (
-      <div style={styles.view}>
-        <div style={styles.fixed} />
-        <div style={styles.fit}>
-          <span style={styles.text}>
+      <View>
+        <Fixed />
+        <Fit>
+          <Text>
             {"Text goes here"}
-          </span>
-        </div>
-        <div style={styles.fill1} />
-        <div style={styles.fill2} />
-      </div>
+          </Text>
+        </Fit>
+        <Fill1 />
+        <Fill2 />
+      </View>
     );
   }
 };
 
-let styles = {
-  view: {
-    alignItems: "flex-start",
-    display: "flex",
-    flex: "1 1 0%",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    paddingTop: "24px",
-    paddingRight: "24px",
-    paddingBottom: "24px",
-    paddingLeft: "24px",
-    height: "500px"
-  },
-  fixed: {
-    alignItems: "flex-start",
-    backgroundColor: "#D8D8D8",
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    marginBottom: "24px",
-    width: "100px",
-    height: "100px"
-  },
-  fit: {
-    alignItems: "flex-start",
-    backgroundColor: "#D8D8D8",
-    display: "flex",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    marginBottom: "24px",
-    width: "100px"
-  },
-  fill1: {
-    alignItems: "flex-start",
-    backgroundColor: colors.cyan500,
-    display: "flex",
-    flex: "1 1 0%",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    width: "100px"
-  },
-  fill2: {
-    alignItems: "flex-start",
-    backgroundColor: colors.blue500,
-    display: "flex",
-    flex: "1 1 0%",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    width: "100px"
-  },
-  text: {
-    textAlign: "left",
-    ...textStyles.body1,
-    alignItems: "flex-start",
-    display: "block",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  }
-}
+let View = styled.div({
+  alignItems: "flex-start",
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  paddingTop: "24px",
+  paddingRight: "24px",
+  paddingBottom: "24px",
+  paddingLeft: "24px",
+  height: "500px"
+})
+
+let Fixed = styled.div({
+  alignItems: "flex-start",
+  backgroundColor: "#D8D8D8",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  marginBottom: "24px",
+  width: "100px",
+  height: "100px"
+})
+
+let Fit = styled.div({
+  alignItems: "flex-start",
+  backgroundColor: "#D8D8D8",
+  display: "flex",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  marginBottom: "24px",
+  width: "100px"
+})
+
+let Text = styled.span({
+  textAlign: "left",
+  ...textStyles.body1,
+  alignItems: "flex-start",
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let Fill1 = styled.div({
+  alignItems: "flex-start",
+  backgroundColor: colors.cyan500,
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  width: "100px"
+})
+
+let Fill2 = styled.div({
+  alignItems: "flex-start",
+  backgroundColor: colors.blue500,
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  width: "100px"
+})

--- a/examples/generated/test/react-dom/layouts/PrimaryAxisFillNestedSiblings.js
+++ b/examples/generated/test/react-dom/layouts/PrimaryAxisFillNestedSiblings.js
@@ -45,15 +45,6 @@ let Horizontal = styled.div({
   justifyContent: "flex-start"
 })
 
-let FillWidthFitHeightCardLeftCardWrapper = styled.div({
-  alignItems: "flex-start",
-  alignSelf: "stretch",
-  display: "flex",
-  flex: "1 1 auto",
-  flexDirection: "row",
-  justifyContent: "flex-start"
-})
-
 let Spacer = styled.div({
   alignItems: "flex-start",
   display: "flex",
@@ -61,13 +52,4 @@ let Spacer = styled.div({
   justifyContent: "flex-start",
   width: "8px",
   height: "0px"
-})
-
-let FillWidthFitHeightCardRightCardWrapper = styled.div({
-  alignItems: "flex-start",
-  alignSelf: "stretch",
-  display: "flex",
-  flex: "1 1 auto",
-  flexDirection: "row",
-  justifyContent: "flex-start"
 })

--- a/examples/generated/test/react-dom/layouts/PrimaryAxisFillNestedSiblings.js
+++ b/examples/generated/test/react-dom/layouts/PrimaryAxisFillNestedSiblings.js
@@ -1,4 +1,5 @@
 import React from "react"
+import styled from "styled-components"
 
 import colors from "../colors"
 import shadows from "../shadows"
@@ -10,61 +11,63 @@ export default class PrimaryAxisFillNestedSiblings extends React.Component {
 
 
     return (
-      <div style={styles.container}>
-        <div style={styles.horizontal}>
+      <Container>
+        <Horizontal>
           <FillWidthFitHeightCard />
-          <div style={styles.spacer} />
+          <Spacer />
           <FillWidthFitHeightCard />
-        </div>
-      </div>
+        </Horizontal>
+      </Container>
     );
   }
 };
 
-let styles = {
-  container: {
-    alignItems: "flex-start",
-    backgroundColor: colors.teal50,
-    display: "flex",
-    flex: "1 1 0%",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    paddingTop: "10px",
-    paddingRight: "10px",
-    paddingBottom: "10px",
-    paddingLeft: "10px"
-  },
-  horizontal: {
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    backgroundColor: colors.teal100,
-    display: "flex",
-    flex: "0 0 auto",
-    flexDirection: "row",
-    justifyContent: "flex-start"
-  },
-  leftCard: {
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    display: "flex",
-    flex: "1 1 auto",
-    flexDirection: "row",
-    justifyContent: "flex-start"
-  },
-  spacer: {
-    alignItems: "flex-start",
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    width: "8px",
-    height: "0px"
-  },
-  rightCard: {
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    display: "flex",
-    flex: "1 1 auto",
-    flexDirection: "row",
-    justifyContent: "flex-start"
-  }
-}
+let Container = styled.div({
+  alignItems: "flex-start",
+  backgroundColor: colors.teal50,
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  paddingTop: "10px",
+  paddingRight: "10px",
+  paddingBottom: "10px",
+  paddingLeft: "10px"
+})
+
+let Horizontal = styled.div({
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  backgroundColor: colors.teal100,
+  display: "flex",
+  flex: "0 0 auto",
+  flexDirection: "row",
+  justifyContent: "flex-start"
+})
+
+let FillWidthFitHeightCardLeftCardWrapper = styled.div({
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  display: "flex",
+  flex: "1 1 auto",
+  flexDirection: "row",
+  justifyContent: "flex-start"
+})
+
+let Spacer = styled.div({
+  alignItems: "flex-start",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  width: "8px",
+  height: "0px"
+})
+
+let FillWidthFitHeightCardRightCardWrapper = styled.div({
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  display: "flex",
+  flex: "1 1 auto",
+  flexDirection: "row",
+  justifyContent: "flex-start"
+})

--- a/examples/generated/test/react-dom/layouts/PrimaryAxisFillSiblings.js
+++ b/examples/generated/test/react-dom/layouts/PrimaryAxisFillSiblings.js
@@ -1,4 +1,5 @@
 import React from "react"
+import styled from "styled-components"
 
 import colors from "../colors"
 import shadows from "../shadows"
@@ -9,156 +10,163 @@ export default class PrimaryAxisFillSiblings extends React.Component {
 
 
     return (
-      <div style={styles.container}>
-        <div style={styles.horizontal}>
-          <div style={styles.leftCard}>
-            <div style={styles.image}>
-              <img
-                style={styles.imageResizeModeCover}
+      <Container>
+        <Horizontal>
+          <LeftCard>
+            <Image>
+              <ImageResizeModeCover
                 src={require("../assets/icon_128x128.png")}
 
               />
-            </div>
-            <span style={styles.title}>
+            </Image>
+            <Title>
               {"Title"}
-            </span>
-            <span style={styles.subtitle}>
+            </Title>
+            <Subtitle>
               {"Subtitle"}
-            </span>
-          </div>
-          <div style={styles.spacer} />
-          <div style={styles.rightCard}>
-            <div style={styles.image1}>
-              <img
-                style={styles.imageResizeModeCover}
+            </Subtitle>
+          </LeftCard>
+          <Spacer />
+          <RightCard>
+            <Image1>
+              <ImageResizeModeCover
                 src={require("../assets/icon_128x128.png")}
 
               />
-            </div>
-            <span style={styles.title1}>
+            </Image1>
+            <Title1>
               {"Title"}
-            </span>
-            <span style={styles.subtitle1}>
+            </Title1>
+            <Subtitle1>
               {"Subtitle"}
-            </span>
-          </div>
-        </div>
-      </div>
+            </Subtitle1>
+          </RightCard>
+        </Horizontal>
+      </Container>
     );
   }
 };
 
-let styles = {
-  container: {
-    alignItems: "flex-start",
-    backgroundColor: colors.teal50,
-    display: "flex",
-    flex: "1 1 0%",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    paddingTop: "10px",
-    paddingRight: "10px",
-    paddingBottom: "10px",
-    paddingLeft: "10px"
-  },
-  horizontal: {
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    backgroundColor: colors.teal100,
-    display: "flex",
-    flex: "0 0 auto",
-    flexDirection: "row",
-    justifyContent: "flex-start"
-  },
-  leftCard: {
-    alignItems: "flex-start",
-    display: "flex",
-    flex: "1 1 0%",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  spacer: {
-    alignItems: "flex-start",
-    backgroundColor: "#D8D8D8",
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    width: "8px",
-    height: "0px"
-  },
-  rightCard: {
-    alignItems: "flex-start",
-    display: "flex",
-    flex: "1 1 0%",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  image: {
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    backgroundColor: colors.teal200,
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    overflow: "hidden",
-    height: "100px",
-    position: "relative"
-  },
-  title: {
-    textAlign: "left",
-    ...textStyles.body2,
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    display: "block",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  subtitle: {
-    textAlign: "left",
-    ...textStyles.body1,
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    display: "block",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  image1: {
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    backgroundColor: colors.teal200,
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    overflow: "hidden",
-    height: "100px",
-    position: "relative"
-  },
-  title1: {
-    textAlign: "left",
-    ...textStyles.body2,
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    display: "block",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  subtitle1: {
-    textAlign: "left",
-    ...textStyles.body1,
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    display: "block",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  imageResizeModeCover: {
-    width: "100%",
-    height: "100%",
-    objectFit: "cover",
-    position: "absolute"
-  }
-}
+let ImageResizeModeCover = styled.img({
+  width: "100%",
+  height: "100%",
+  objectFit: "cover",
+  position: "absolute"
+})
+
+let Container = styled.div({
+  alignItems: "flex-start",
+  backgroundColor: colors.teal50,
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  paddingTop: "10px",
+  paddingRight: "10px",
+  paddingBottom: "10px",
+  paddingLeft: "10px"
+})
+
+let Horizontal = styled.div({
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  backgroundColor: colors.teal100,
+  display: "flex",
+  flex: "0 0 auto",
+  flexDirection: "row",
+  justifyContent: "flex-start"
+})
+
+let LeftCard = styled.div({
+  alignItems: "flex-start",
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let Image = styled.div({
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  backgroundColor: colors.teal200,
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  overflow: "hidden",
+  height: "100px",
+  position: "relative"
+})
+
+let Title = styled.span({
+  textAlign: "left",
+  ...textStyles.body2,
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let Subtitle = styled.span({
+  textAlign: "left",
+  ...textStyles.body1,
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let Spacer = styled.div({
+  alignItems: "flex-start",
+  backgroundColor: "#D8D8D8",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  width: "8px",
+  height: "0px"
+})
+
+let RightCard = styled.div({
+  alignItems: "flex-start",
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let Image1 = styled.div({
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  backgroundColor: colors.teal200,
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  overflow: "hidden",
+  height: "100px",
+  position: "relative"
+})
+
+let Title1 = styled.span({
+  textAlign: "left",
+  ...textStyles.body2,
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let Subtitle1 = styled.span({
+  textAlign: "left",
+  ...textStyles.body1,
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})

--- a/examples/generated/test/react-dom/layouts/SecondaryAxis.js
+++ b/examples/generated/test/react-dom/layouts/SecondaryAxis.js
@@ -1,4 +1,5 @@
 import React from "react"
+import styled from "styled-components"
 
 import colors from "../colors"
 import shadows from "../shadows"
@@ -9,70 +10,72 @@ export default class SecondaryAxis extends React.Component {
 
 
     return (
-      <div style={styles.container}>
-        <div style={styles.fixed} />
-        <div style={styles.fit}>
-          <span style={styles.text}>
+      <Container>
+        <Fixed />
+        <Fit>
+          <Text>
             {"Text goes here"}
-          </span>
-        </div>
-        <div style={styles.fill} />
-      </div>
+          </Text>
+        </Fit>
+        <Fill />
+      </Container>
     );
   }
 };
 
-let styles = {
-  container: {
-    alignItems: "flex-start",
-    display: "flex",
-    flex: "1 1 0%",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    paddingTop: "24px",
-    paddingRight: "24px",
-    paddingBottom: "24px",
-    paddingLeft: "24px"
-  },
-  fixed: {
-    alignItems: "flex-start",
-    backgroundColor: "#D8D8D8",
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    marginBottom: "24px",
-    width: "100px",
-    height: "100px"
-  },
-  fit: {
-    alignItems: "flex-start",
-    backgroundColor: "#D8D8D8",
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    marginBottom: "24px",
-    paddingTop: "12px",
-    paddingRight: "12px",
-    paddingBottom: "12px",
-    paddingLeft: "12px",
-    height: "100px"
-  },
-  fill: {
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    backgroundColor: "#D8D8D8",
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    height: "100px"
-  },
-  text: {
-    textAlign: "left",
-    ...textStyles.body1,
-    alignItems: "flex-start",
-    display: "block",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  }
-}
+let Container = styled.div({
+  alignItems: "flex-start",
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  paddingTop: "24px",
+  paddingRight: "24px",
+  paddingBottom: "24px",
+  paddingLeft: "24px"
+})
+
+let Fixed = styled.div({
+  alignItems: "flex-start",
+  backgroundColor: "#D8D8D8",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  marginBottom: "24px",
+  width: "100px",
+  height: "100px"
+})
+
+let Fit = styled.div({
+  alignItems: "flex-start",
+  backgroundColor: "#D8D8D8",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  marginBottom: "24px",
+  paddingTop: "12px",
+  paddingRight: "12px",
+  paddingBottom: "12px",
+  paddingLeft: "12px",
+  height: "100px"
+})
+
+let Text = styled.span({
+  textAlign: "left",
+  ...textStyles.body1,
+  alignItems: "flex-start",
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let Fill = styled.div({
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  backgroundColor: "#D8D8D8",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  height: "100px"
+})

--- a/examples/generated/test/react-dom/logic/Assign.js
+++ b/examples/generated/test/react-dom/logic/Assign.js
@@ -1,4 +1,5 @@
 import React from "react"
+import styled from "styled-components"
 
 import colors from "../colors"
 import shadows from "../shadows"
@@ -10,31 +11,24 @@ export default class Assign extends React.Component {
     let Text$text
 
     Text$text = this.props.text
-    return (
-      <div style={styles.view}>
-        <span style={styles.text}>
-          {Text$text}
-        </span>
-      </div>
-    );
+    return <View> <Text> {Text$text} </Text> </View>;
   }
 };
 
-let styles = {
-  view: {
-    alignItems: "flex-start",
-    display: "flex",
-    flex: "1 1 0%",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  text: {
-    textAlign: "left",
-    ...textStyles.body1,
-    alignItems: "flex-start",
-    display: "block",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  }
-}
+let View = styled.div({
+  alignItems: "flex-start",
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let Text = styled.span({
+  textAlign: "left",
+  ...textStyles.body1,
+  alignItems: "flex-start",
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})

--- a/examples/generated/test/react-dom/logic/If.js
+++ b/examples/generated/test/react-dom/logic/If.js
@@ -1,4 +1,5 @@
 import React from "react"
+import styled from "styled-components"
 
 import colors from "../colors"
 import shadows from "../shadows"
@@ -13,23 +14,14 @@ export default class If extends React.Component {
     if (this.props.enabled) {
       View$backgroundColor = colors.red500
     }
-    return (
-      <div
-        style={Object.assign({}, styles.view, {
-          backgroundColor: View$backgroundColor
-        })}
-
-      />
-    );
+    return <View style={{ backgroundColor: View$backgroundColor }} />;
   }
 };
 
-let styles = {
-  view: {
-    alignItems: "flex-start",
-    display: "flex",
-    flex: "1 1 0%",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  }
-}
+let View = styled.div({
+  alignItems: "flex-start",
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})

--- a/examples/generated/test/react-dom/logic/Optionals.js
+++ b/examples/generated/test/react-dom/logic/Optionals.js
@@ -1,4 +1,5 @@
 import React from "react"
+import styled from "styled-components"
 
 import colors from "../colors"
 import shadows from "../shadows"
@@ -32,46 +33,42 @@ export default class Optionals extends React.Component {
       StringParam$text = unwrapped
     }
     return (
-      <div
-        style={Object.assign({}, styles.view, {
-          backgroundColor: View$backgroundColor
-        })}
-      >
-        <span style={styles.label}>
+      <View style={{ backgroundColor: View$backgroundColor }}>
+        <Label>
           {Label$text}
-        </span>
-        <span style={styles.stringParam}>
+        </Label>
+        <StringParam>
           {StringParam$text}
-        </span>
-      </div>
+        </StringParam>
+      </View>
     );
   }
 };
 
-let styles = {
-  view: {
-    alignItems: "flex-start",
-    display: "flex",
-    flex: "1 1 0%",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  label: {
-    textAlign: "left",
-    ...textStyles.body1,
-    alignItems: "flex-start",
-    display: "block",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  stringParam: {
-    textAlign: "left",
-    ...textStyles.body1,
-    alignItems: "flex-start",
-    display: "block",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  }
-}
+let View = styled.div({
+  alignItems: "flex-start",
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let Label = styled.span({
+  textAlign: "left",
+  ...textStyles.body1,
+  alignItems: "flex-start",
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let StringParam = styled.span({
+  textAlign: "left",
+  ...textStyles.body1,
+  alignItems: "flex-start",
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})

--- a/examples/generated/test/react-dom/logic/RepeatedVector.js
+++ b/examples/generated/test/react-dom/logic/RepeatedVector.js
@@ -1,12 +1,13 @@
 import React from "react"
+import styled from "styled-components"
 
 import colors from "../colors"
 import shadows from "../shadows"
 import textStyles from "../textStyles"
 
-let CheckCircleVector = (props) => {
+let CheckCheckCircleVector = (props) => {
   return (
-    <svg
+    <Check
       style={props.style}
       preserveAspectRatio={props.preserveAspectRatio || "xMidYMid slice"}
       viewBox={"0 0 24 24"}
@@ -24,7 +25,30 @@ let CheckCircleVector = (props) => {
         strokeLinecap={"round"}
 
       />
-    </svg>
+    </Check>
+  );
+}
+let AnotherCheckCheckCircleVector = (props) => {
+  return (
+    <AnotherCheck
+      style={props.style}
+      preserveAspectRatio={props.preserveAspectRatio || "xMidYMid slice"}
+      viewBox={"0 0 24 24"}
+    >
+      <path
+        d={"M12,0L12,0C18.627416998,0 24,5.37258300203 24,12L24,12C24,18.627416998 18.627416998,24 12,24L12,24C5.37258300203,24 0,18.627416998 0,12L0,12C0,5.37258300203 5.37258300203,0 12,0Z"}
+        fill={props.ovalFill || "#00C121"}
+
+      />
+      <path
+        d={"M6.5,12.6L9.75,15.85L17.25,8.35"}
+        fill={"none"}
+        stroke={props.pathStroke || "#FFFFFF"}
+        strokeWidth={"2"}
+        strokeLinecap={"round"}
+
+      />
+    </AnotherCheck>
   );
 }
 
@@ -40,48 +64,46 @@ export default class RepeatedVector extends React.Component {
     }
     AnotherCheck$vector$path$stroke = colors.green800
     return (
-      <div style={styles.view}>
-        <CheckCircleVector
-          style={styles.check}
+      <View>
+        <CheckCheckCircleVector
           ovalFill={Check$vector$oval$fill}
           preserveAspectRatio={"xMidYMid meet"}
 
         />
-        <CheckCircleVector
-          style={styles.anotherCheck}
+        <AnotherCheckCheckCircleVector
           pathStroke={AnotherCheck$vector$path$stroke}
           preserveAspectRatio={"xMidYMid meet"}
 
         />
-      </div>
+      </View>
     );
   }
 };
 
-let styles = {
-  view: {
-    alignItems: "flex-start",
-    display: "flex",
-    flex: "1 1 0%",
-    flexDirection: "row",
-    justifyContent: "flex-start"
-  },
-  check: {
-    alignItems: "flex-start",
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    width: "100px",
-    height: "100px",
-    objectFit: "contain"
-  },
-  anotherCheck: {
-    alignItems: "flex-start",
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    width: "100px",
-    height: "100px",
-    objectFit: "contain"
-  }
-}
+let View = styled.div({
+  alignItems: "flex-start",
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "row",
+  justifyContent: "flex-start"
+})
+
+let Check = styled.svg({
+  alignItems: "flex-start",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  width: "100px",
+  height: "100px",
+  objectFit: "contain"
+})
+
+let AnotherCheck = styled.svg({
+  alignItems: "flex-start",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  width: "100px",
+  height: "100px",
+  objectFit: "contain"
+})

--- a/examples/generated/test/react-dom/logic/VectorLogic.js
+++ b/examples/generated/test/react-dom/logic/VectorLogic.js
@@ -1,12 +1,13 @@
 import React from "react"
+import styled from "styled-components"
 
 import colors from "../colors"
 import shadows from "../shadows"
 import textStyles from "../textStyles"
 
-let CheckCircleVector = (props) => {
+let CheckCheckCircleVector = (props) => {
   return (
-    <svg
+    <Check
       style={props.style}
       preserveAspectRatio={props.preserveAspectRatio || "xMidYMid slice"}
       viewBox={"0 0 24 24"}
@@ -24,7 +25,7 @@ let CheckCircleVector = (props) => {
         strokeLinecap={"round"}
 
       />
-    </svg>
+    </Check>
   );
 }
 
@@ -40,34 +41,32 @@ export default class VectorLogic extends React.Component {
       Check$vector$path$stroke = colors.green100
     }
     return (
-      <div style={styles.view}>
-        <CheckCircleVector
-          style={styles.check}
+      <View>
+        <CheckCheckCircleVector
           ovalFill={Check$vector$oval$fill}
           pathStroke={Check$vector$path$stroke}
           preserveAspectRatio={"xMidYMid meet"}
 
         />
-      </div>
+      </View>
     );
   }
 };
 
-let styles = {
-  view: {
-    alignItems: "flex-start",
-    display: "flex",
-    flex: "1 1 0%",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  check: {
-    alignItems: "flex-start",
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    width: "100px",
-    height: "100px",
-    objectFit: "contain"
-  }
-}
+let View = styled.div({
+  alignItems: "flex-start",
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let Check = styled.svg({
+  alignItems: "flex-start",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  width: "100px",
+  height: "100px",
+  objectFit: "contain"
+})

--- a/examples/generated/test/react-dom/style/BorderWidthColor.js
+++ b/examples/generated/test/react-dom/style/BorderWidthColor.js
@@ -1,4 +1,5 @@
 import React from "react"
+import styled from "styled-components"
 
 import colors from "../colors"
 import shadows from "../shadows"
@@ -20,37 +21,36 @@ export default class BorderWidthColor extends React.Component {
       Inner$borderRadius = 20
     }
     return (
-      <div style={styles.view}>
-        <div
-          style={Object.assign({}, styles.inner, {
+      <View>
+        <Inner
+          style={{
             borderRadius: Inner$borderRadius + "px",
             borderWidth: Inner$borderWidth + "px",
             borderColor: Inner$borderColor
-          })}
+          }}
 
         />
-      </div>
+      </View>
     );
   }
 };
 
-let styles = {
-  view: {
-    alignItems: "flex-start",
-    display: "flex",
-    flex: "1 1 0%",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  inner: {
-    alignItems: "flex-start",
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    borderRadius: "10px",
-    borderWidth: "20px",
-    borderColor: colors.blue300,
-    width: "100px",
-    height: "100px"
-  }
-}
+let View = styled.div({
+  alignItems: "flex-start",
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let Inner = styled.div({
+  alignItems: "flex-start",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  borderRadius: "10px",
+  borderWidth: "20px",
+  borderColor: colors.blue300,
+  width: "100px",
+  height: "100px"
+})

--- a/examples/generated/test/react-dom/style/BoxModelConditional.js
+++ b/examples/generated/test/react-dom/style/BoxModelConditional.js
@@ -1,4 +1,5 @@
 import React from "react"
+import styled from "styled-components"
 
 import colors from "../colors"
 import shadows from "../shadows"
@@ -21,42 +22,41 @@ export default class BoxModelConditional extends React.Component {
     Inner$height = this.props.size
     Inner$width = this.props.size
     return (
-      <div style={styles.outer}>
-        <div
-          style={Object.assign({}, styles.inner, {
+      <Outer>
+        <Inner
+          style={{
             marginTop: Inner$marginTop + "px",
             marginRight: Inner$marginRight + "px",
             marginBottom: Inner$marginBottom + "px",
             marginLeft: Inner$marginLeft + "px",
             width: Inner$width + "px",
             height: Inner$height + "px"
-          })}
+          }}
 
         />
-      </div>
+      </Outer>
     );
   }
 };
 
-let styles = {
-  outer: {
-    alignItems: "flex-start",
-    display: "flex",
-    flex: "1 1 0%",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    paddingTop: "4px",
-    paddingRight: "4px",
-    paddingBottom: "4px",
-    paddingLeft: "4px"
-  },
-  inner: {
-    alignItems: "flex-start",
-    backgroundColor: "#D8D8D8",
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    width: "60px",
-    height: "60px"
-  }
-}
+let Outer = styled.div({
+  alignItems: "flex-start",
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  paddingTop: "4px",
+  paddingRight: "4px",
+  paddingBottom: "4px",
+  paddingLeft: "4px"
+})
+
+let Inner = styled.div({
+  alignItems: "flex-start",
+  backgroundColor: "#D8D8D8",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  width: "60px",
+  height: "60px"
+})

--- a/examples/generated/test/react-dom/style/ShadowsTest.js
+++ b/examples/generated/test/react-dom/style/ShadowsTest.js
@@ -1,4 +1,5 @@
 import React from "react"
+import styled from "styled-components"
 
 import colors from "../colors"
 import shadows from "../shadows"
@@ -13,32 +14,27 @@ export default class ShadowsTest extends React.Component {
     if (this.props.largeShadow) {
       Inner$shadow = shadows.elevation3
     }
-    return (
-      <div style={styles.container}>
-        <div style={Object.assign({}, styles.inner, { ...Inner$shadow })} />
-      </div>
-    );
+    return <Container> <Inner style={{ ...Inner$shadow }} /> </Container>;
   }
 };
 
-let styles = {
-  container: {
-    alignItems: "center",
-    display: "flex",
-    flex: "1 1 0%",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    paddingTop: "20px",
-    paddingBottom: "20px"
-  },
-  inner: {
-    alignItems: "flex-start",
-    backgroundColor: colors.blue300,
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    ...shadows.elevation2,
-    width: "60px",
-    height: "60px"
-  }
-}
+let Container = styled.div({
+  alignItems: "center",
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  paddingTop: "20px",
+  paddingBottom: "20px"
+})
+
+let Inner = styled.div({
+  alignItems: "flex-start",
+  backgroundColor: colors.blue300,
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  ...shadows.elevation2,
+  width: "60px",
+  height: "60px"
+})

--- a/examples/generated/test/react-dom/style/TextAlignment.js
+++ b/examples/generated/test/react-dom/style/TextAlignment.js
@@ -1,4 +1,5 @@
 import React from "react"
+import styled from "styled-components"
 
 import colors from "../colors"
 import shadows from "../shadows"
@@ -9,284 +10,295 @@ export default class TextAlignment extends React.Component {
 
 
     return (
-      <div style={styles.view}>
-        <div style={styles.view1}>
-          <img
-            style={styles.image}
-            src={require("../assets/icon_128x128.png")}
-
-          />
-          <div style={styles.view2} />
-          <span style={styles.text}>
+      <View>
+        <View1>
+          <Image src={require("../assets/icon_128x128.png")} />
+          <View2 />
+          <Text>
             {"Welcome to Lona Studio"}
-          </span>
-          <span style={styles.text1}>
+          </Text>
+          <Text1>
             {"Centered - Width: Fit"}
-          </span>
-          <span style={styles.text2}>
+          </Text1>
+          <Text2>
             {"Left aligned - Width: Fill"}
-          </span>
-          <span style={styles.text3}>
+          </Text2>
+          <Text3>
             {"Right aligned - Width: Fill"}
-          </span>
-          <span style={styles.text4}>
+          </Text3>
+          <Text4>
             {"Centered - Width: 80"}
-          </span>
-        </div>
-        <div style={styles.view3}>
-          <span style={styles.text5}>
+          </Text4>
+        </View1>
+        <View3>
+          <Text5>
             {"Left aligned text, Fit w/ secondary centering"}
-          </span>
-        </div>
-        <div style={styles.view4}>
-          <span style={styles.text6}>
+          </Text5>
+        </View3>
+        <View4>
+          <Text6>
             {"Left aligned text, Fixed w/ secondary centering"}
-          </span>
-        </div>
-        <div style={styles.view5}>
-          <span style={styles.text7}>
+          </Text6>
+        </View4>
+        <View5>
+          <Text7>
             {"Centered text, Fit parent no centering"}
-          </span>
-        </div>
-        <div style={styles.view6}>
-          <span style={styles.text8}>
+          </Text7>
+        </View5>
+        <View6>
+          <Text8>
             {"Centered text, Fixed parent no centering"}
-          </span>
-        </div>
-        <div style={styles.rightAlignmentContainer}>
-          <span style={styles.text9}>
+          </Text8>
+        </View6>
+        <RightAlignmentContainer>
+          <Text9>
             {"Fit Text"}
-          </span>
-          <span style={styles.text10}>
+          </Text9>
+          <Text10>
             {"Fill and center aligned text"}
-          </span>
-          <img
-            style={styles.image1}
-            src={require("../assets/icon_128x128.png")}
-
-          />
-        </div>
-      </div>
+          </Text10>
+          <Image1 src={require("../assets/icon_128x128.png")} />
+        </RightAlignmentContainer>
+      </View>
     );
   }
 };
 
-let styles = {
-  view: {
-    alignItems: "flex-start",
-    display: "flex",
-    flex: "1 1 0%",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    paddingTop: "10px",
-    paddingRight: "10px",
-    paddingBottom: "10px",
-    paddingLeft: "10px"
-  },
-  view1: {
-    alignItems: "center",
-    alignSelf: "stretch",
-    backgroundColor: colors.indigo50,
-    display: "flex",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "center"
-  },
-  view3: {
-    alignItems: "center",
-    backgroundColor: "#D8D8D8",
-    display: "flex",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    paddingRight: "12px",
-    paddingLeft: "12px"
-  },
-  view4: {
-    alignItems: "center",
-    backgroundColor: "#D8D8D8",
-    display: "flex",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    paddingRight: "12px",
-    paddingLeft: "12px",
-    width: "400px"
-  },
-  view5: {
-    alignItems: "flex-start",
-    backgroundColor: "#D8D8D8",
-    display: "flex",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    paddingRight: "12px",
-    paddingLeft: "12px"
-  },
-  view6: {
-    alignItems: "flex-start",
-    backgroundColor: "#D8D8D8",
-    display: "flex",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    paddingRight: "12px",
-    paddingLeft: "12px",
-    width: "400px"
-  },
-  rightAlignmentContainer: {
-    alignItems: "flex-end",
-    alignSelf: "stretch",
-    backgroundColor: "#D8D8D8",
-    display: "flex",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  image: {
-    alignItems: "flex-start",
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    overflow: "hidden",
-    width: "100px",
-    height: "100px",
-    objectFit: "cover",
-    position: "relative"
-  },
-  view2: {
-    alignItems: "flex-start",
-    backgroundColor: "#D8D8D8",
-    display: "flex",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  text: {
-    textAlign: "center",
-    ...textStyles.display1,
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    display: "block",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    marginTop: "16px",
-    overflow: "hidden",
-    maxHeight: "80px"
-  },
-  text1: {
-    textAlign: "center",
-    ...textStyles.subheading2,
-    alignItems: "flex-start",
-    display: "block",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    marginTop: "16px"
-  },
-  text2: {
-    textAlign: "left",
-    ...textStyles.body1,
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    display: "block",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    marginTop: "12px"
-  },
-  text3: {
-    textAlign: "right",
-    ...textStyles.body1,
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    display: "block",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  text4: {
-    textAlign: "center",
-    ...textStyles.body1,
-    alignItems: "flex-start",
-    display: "block",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    width: "80px"
-  },
-  text5: {
-    textAlign: "left",
-    ...textStyles.body1,
-    alignItems: "flex-start",
-    display: "block",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  text6: {
-    textAlign: "left",
-    ...textStyles.body1,
-    alignItems: "flex-start",
-    display: "block",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  text7: {
-    textAlign: "center",
-    ...textStyles.body1,
-    alignItems: "flex-start",
-    display: "block",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  text8: {
-    textAlign: "center",
-    ...textStyles.body1,
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    display: "block",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  text9: {
-    textAlign: "left",
-    ...textStyles.body1,
-    alignItems: "flex-start",
-    display: "block",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  text10: {
-    textAlign: "center",
-    ...textStyles.body1,
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    display: "block",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  image1: {
-    alignItems: "flex-start",
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    overflow: "hidden",
-    width: "100px",
-    height: "100px",
-    objectFit: "cover",
-    position: "relative"
-  },
-  imageResizeModeCover: {
-    width: "100%",
-    height: "100%",
-    objectFit: "cover",
-    position: "absolute"
-  }
-}
+let ImageResizeModeCover = styled.img({
+  width: "100%",
+  height: "100%",
+  objectFit: "cover",
+  position: "absolute"
+})
+
+let View = styled.div({
+  alignItems: "flex-start",
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  paddingTop: "10px",
+  paddingRight: "10px",
+  paddingBottom: "10px",
+  paddingLeft: "10px"
+})
+
+let View1 = styled.div({
+  alignItems: "center",
+  alignSelf: "stretch",
+  backgroundColor: colors.indigo50,
+  display: "flex",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "center"
+})
+
+let Image = styled.img({
+  alignItems: "flex-start",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  overflow: "hidden",
+  width: "100px",
+  height: "100px",
+  objectFit: "cover",
+  position: "relative"
+})
+
+let View2 = styled.div({
+  alignItems: "flex-start",
+  backgroundColor: "#D8D8D8",
+  display: "flex",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let Text = styled.span({
+  textAlign: "center",
+  ...textStyles.display1,
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  marginTop: "16px",
+  overflow: "hidden",
+  maxHeight: "80px"
+})
+
+let Text1 = styled.span({
+  textAlign: "center",
+  ...textStyles.subheading2,
+  alignItems: "flex-start",
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  marginTop: "16px"
+})
+
+let Text2 = styled.span({
+  textAlign: "left",
+  ...textStyles.body1,
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  marginTop: "12px"
+})
+
+let Text3 = styled.span({
+  textAlign: "right",
+  ...textStyles.body1,
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let Text4 = styled.span({
+  textAlign: "center",
+  ...textStyles.body1,
+  alignItems: "flex-start",
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  width: "80px"
+})
+
+let View3 = styled.div({
+  alignItems: "center",
+  backgroundColor: "#D8D8D8",
+  display: "flex",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  paddingRight: "12px",
+  paddingLeft: "12px"
+})
+
+let Text5 = styled.span({
+  textAlign: "left",
+  ...textStyles.body1,
+  alignItems: "flex-start",
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let View4 = styled.div({
+  alignItems: "center",
+  backgroundColor: "#D8D8D8",
+  display: "flex",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  paddingRight: "12px",
+  paddingLeft: "12px",
+  width: "400px"
+})
+
+let Text6 = styled.span({
+  textAlign: "left",
+  ...textStyles.body1,
+  alignItems: "flex-start",
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let View5 = styled.div({
+  alignItems: "flex-start",
+  backgroundColor: "#D8D8D8",
+  display: "flex",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  paddingRight: "12px",
+  paddingLeft: "12px"
+})
+
+let Text7 = styled.span({
+  textAlign: "center",
+  ...textStyles.body1,
+  alignItems: "flex-start",
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let View6 = styled.div({
+  alignItems: "flex-start",
+  backgroundColor: "#D8D8D8",
+  display: "flex",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  paddingRight: "12px",
+  paddingLeft: "12px",
+  width: "400px"
+})
+
+let Text8 = styled.span({
+  textAlign: "center",
+  ...textStyles.body1,
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let RightAlignmentContainer = styled.div({
+  alignItems: "flex-end",
+  alignSelf: "stretch",
+  backgroundColor: "#D8D8D8",
+  display: "flex",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let Text9 = styled.span({
+  textAlign: "left",
+  ...textStyles.body1,
+  alignItems: "flex-start",
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let Text10 = styled.span({
+  textAlign: "center",
+  ...textStyles.body1,
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let Image1 = styled.img({
+  alignItems: "flex-start",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  overflow: "hidden",
+  width: "100px",
+  height: "100px",
+  objectFit: "cover",
+  position: "relative"
+})

--- a/examples/generated/test/react-dom/style/TextStyleConditional.js
+++ b/examples/generated/test/react-dom/style/TextStyleConditional.js
@@ -1,4 +1,5 @@
 import React from "react"
+import styled from "styled-components"
 
 import colors from "../colors"
 import shadows from "../shadows"
@@ -14,30 +15,29 @@ export default class TextStyleConditional extends React.Component {
       Text$textStyle = textStyles.display2
     }
     return (
-      <div style={styles.view}>
-        <span style={Object.assign({}, styles.text, { ...Text$textStyle })}>
+      <View>
+        <Text style={{ ...Text$textStyle }}>
           {"Text goes here"}
-        </span>
-      </div>
+        </Text>
+      </View>
     );
   }
 };
 
-let styles = {
-  view: {
-    alignItems: "flex-start",
-    display: "flex",
-    flex: "1 1 0%",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  text: {
-    textAlign: "left",
-    ...textStyles.headline,
-    alignItems: "flex-start",
-    display: "block",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  }
-}
+let View = styled.div({
+  alignItems: "flex-start",
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let Text = styled.span({
+  textAlign: "left",
+  ...textStyles.headline,
+  alignItems: "flex-start",
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})

--- a/examples/generated/test/react-dom/style/TextStylesTest.js
+++ b/examples/generated/test/react-dom/style/TextStylesTest.js
@@ -1,4 +1,5 @@
 import React from "react"
+import styled from "styled-components"
 
 import colors from "../colors"
 import shadows from "../shadows"
@@ -9,161 +10,171 @@ export default class TextStylesTest extends React.Component {
 
 
     return (
-      <div style={styles.view}>
-        <span style={styles.text1}>
+      <View>
+        <Text1>
           {"Text goes here"}
-        </span>
-        <span style={styles.text2}>
+        </Text1>
+        <Text2>
           {"Text goes here"}
-        </span>
-        <span style={styles.text3}>
+        </Text2>
+        <Text3>
           {"Text goes here"}
-        </span>
-        <div style={styles.view3}>
-          <span style={styles.text4}>
+        </Text3>
+        <View3>
+          <Text4>
             {"Text goes here"}
-          </span>
-        </div>
-        <div style={styles.view1}>
-          <span style={styles.text5}>
+          </Text4>
+        </View3>
+        <View1>
+          <Text5>
             {"Text goes here"}
-          </span>
-        </div>
-        <div style={styles.view2}>
-          <span style={styles.text6}>
+          </Text5>
+        </View1>
+        <View2>
+          <Text6>
             {
               "Text goes here and wraps around when it reaches the end of the text field."
             }
-          </span>
-        </div>
-        <span style={styles.text7}>
+          </Text6>
+        </View2>
+        <Text7>
           {"Text goes here"}
-        </span>
-        <span style={styles.text8}>
+        </Text7>
+        <Text8>
           {"Text goes here"}
-        </span>
-        <span style={styles.text9}>
+        </Text8>
+        <Text9>
           {"Text goes here"}
-        </span>
-      </div>
+        </Text9>
+      </View>
     );
   }
 };
 
-let styles = {
-  view: {
-    alignItems: "flex-start",
-    display: "flex",
-    flex: "1 1 0%",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  text1: {
-    textAlign: "left",
-    ...textStyles.display3,
-    alignItems: "flex-start",
-    display: "block",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  text2: {
-    textAlign: "left",
-    ...textStyles.display2,
-    alignItems: "flex-start",
-    display: "block",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  text3: {
-    textAlign: "left",
-    ...textStyles.display1,
-    alignItems: "flex-start",
-    display: "block",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  view3: {
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    backgroundColor: colors.green50,
-    display: "flex",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  view1: {
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    backgroundColor: colors.green100,
-    display: "flex",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  view2: {
-    alignItems: "flex-start",
-    alignSelf: "stretch",
-    backgroundColor: colors.green200,
-    display: "flex",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  text7: {
-    textAlign: "left",
-    ...textStyles.body2,
-    alignItems: "flex-start",
-    display: "block",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  text8: {
-    textAlign: "left",
-    ...textStyles.body1,
-    alignItems: "flex-start",
-    display: "block",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  text9: {
-    textAlign: "left",
-    ...textStyles.caption,
-    alignItems: "flex-start",
-    display: "block",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  text4: {
-    textAlign: "left",
-    ...textStyles.headline,
-    alignItems: "flex-start",
-    display: "block",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  text5: {
-    textAlign: "left",
-    ...textStyles.subheading2,
-    alignItems: "flex-start",
-    display: "block",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  text6: {
-    textAlign: "left",
-    ...textStyles.subheading1,
-    alignItems: "flex-start",
-    display: "block",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  }
-}
+let View = styled.div({
+  alignItems: "flex-start",
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let Text1 = styled.span({
+  textAlign: "left",
+  ...textStyles.display3,
+  alignItems: "flex-start",
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let Text2 = styled.span({
+  textAlign: "left",
+  ...textStyles.display2,
+  alignItems: "flex-start",
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let Text3 = styled.span({
+  textAlign: "left",
+  ...textStyles.display1,
+  alignItems: "flex-start",
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let View3 = styled.div({
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  backgroundColor: colors.green50,
+  display: "flex",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let Text4 = styled.span({
+  textAlign: "left",
+  ...textStyles.headline,
+  alignItems: "flex-start",
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let View1 = styled.div({
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  backgroundColor: colors.green100,
+  display: "flex",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let Text5 = styled.span({
+  textAlign: "left",
+  ...textStyles.subheading2,
+  alignItems: "flex-start",
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let View2 = styled.div({
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  backgroundColor: colors.green200,
+  display: "flex",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let Text6 = styled.span({
+  textAlign: "left",
+  ...textStyles.subheading1,
+  alignItems: "flex-start",
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let Text7 = styled.span({
+  textAlign: "left",
+  ...textStyles.body2,
+  alignItems: "flex-start",
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let Text8 = styled.span({
+  textAlign: "left",
+  ...textStyles.body1,
+  alignItems: "flex-start",
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let Text9 = styled.span({
+  textAlign: "left",
+  ...textStyles.caption,
+  alignItems: "flex-start",
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})

--- a/examples/generated/test/react-dom/style/VisibilityTest.js
+++ b/examples/generated/test/react-dom/style/VisibilityTest.js
@@ -1,4 +1,5 @@
 import React from "react"
+import styled from "styled-components"
 
 import colors from "../colors"
 import shadows from "../shadows"
@@ -11,48 +12,49 @@ export default class VisibilityTest extends React.Component {
 
     Title$visible = this.props.enabled
     return (
-      <div style={styles.container}>
-        {false && <div style={styles.inner} />}
-        {Title$visible && <span style={styles.title}> {"Enabled"} </span>}
-        <div style={styles.view} />
-      </div>
+      <Container>
+        {false && <Inner />}
+        {Title$visible && <Title> {"Enabled"} </Title>}
+        <View />
+      </Container>
     );
   }
 };
 
-let styles = {
-  container: {
-    alignItems: "flex-start",
-    display: "flex",
-    flex: "1 1 0%",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  inner: {
-    alignItems: "flex-start",
-    backgroundColor: colors.green300,
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    width: "100px",
-    height: "100px"
-  },
-  title: {
-    textAlign: "left",
-    ...textStyles.body1,
-    alignItems: "flex-start",
-    display: "block",
-    flex: "0 0 auto",
-    flexDirection: "column",
-    justifyContent: "flex-start"
-  },
-  view: {
-    alignItems: "flex-start",
-    backgroundColor: colors.blue300,
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    width: "100px",
-    height: "100px"
-  }
-}
+let Container = styled.div({
+  alignItems: "flex-start",
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let Inner = styled.div({
+  alignItems: "flex-start",
+  backgroundColor: colors.green300,
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  width: "100px",
+  height: "100px"
+})
+
+let Title = styled.span({
+  textAlign: "left",
+  ...textStyles.body1,
+  alignItems: "flex-start",
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let View = styled.div({
+  alignItems: "flex-start",
+  backgroundColor: colors.blue300,
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  width: "100px",
+  height: "100px"
+})

--- a/examples/generated/test/react-native/images/VectorAsset.js
+++ b/examples/generated/test/react-native/images/VectorAsset.js
@@ -6,7 +6,7 @@ import colors from "../colors"
 import shadows from "../shadows"
 import textStyles from "../textStyles"
 
-let ToggleVector = (props) => {
+let VectorGraphic1ToggleVector = (props) => {
   return (
     <Svg
       style={props.style}
@@ -29,7 +29,7 @@ let ToggleVector = (props) => {
     </Svg>
   );
 }
-let ToggleVerticalVector = (props) => {
+let VectorGraphic2ToggleVerticalVector = (props) => {
   return (
     <Svg
       style={props.style}
@@ -52,7 +52,7 @@ let ToggleVerticalVector = (props) => {
     </Svg>
   );
 }
-let CheckCircleVector = (props) => {
+let VectorGraphic3CheckCircleVector = (props) => {
   return (
     <Svg
       style={props.style}
@@ -82,17 +82,17 @@ export default class VectorAsset extends React.Component {
 
     return (
       <View style={styles.view}>
-        <ToggleVector
+        <VectorGraphic1ToggleVector
           style={styles.vectorGraphic1}
           preserveAspectRatio={"xMidYMid meet"}
 
         />
-        <ToggleVerticalVector
+        <VectorGraphic2ToggleVerticalVector
           style={styles.vectorGraphic2}
           preserveAspectRatio={"xMidYMid meet"}
 
         />
-        <CheckCircleVector style={styles.vectorGraphic3} />
+        <VectorGraphic3CheckCircleVector style={styles.vectorGraphic3} />
       </View>
     );
   }

--- a/examples/generated/test/react-native/logic/RepeatedVector.js
+++ b/examples/generated/test/react-native/logic/RepeatedVector.js
@@ -6,7 +6,30 @@ import colors from "../colors"
 import shadows from "../shadows"
 import textStyles from "../textStyles"
 
-let CheckCircleVector = (props) => {
+let CheckCheckCircleVector = (props) => {
+  return (
+    <Svg
+      style={props.style}
+      preserveAspectRatio={props.preserveAspectRatio || "xMidYMid slice"}
+      viewBox={"0 0 24 24"}
+    >
+      <Svg.Path
+        d={"M12,0L12,0C18.627416998,0 24,5.37258300203 24,12L24,12C24,18.627416998 18.627416998,24 12,24L12,24C5.37258300203,24 0,18.627416998 0,12L0,12C0,5.37258300203 5.37258300203,0 12,0Z"}
+        fill={props.ovalFill || "#00C121"}
+
+      />
+      <Svg.Path
+        d={"M6.5,12.6L9.75,15.85L17.25,8.35"}
+        fill={"none"}
+        stroke={props.pathStroke || "#FFFFFF"}
+        strokeWidth={"2"}
+        strokeLinecap={"round"}
+
+      />
+    </Svg>
+  );
+}
+let AnotherCheckCheckCircleVector = (props) => {
   return (
     <Svg
       style={props.style}
@@ -43,13 +66,13 @@ export default class RepeatedVector extends React.Component {
     AnotherCheck$vector$path$stroke = colors.green800
     return (
       <View style={styles.view}>
-        <CheckCircleVector
+        <CheckCheckCircleVector
           style={styles.check}
           ovalFill={Check$vector$oval$fill}
           preserveAspectRatio={"xMidYMid meet"}
 
         />
-        <CheckCircleVector
+        <AnotherCheckCheckCircleVector
           style={styles.anotherCheck}
           pathStroke={AnotherCheck$vector$path$stroke}
           preserveAspectRatio={"xMidYMid meet"}

--- a/examples/generated/test/react-native/logic/VectorLogic.js
+++ b/examples/generated/test/react-native/logic/VectorLogic.js
@@ -6,7 +6,7 @@ import colors from "../colors"
 import shadows from "../shadows"
 import textStyles from "../textStyles"
 
-let CheckCircleVector = (props) => {
+let CheckCheckCircleVector = (props) => {
   return (
     <Svg
       style={props.style}
@@ -43,7 +43,7 @@ export default class VectorLogic extends React.Component {
     }
     return (
       <View style={styles.view}>
-        <CheckCircleVector
+        <CheckCheckCircleVector
           style={styles.check}
           ovalFill={Check$vector$oval$fill}
           pathStroke={Check$vector$path$stroke}

--- a/examples/generated/test/sketchJs/images/VectorAsset.js
+++ b/examples/generated/test/sketchJs/images/VectorAsset.js
@@ -6,7 +6,7 @@ import colors from "../colors"
 import shadows from "../shadows"
 import textStyles from "../textStyles"
 
-let ToggleVector = (props) => {
+let VectorGraphic1ToggleVector = (props) => {
   return (
     <Svg
       style={props.style}
@@ -29,7 +29,7 @@ let ToggleVector = (props) => {
     </Svg>
   );
 }
-let ToggleVerticalVector = (props) => {
+let VectorGraphic2ToggleVerticalVector = (props) => {
   return (
     <Svg
       style={props.style}
@@ -52,7 +52,7 @@ let ToggleVerticalVector = (props) => {
     </Svg>
   );
 }
-let CheckCircleVector = (props) => {
+let VectorGraphic3CheckCircleVector = (props) => {
   return (
     <Svg
       style={props.style}
@@ -82,17 +82,17 @@ export default class VectorAsset extends React.Component {
 
     return (
       <View style={styles.view}>
-        <ToggleVector
+        <VectorGraphic1ToggleVector
           style={styles.vectorGraphic1}
           preserveAspectRatio={"xMidYMid meet"}
 
         />
-        <ToggleVerticalVector
+        <VectorGraphic2ToggleVerticalVector
           style={styles.vectorGraphic2}
           preserveAspectRatio={"xMidYMid meet"}
 
         />
-        <CheckCircleVector style={styles.vectorGraphic3} />
+        <VectorGraphic3CheckCircleVector style={styles.vectorGraphic3} />
       </View>
     );
   }

--- a/examples/generated/test/sketchJs/logic/RepeatedVector.js
+++ b/examples/generated/test/sketchJs/logic/RepeatedVector.js
@@ -6,7 +6,30 @@ import colors from "../colors"
 import shadows from "../shadows"
 import textStyles from "../textStyles"
 
-let CheckCircleVector = (props) => {
+let CheckCheckCircleVector = (props) => {
+  return (
+    <Svg
+      style={props.style}
+      preserveAspectRatio={props.preserveAspectRatio || "xMidYMid slice"}
+      viewBox={"0 0 24 24"}
+    >
+      <Svg.Path
+        d={"M12,0L12,0C18.627416998,0 24,5.37258300203 24,12L24,12C24,18.627416998 18.627416998,24 12,24L12,24C5.37258300203,24 0,18.627416998 0,12L0,12C0,5.37258300203 5.37258300203,0 12,0Z"}
+        fill={props.ovalFill || "#00C121"}
+
+      />
+      <Svg.Path
+        d={"M6.5,12.6L9.75,15.85L17.25,8.35"}
+        fill={"none"}
+        stroke={props.pathStroke || "#FFFFFF"}
+        strokeWidth={"2"}
+        strokeLinecap={"round"}
+
+      />
+    </Svg>
+  );
+}
+let AnotherCheckCheckCircleVector = (props) => {
   return (
     <Svg
       style={props.style}
@@ -43,13 +66,13 @@ export default class RepeatedVector extends React.Component {
     AnotherCheck$vector$path$stroke = colors.green800
     return (
       <View style={styles.view}>
-        <CheckCircleVector
+        <CheckCheckCircleVector
           style={styles.check}
           ovalFill={Check$vector$oval$fill}
           preserveAspectRatio={"xMidYMid meet"}
 
         />
-        <CheckCircleVector
+        <AnotherCheckCheckCircleVector
           style={styles.anotherCheck}
           pathStroke={AnotherCheck$vector$path$stroke}
           preserveAspectRatio={"xMidYMid meet"}

--- a/examples/generated/test/sketchJs/logic/VectorLogic.js
+++ b/examples/generated/test/sketchJs/logic/VectorLogic.js
@@ -6,7 +6,7 @@ import colors from "../colors"
 import shadows from "../shadows"
 import textStyles from "../textStyles"
 
-let CheckCircleVector = (props) => {
+let CheckCheckCircleVector = (props) => {
   return (
     <Svg
       style={props.style}
@@ -43,7 +43,7 @@ export default class VectorLogic extends React.Component {
     }
     return (
       <View style={styles.view}>
-        <CheckCircleVector
+        <CheckCheckCircleVector
           style={styles.check}
           ovalFill={Check$vector$oval$fill}
           pathStroke={Check$vector$path$stroke}


### PR DESCRIPTION
## What

Support generating React DOM code using styled-components for styling. In theory RN and Sketch should work too, though I haven't tested.

This can be configured with the `--styleFramework=styledcomponents` CLI flag.

A couple things to note:
- Dynamic styles (set via logic) are still applied using the `style` jsx attribute of the element. I'm not sure if styled-components prefixes these -- but all of the styles we support setting dynamically should work on every browser without vendor prefixing, except maybe shadow.
- I temporarily removed an svg optimization where I reused the same svg component if the svg is used twice within the same file. I'm not sure what's the best way to support this using styled-components.
- A left a couple theme-related things commented since I don't want to forget what we had planned.
- For RN/Sketch there will be naming collisions if you leave your layers as default names like "View", but we can deal with that if we ever end up using styled-components with those.

## Testing Plan

- [X] Tested this change locally
- [X] Checked that existing features work

@outdooricon 