### PR TITLE
iOS interactions

### DIFF
--- a/compiler/core/src/core/layer.re
+++ b/compiler/core/src/core/layer.re
@@ -414,6 +414,13 @@ let logicAssignmentsFromLayerParameters = layer => {
   layerMap^;
 };
 
+let isInteractive = (logic: Logic.logicNode, layer: Types.layer) =>
+  [ParameterKey.OnPress, ParameterKey.Hovered, ParameterKey.Pressed]
+  |> List.map(ParameterKey.toString)
+  |> List.exists(variableName =>
+       Logic.isLayerParameterAssigned(logic, variableName, layer)
+     );
+
 let parameterIsStyle = key => getParameterCategory(key) == Style;
 
 let splitParamsMap = params =>

--- a/compiler/core/src/main.re
+++ b/compiler/core/src/main.re
@@ -245,57 +245,31 @@ let convertComponent = (config: Config.t, filename: string) => {
 let copyStaticFiles = outputDirectory =>
   switch (target) {
   | Types.Swift =>
-    let framework =
+    let staticFiles =
+      ["TextStyle", "CGSize+Resizing"]
+      @ (
+        switch (swiftOptions.framework) {
+        | UIKit => ["Shadow"]
+        | AppKit => ["LNATextField", "LNAImageView", "NSImage+Resizing"]
+        }
+      );
+
+    let frameworkExtension =
       switch (swiftOptions.framework) {
       | AppKit => "appkit"
       | UIKit => "uikit"
       };
-    switch (swiftOptions.framework) {
-    | UIKit =>
-      copySync(
-        concat(
-          [%bs.raw {| __dirname |}],
-          "static/swift/Shadow." ++ framework ++ ".swift",
-        ),
-        concat(outputDirectory, "Shadow.swift"),
-      )
-    | AppKit =>
-      copySync(
-        concat(
-          [%bs.raw {| __dirname |}],
-          "static/swift/LNATextField." ++ framework ++ ".swift",
-        ),
-        concat(outputDirectory, "LNATextField.swift"),
-      );
-      copySync(
-        concat(
-          [%bs.raw {| __dirname |}],
-          "static/swift/LNAImageView." ++ framework ++ ".swift",
-        ),
-        concat(outputDirectory, "LNAImageView.swift"),
-      );
-      copySync(
-        concat(
-          [%bs.raw {| __dirname |}],
-          "static/swift/NSImage+Resizing." ++ framework ++ ".swift",
-        ),
-        concat(outputDirectory, "NSImage+Resizing.swift"),
-      );
-    };
-    copySync(
-      concat(
-        [%bs.raw {| __dirname |}],
-        "static/swift/TextStyle." ++ framework ++ ".swift",
-      ),
-      concat(outputDirectory, "TextStyle.swift"),
-    );
-    copySync(
-      concat(
-        [%bs.raw {| __dirname |}],
-        "static/swift/CGSize+Resizing." ++ framework ++ ".swift",
-      ),
-      concat(outputDirectory, "CGSize+Resizing.swift"),
-    );
+
+    staticFiles
+    |> List.iter(file =>
+         copySync(
+           concat(
+             [%bs.raw {| __dirname |}],
+             "static/swift/" ++ file ++ "." ++ frameworkExtension ++ ".swift",
+           ),
+           concat(outputDirectory, file ++ ".swift"),
+         )
+       );
   | _ => ()
   };
 

--- a/compiler/core/src/main.re
+++ b/compiler/core/src/main.re
@@ -249,7 +249,7 @@ let copyStaticFiles = outputDirectory =>
       ["TextStyle", "CGSize+Resizing"]
       @ (
         switch (swiftOptions.framework) {
-        | UIKit => ["Shadow"]
+        | UIKit => ["LonaControlView", "Shadow"]
         | AppKit => ["LNATextField", "LNAImageView", "NSImage+Resizing"]
         }
       );

--- a/compiler/core/src/static/swift/LonaControlView.uikit.swift
+++ b/compiler/core/src/static/swift/LonaControlView.uikit.swift
@@ -1,0 +1,18 @@
+import UIKit
+
+// MARK: - LonaControl
+
+protocol LonaControl {}
+
+// MARK: - LonaControlView
+
+public class LonaControlView: UIControl, LonaControl {
+
+  var onHighlight: (() -> Void)?
+
+  public override var isHighlighted: Bool {
+    didSet {
+      onHighlight?()
+    }
+  }
+}

--- a/compiler/core/src/swift/appkit/appkitPressable.re
+++ b/compiler/core/src/swift/appkit/appkitPressable.re
@@ -10,7 +10,7 @@ let trackingAreaVar =
     "pattern":
       IdentifierPattern({
         "identifier": SwiftIdentifier("trackingArea"),
-        "annotation": None
+        "annotation": None,
       }),
     "init":
       Some(
@@ -22,8 +22,8 @@ let trackingAreaVar =
               "value":
                 MemberExpression([
                   SwiftIdentifier("self"),
-                  SwiftIdentifier("frame")
-                ])
+                  SwiftIdentifier("frame"),
+                ]),
             }),
             FunctionCallArgument({
               "name": Some(SwiftIdentifier("options")),
@@ -33,18 +33,18 @@ let trackingAreaVar =
                     SwiftIdentifier(".mouseEnteredAndExited"),
                     SwiftIdentifier(".activeAlways"),
                     SwiftIdentifier(".mouseMoved"),
-                    SwiftIdentifier(".inVisibleRect")
-                  ])
-                )
+                    SwiftIdentifier(".inVisibleRect"),
+                  ]),
+                ),
             }),
             FunctionCallArgument({
               "name": Some(SwiftIdentifier("owner")),
-              "value": SwiftIdentifier("self")
-            })
-          ]
-        })
+              "value": SwiftIdentifier("self"),
+            }),
+          ],
+        }),
       ),
-    "block": None
+    "block": None,
   });
 
 /* addTrackingArea(trackingArea) */
@@ -54,9 +54,9 @@ let addTrackingArea =
     "arguments": [
       FunctionCallArgument({
         "name": None,
-        "value": SwiftIdentifier("trackingArea")
-      })
-    ]
+        "value": SwiftIdentifier("trackingArea"),
+      }),
+    ],
   });
 
 /* deinit {
@@ -69,10 +69,10 @@ let deinitTrackingArea =
       "arguments": [
         FunctionCallArgument({
           "name": None,
-          "value": SwiftIdentifier("trackingArea")
-        })
-      ]
-    })
+          "value": SwiftIdentifier("trackingArea"),
+        }),
+      ],
+    }),
   ]);
 
 let mouseTrackingFunctions = (rootLayer, pressableLayers: list(Types.layer)) => {
@@ -90,7 +90,7 @@ let mouseTrackingFunctions = (rootLayer, pressableLayers: list(Types.layer)) => 
                 SwiftDocument.layerMemberExpression(
                   rootLayer,
                   layer,
-                  [SwiftIdentifier("convert")]
+                  [SwiftIdentifier("convert")],
                 ),
               "arguments": [
                 FunctionCallArgument({
@@ -98,18 +98,18 @@ let mouseTrackingFunctions = (rootLayer, pressableLayers: list(Types.layer)) => 
                   "value":
                     MemberExpression([
                       SwiftIdentifier("event"),
-                      SwiftIdentifier("locationInWindow")
-                    ])
+                      SwiftIdentifier("locationInWindow"),
+                    ]),
                 }),
                 FunctionCallArgument({
                   "name": Some(SwiftIdentifier("from")),
-                  "value": LiteralExpression(Nil)
-                })
-              ]
-            })
-          ]
-        })
-      ]
+                  "value": LiteralExpression(Nil),
+                }),
+              ],
+            }),
+          ],
+        }),
+      ],
     );
   let containsPointVariable = (variableName, layer: Types.layer) =>
     ConstantDeclaration({
@@ -119,10 +119,10 @@ let mouseTrackingFunctions = (rootLayer, pressableLayers: list(Types.layer)) => 
         IdentifierPattern({
           "identifier":
             SwiftIdentifier(
-              SwiftFormat.layerVariableName(rootLayer, layer, variableName)
+              SwiftFormat.layerVariableName(rootLayer, layer, variableName),
             ),
-          "annotation": None
-        })
+          "annotation": None,
+        }),
     });
   let wasClicked = (layer: Types.layer) =>
     ConstantDeclaration({
@@ -131,9 +131,9 @@ let mouseTrackingFunctions = (rootLayer, pressableLayers: list(Types.layer)) => 
         IdentifierPattern({
           "identifier":
             SwiftIdentifier(
-              SwiftFormat.layerVariableName(rootLayer, layer, "clicked")
+              SwiftFormat.layerVariableName(rootLayer, layer, "clicked"),
             ),
-          "annotation": None
+          "annotation": None,
         }),
       "init":
         Some(
@@ -141,12 +141,12 @@ let mouseTrackingFunctions = (rootLayer, pressableLayers: list(Types.layer)) => 
             "&&",
             [
               SwiftIdentifier(
-                SwiftFormat.layerVariableName(rootLayer, layer, "pressed")
+                SwiftFormat.layerVariableName(rootLayer, layer, "pressed"),
               ),
-              containsPoint(layer)
-            ]
-          )
-        )
+              containsPoint(layer),
+            ],
+          ),
+        ),
     });
   let ifChanged = variableName => {
     let layerVariableName = layer =>
@@ -161,11 +161,11 @@ let mouseTrackingFunctions = (rootLayer, pressableLayers: list(Types.layer)) => 
             "right":
               MemberExpression([
                 SwiftIdentifier("self"),
-                SwiftIdentifier(layerVariableName(layer))
-              ])
+                SwiftIdentifier(layerVariableName(layer)),
+              ]),
           })
         ) @@
-        pressableLayers
+        pressableLayers,
       );
     let assignments =
       List.map(layer =>
@@ -173,10 +173,10 @@ let mouseTrackingFunctions = (rootLayer, pressableLayers: list(Types.layer)) => 
           "left":
             MemberExpression([
               SwiftIdentifier("self"),
-              SwiftIdentifier(layerVariableName(layer))
+              SwiftIdentifier(layerVariableName(layer)),
             ]),
           "operator": "=",
-          "right": SwiftIdentifier(layerVariableName(layer))
+          "right": SwiftIdentifier(layerVariableName(layer)),
         })
       ) @@
       pressableLayers;
@@ -190,11 +190,11 @@ let mouseTrackingFunctions = (rootLayer, pressableLayers: list(Types.layer)) => 
             [
               FunctionCallExpression({
                 "name": SwiftIdentifier("update"),
-                "arguments": []
-              })
-            ]
-          ]
-        )
+                "arguments": [],
+              }),
+            ],
+          ],
+        ),
     });
   };
   let ifTrueSetFalse = variableName => {
@@ -203,10 +203,10 @@ let mouseTrackingFunctions = (rootLayer, pressableLayers: list(Types.layer)) => 
         "||",
         List.map(layer =>
           SwiftIdentifier(
-            SwiftFormat.layerVariableName(rootLayer, layer, variableName)
+            SwiftFormat.layerVariableName(rootLayer, layer, variableName),
           )
         ) @@
-        pressableLayers
+        pressableLayers,
       );
     let assignments =
       List.map(layer =>
@@ -214,11 +214,11 @@ let mouseTrackingFunctions = (rootLayer, pressableLayers: list(Types.layer)) => 
           "left":
             MemberExpression([
               SwiftIdentifier(
-                SwiftFormat.layerVariableName(rootLayer, layer, variableName)
-              )
+                SwiftFormat.layerVariableName(rootLayer, layer, variableName),
+              ),
             ]),
           "operator": "=",
-          "right": LiteralExpression(Boolean(false))
+          "right": LiteralExpression(Boolean(false)),
         })
       ) @@
       pressableLayers;
@@ -232,62 +232,64 @@ let mouseTrackingFunctions = (rootLayer, pressableLayers: list(Types.layer)) => 
             [
               FunctionCallExpression({
                 "name": SwiftIdentifier("update"),
-                "arguments": []
-              })
-            ]
-          ]
-        )
+                "arguments": [],
+              }),
+            ],
+          ],
+        ),
     });
   };
   let invokePressHandler = (layer: Types.layer) =>
     IfStatement({
       "condition":
         SwiftIdentifier(
-          SwiftFormat.layerVariableName(rootLayer, layer, "clicked")
+          SwiftFormat.layerVariableName(rootLayer, layer, "clicked"),
         ),
       "block": [
         FunctionCallExpression({
           "name":
             SwiftIdentifier(
-              SwiftFormat.layerVariableName(rootLayer, layer, "onPress?")
+              SwiftFormat.layerVariableName(rootLayer, layer, "onPress?"),
             ),
-          "arguments": []
-        })
-      ]
+          "arguments": [],
+        }),
+      ],
     });
   let eventHandler = (name, body) =>
     FunctionDeclaration({
       "name": name,
+      "attributes": [],
       "modifiers": [AccessLevelModifier(PublicModifier), OverrideModifier],
       "parameters": [
         Parameter({
           "externalName": Some("with"),
           "localName": "event",
           "defaultValue": None,
-          "annotation": TypeName("NSEvent")
-        })
+          "annotation": TypeName("NSEvent"),
+        }),
       ],
       "throws": false,
       "result": None,
-      "body": body
+      "body": body,
     });
   let updateHoverState =
     FunctionDeclaration({
       "name": "updateHoverState",
+      "attributes": [],
       "modifiers": [AccessLevelModifier(PrivateModifier)],
       "parameters": [
         Parameter({
           "externalName": Some("with"),
           "localName": "event",
           "defaultValue": None,
-          "annotation": TypeName("NSEvent")
-        })
+          "annotation": TypeName("NSEvent"),
+        }),
       ],
       "throws": false,
       "result": None,
       "body":
         (pressableLayers |> List.map(containsPointVariable("hovered")))
-        @ [ifChanged("hovered")]
+        @ [ifChanged("hovered")],
     });
   let invokeUpdateHoverState =
     FunctionCallExpression({
@@ -295,9 +297,9 @@ let mouseTrackingFunctions = (rootLayer, pressableLayers: list(Types.layer)) => 
       "arguments": [
         FunctionCallArgument({
           "name": Some(SwiftIdentifier("with")),
-          "value": SwiftIdentifier("event")
-        })
-      ]
+          "value": SwiftIdentifier("event"),
+        }),
+      ],
     });
   let mouseEntered = eventHandler("mouseEntered", [invokeUpdateHoverState]);
   let mouseMoved = eventHandler("mouseMoved", [invokeUpdateHoverState]);
@@ -307,7 +309,7 @@ let mouseTrackingFunctions = (rootLayer, pressableLayers: list(Types.layer)) => 
     eventHandler(
       "mouseDown",
       (pressableLayers |> List.map(containsPointVariable("pressed")))
-      @ [ifChanged("pressed")]
+      @ [ifChanged("pressed")],
     );
   let mouseUp =
     eventHandler(
@@ -316,7 +318,7 @@ let mouseTrackingFunctions = (rootLayer, pressableLayers: list(Types.layer)) => 
       @ [Empty]
       @ [ifTrueSetFalse("pressed")]
       @ [Empty]
-      @ (pressableLayers |> List.map(invokePressHandler))
+      @ (pressableLayers |> List.map(invokePressHandler)),
     );
   [
     updateHoverState,
@@ -331,6 +333,6 @@ let mouseTrackingFunctions = (rootLayer, pressableLayers: list(Types.layer)) => 
     Empty,
     mouseDown,
     Empty,
-    mouseUp
+    mouseUp,
   ];
 };

--- a/compiler/core/src/swift/swiftAst.re
+++ b/compiler/core/src/swift/swiftAst.re
@@ -11,6 +11,8 @@ type mutationModifier =
   | MutatingModifier
   | NonmutatingModifier;
 
+type attribute = string;
+
 [@bs.deriving accessors]
 type declarationModifier =
   | ClassModifier
@@ -209,6 +211,7 @@ and node =
       {
         .
         "name": string,
+        "attributes": list(attribute),
         "modifiers": list(declarationModifier),
         "parameters": list(node),
         "result": option(typeAnnotation),

--- a/compiler/core/src/swift/swiftColor.re
+++ b/compiler/core/src/swift/swiftColor.re
@@ -70,6 +70,7 @@ let render =
     let colorFuncDoc = () =>
       FunctionDeclaration({
         "name": "color",
+        "attributes": [],
         "modifiers": [],
         "parameters": [
           Parameter({

--- a/compiler/core/src/swift/swiftComponent.re
+++ b/compiler/core/src/swift/swiftComponent.re
@@ -1065,7 +1065,7 @@ let generate =
                       |> Layer.flatten
                       |> List.filter(Layer.isInteractive(logic))
                       |> List.map(Doc.tapHandler)
-                      |> List.concat :
+                      |> SwiftDocument.joinGroups(Empty) :
                       [],
                   ],
                 ),

--- a/compiler/core/src/swift/swiftComponent.re
+++ b/compiler/core/src/swift/swiftComponent.re
@@ -100,7 +100,7 @@ module Doc = {
 
   let tapVariables = (rootLayer: Types.layer, layer: Types.layer) => [
     SwiftAst.Builders.privateVariableDeclaration(
-      SwiftFormat.layerName(layer.name) ++ "OnTap",
+      SwiftFormat.tapHandler(layer.name),
       Some(OptionalType(TypeName("(() -> Void)"))),
       None,
     ),
@@ -118,7 +118,7 @@ module Doc = {
     },
   ];
 
-  let tapHandler = (rootLayer: Types.layer, layer: Types.layer) => [
+  let tapHandler = (layer: Types.layer) => [
     FunctionDeclaration({
       "name":
         "handleTap" ++ Format.upperFirst(SwiftFormat.layerName(layer.name)),
@@ -129,7 +129,7 @@ module Doc = {
       "throws": false,
       "body": [
         SwiftAst.Builders.functionCall(
-          [SwiftFormat.layerName(layer.name) ++ "OnTap?"],
+          [SwiftFormat.tapHandler(layer.name) ++ "?"],
           [],
         ),
       ],
@@ -1064,7 +1064,7 @@ let generate =
                       rootLayer
                       |> Layer.flatten
                       |> List.filter(Layer.isInteractive(logic))
-                      |> List.map(Doc.tapHandler(rootLayer))
+                      |> List.map(Doc.tapHandler)
                       |> List.concat :
                       [],
                   ],

--- a/compiler/core/src/swift/swiftComponent.re
+++ b/compiler/core/src/swift/swiftComponent.re
@@ -100,7 +100,7 @@ module Doc = {
 
   let tapVariables = (rootLayer: Types.layer, layer: Types.layer) => [
     SwiftAst.Builders.privateVariableDeclaration(
-      SwiftFormat.layerVariableName(rootLayer, layer, "onPress") /* onTap */,
+      SwiftFormat.layerName(layer.name) ++ "OnTap",
       Some(OptionalType(TypeName("(() -> Void)"))),
       None,
     ),
@@ -129,9 +129,7 @@ module Doc = {
       "throws": false,
       "body": [
         SwiftAst.Builders.functionCall(
-          [
-            SwiftFormat.layerVariableName(rootLayer, layer, "onPress?") /* onTap */,
-          ],
+          [SwiftFormat.layerName(layer.name) ++ "OnTap?"],
           [],
         ),
       ],

--- a/compiler/core/src/swift/swiftComponent.re
+++ b/compiler/core/src/swift/swiftComponent.re
@@ -12,12 +12,18 @@ module Naming = {
         config: Config.t,
         pluginContext: Plugin.context,
         swiftOptions: SwiftOptions.options,
+        logic: Logic.logicNode,
         componentName: string,
         layer: Types.layer,
       ) => {
     let typeName =
       switch (swiftOptions.framework, layer.typeName) {
-      | (UIKit, Types.View) => "UIView"
+      | (UIKit, Types.View) =>
+        if (Layer.isInteractive(logic, layer)) {
+          "LonaControlView";
+        } else {
+          "UIView";
+        }
       | (UIKit, Text) => "UILabel"
       | (UIKit, Image) => "BackgroundImageView"
       | (AppKit, Types.View) => "NSBox"
@@ -90,6 +96,46 @@ module Doc = {
       Some(OptionalType(TypeName("(() -> Void)"))),
       None,
     ),
+  ];
+
+  let tapVariables = (rootLayer: Types.layer, layer: Types.layer) => [
+    SwiftAst.Builders.privateVariableDeclaration(
+      SwiftFormat.layerVariableName(rootLayer, layer, "onPress") /* onTap */,
+      Some(OptionalType(TypeName("(() -> Void)"))),
+      None,
+    ),
+  ];
+
+  let interactiveVariables =
+      (
+        framework: SwiftOptions.framework,
+        rootLayer: Types.layer,
+        layer: Types.layer,
+      ) => [
+    switch (framework) {
+    | UIKit => tapVariables(rootLayer, layer)
+    | AppKit => pressableVariables(rootLayer, layer)
+    },
+  ];
+
+  let tapHandler = (rootLayer: Types.layer, layer: Types.layer) => [
+    FunctionDeclaration({
+      "name":
+        "handleTap" ++ Format.upperFirst(SwiftFormat.layerName(layer.name)),
+      "attributes": ["@objc"],
+      "modifiers": [AccessLevelModifier(PrivateModifier)],
+      "parameters": [],
+      "result": None,
+      "throws": false,
+      "body": [
+        SwiftAst.Builders.functionCall(
+          [
+            SwiftFormat.layerVariableName(rootLayer, layer, "onPress?") /* onTap */,
+          ],
+          [],
+        ),
+      ],
+    }),
   ];
 
   let parameterVariable =
@@ -221,6 +267,7 @@ module Doc = {
         swiftOptions: SwiftOptions.options,
         config: Config.t,
         getComponent,
+        logic,
         assignmentsFromLayerParameters,
         assignmentsFromLogic,
         layerMemberExpression,
@@ -407,8 +454,47 @@ module Doc = {
           }),
         ]
       };
+    let addInteractionHandlers = (layer: Types.layer) => [
+      FunctionCallExpression({
+        "name":
+          layerMemberExpression(layer, [SwiftIdentifier("addTarget")]),
+        "arguments": [
+          FunctionCallArgument({
+            "name": None,
+            "value": SwiftIdentifier("self"),
+          }),
+          FunctionCallArgument({
+            "name": Some(SwiftIdentifier("action")),
+            "value":
+              SwiftAst.Builders.functionCall(
+                ["#selector"],
+                [
+                  (
+                    None,
+                    [
+                      "handleTap"
+                      ++ Format.upperFirst(SwiftFormat.layerName(layer.name)),
+                    ],
+                  ),
+                ],
+              ),
+          }),
+          FunctionCallArgument({
+            "name": Some(SwiftIdentifier("for")),
+            "value": SwiftIdentifier(".touchUpInside"),
+          }),
+        ],
+      }),
+      BinaryExpression({
+        "left":
+          layerMemberExpression(layer, [SwiftIdentifier("onHighlight")]),
+        "operator": "=",
+        "right": SwiftIdentifier("update"),
+      }),
+    ];
     FunctionDeclaration({
       "name": "setUpViews",
+      "attributes": [],
       "modifiers": [AccessLevelModifier(PrivateModifier)],
       "parameters": [],
       "result": None,
@@ -420,6 +506,15 @@ module Doc = {
             Layer.flatmap(resetViewStyling, rootLayer) |> List.concat,
             Layer.flatmapParent(addSubviews, rootLayer) |> List.concat,
             setUpDefaultsDoc(),
+            switch (swiftOptions.framework) {
+            | UIKit =>
+              rootLayer
+              |> Layer.flatten
+              |> List.filter(Layer.isInteractive(logic))
+              |> List.map(addInteractionHandlers)
+              |> List.concat
+            | AppKit => []
+            },
           ],
         ),
     });
@@ -598,6 +693,7 @@ module Doc = {
 
     FunctionDeclaration({
       "name": "update",
+      "attributes": [],
       "modifiers": [AccessLevelModifier(PrivateModifier)],
       "parameters": [],
       "result": None,
@@ -660,7 +756,14 @@ let generate =
           swiftOptions,
           assignmentsFromLayerParameters,
           layer,
-          Naming.layerType(config, pluginContext, swiftOptions, name, layer),
+          Naming.layerType(
+            config,
+            pluginContext,
+            swiftOptions,
+            logic,
+            name,
+            layer,
+          ),
         ),
       ),
     );
@@ -833,7 +936,14 @@ let generate =
         config.plugins,
         pluginContext,
         name,
-        swiftOptions.framework == UIKit ? "UIView" : "NSBox",
+        switch (
+          swiftOptions.framework,
+          Layer.isInteractive(logic, rootLayer),
+        ) {
+        | (UIKit, true) => "LonaControlView"
+        | (UIKit, false) => "UIView"
+        | (AppKit, _) => "NSBox"
+        },
       ),
     );
   TopLevelDeclaration({
@@ -876,7 +986,13 @@ let generate =
                     |> List.filter(Layer.isTextLayer)
                     |> List.map(textStyleVariableDoc),
                     pressableLayers
-                    |> List.map(Doc.pressableVariables(rootLayer))
+                    |> List.map(
+                         Doc.interactiveVariables(
+                           swiftOptions.framework,
+                           rootLayer,
+                         ),
+                       )
+                    |> List.concat
                     |> List.concat,
                     Constraint.conditionalConstraints(visibilityCombinations)
                     @ (
@@ -902,6 +1018,7 @@ let generate =
                         swiftOptions,
                         config,
                         getComponent,
+                        logic,
                         assignmentsFromLayerParameters,
                         assignmentsFromLogic,
                         layerMemberExpression,
@@ -944,6 +1061,13 @@ let generate =
                         rootLayer,
                         pressableLayers,
                       ) :
+                      [],
+                    swiftOptions.framework == UIKit ?
+                      rootLayer
+                      |> Layer.flatten
+                      |> List.filter(Layer.isInteractive(logic))
+                      |> List.map(Doc.tapHandler(rootLayer))
+                      |> List.concat :
                       [],
                   ],
                 ),

--- a/compiler/core/src/swift/swiftConstraint.re
+++ b/compiler/core/src/swift/swiftConstraint.re
@@ -434,6 +434,7 @@ let setUpFunction =
 
   FunctionDeclaration({
     "name": "setUpConstraints",
+    "attributes": [],
     "modifiers": [AccessLevelModifier(PrivateModifier)],
     "parameters": [],
     "result": None,
@@ -505,6 +506,7 @@ let conditionalConstraintsFunction =
 
   FunctionDeclaration({
     "name": "conditionalConstraints",
+    "attributes": [],
     "modifiers": [AccessLevelModifier(PrivateModifier)],
     "parameters": [],
     "result": Some(ArrayType(TypeName("NSLayoutConstraint"))),

--- a/compiler/core/src/swift/swiftFormat.re
+++ b/compiler/core/src/swift/swiftFormat.re
@@ -39,3 +39,6 @@ let vectorVariableName = (vectorAssignment: Layer.vectorAssignment): string =>
   ++ Format.upperFirst(
        Layer.vectorParamKeyToString(vectorAssignment.paramKey),
      );
+
+let tapHandler = (name: string): string =>
+  "onTap" ++ Format.upperFirst(layerName(name));

--- a/compiler/core/src/swift/swiftHelperClass.re
+++ b/compiler/core/src/swift/swiftHelperClass.re
@@ -37,6 +37,7 @@ let generateImageWithBackgroundColor =
         Empty,
         FunctionDeclaration({
           "name": "draw",
+          "attributes": [],
           "modifiers": [OverrideModifier],
           "parameters": [
             Parameter({
@@ -260,6 +261,7 @@ let generateVectorGraphic =
           [
             FunctionDeclaration({
               "name": "draw",
+              "attributes": [],
               "modifiers": [OverrideModifier],
               "parameters": [
                 Parameter({

--- a/compiler/core/src/swift/swiftLogic.re
+++ b/compiler/core/src/swift/swiftLogic.re
@@ -119,7 +119,7 @@ let toSwiftAST =
         when name |> Js.String.endsWith("onPress") =>
       switch (layer) {
       | Some(layer) =>
-        Ast.SwiftIdentifier(SwiftFormat.layerName(layer.name) ++ "OnTap")
+        Ast.SwiftIdentifier(SwiftFormat.tapHandler(layer.name))
       | None => Ast.SwiftIdentifier("Unknown interactive layer")
       }
     /* -- AppKit -- */

--- a/compiler/core/src/swift/swiftLogic.re
+++ b/compiler/core/src/swift/swiftLogic.re
@@ -82,12 +82,6 @@ let toSwiftAST =
     | (_, Ast.SwiftIdentifier(name))
         when name |> Js.String.endsWith("onPress") =>
       Ast.SwiftIdentifier(name |> Js.String.replace(".onPress", "OnPress"))
-    | (_, Ast.SwiftIdentifier(name))
-        when name |> Js.String.endsWith("hovered") =>
-      Ast.SwiftIdentifier(name |> Js.String.replace(".hovered", "Hovered"))
-    | (_, Ast.SwiftIdentifier(name))
-        when name |> Js.String.endsWith("pressed") =>
-      Ast.SwiftIdentifier(name |> Js.String.replace(".pressed", "Pressed"))
     /* -- UIKit -- */
     /* TODO: Make sure "borderRadius" without the "." doesn't match intermediate variables */
     | (UIKit, Ast.SwiftIdentifier(name))
@@ -116,6 +110,14 @@ let toSwiftAST =
       Ast.SwiftIdentifier(
         name |> Js.String.replace("borderWidth", "layer.borderWidth"),
       )
+    | (UIKit, Ast.SwiftIdentifier(name))
+        when name |> Js.String.endsWith("hovered") =>
+      Ast.SwiftIdentifier("false")
+    | (UIKit, Ast.SwiftIdentifier(name))
+        when name |> Js.String.endsWith("pressed") =>
+      Ast.SwiftIdentifier(
+        name |> Js.String.replace("pressed", "isHighlighted"),
+      )
     /* -- AppKit -- */
     /* TODO: Make sure "borderRadius" without the "." doesn't match intermediate variables */
     | (AppKit, Ast.SwiftIdentifier(name))
@@ -141,6 +143,12 @@ let toSwiftAST =
       Ast.SwiftIdentifier(
         name |> Js.String.replace("numberOfLines", "maximumNumberOfLines"),
       )
+    | (AppKit, Ast.SwiftIdentifier(name))
+        when name |> Js.String.endsWith("hovered") =>
+      Ast.SwiftIdentifier(name |> Js.String.replace(".hovered", "Hovered"))
+    | (AppKit, Ast.SwiftIdentifier(name))
+        when name |> Js.String.endsWith("pressed") =>
+      Ast.SwiftIdentifier(name |> Js.String.replace(".pressed", "Pressed"))
     | _ => initialValue
     };
   };

--- a/compiler/core/src/swift/swiftLogic.re
+++ b/compiler/core/src/swift/swiftLogic.re
@@ -79,9 +79,6 @@ let toSwiftAST =
       Ast.SwiftIdentifier(
         name |> Js.String.replace(".width", "WidthAnchorConstraint?.constant"),
       )
-    | (_, Ast.SwiftIdentifier(name))
-        when name |> Js.String.endsWith("onPress") =>
-      Ast.SwiftIdentifier(name |> Js.String.replace(".onPress", "OnPress"))
     /* -- UIKit -- */
     /* TODO: Make sure "borderRadius" without the "." doesn't match intermediate variables */
     | (UIKit, Ast.SwiftIdentifier(name))
@@ -118,6 +115,13 @@ let toSwiftAST =
       Ast.SwiftIdentifier(
         name |> Js.String.replace("pressed", "isHighlighted"),
       )
+    | (UIKit, Ast.SwiftIdentifier(name))
+        when name |> Js.String.endsWith("onPress") =>
+      switch (layer) {
+      | Some(layer) =>
+        Ast.SwiftIdentifier(SwiftFormat.layerName(layer.name) ++ "OnTap")
+      | None => Ast.SwiftIdentifier("Unknown interactive layer")
+      }
     /* -- AppKit -- */
     /* TODO: Make sure "borderRadius" without the "." doesn't match intermediate variables */
     | (AppKit, Ast.SwiftIdentifier(name))
@@ -149,6 +153,9 @@ let toSwiftAST =
     | (AppKit, Ast.SwiftIdentifier(name))
         when name |> Js.String.endsWith("pressed") =>
       Ast.SwiftIdentifier(name |> Js.String.replace(".pressed", "Pressed"))
+    | (AppKit, Ast.SwiftIdentifier(name))
+        when name |> Js.String.endsWith("onPress") =>
+      Ast.SwiftIdentifier(name |> Js.String.replace(".onPress", "OnPress"))
     | _ => initialValue
     };
   };

--- a/compiler/core/src/swift/swiftLogic.re
+++ b/compiler/core/src/swift/swiftLogic.re
@@ -112,7 +112,7 @@ let toSwiftAST =
       )
     | (UIKit, Ast.SwiftIdentifier(name))
         when name |> Js.String.endsWith("hovered") =>
-      Ast.SwiftIdentifier("false")
+      Ast.LiteralExpression(Boolean(false))
     | (UIKit, Ast.SwiftIdentifier(name))
         when name |> Js.String.endsWith("pressed") =>
       Ast.SwiftIdentifier(
@@ -388,6 +388,26 @@ let toSwiftAST =
       let bIsOptional = LonaValue.isOptionalType(Logic.getValueType(b));
 
       switch (left, operator, right) {
+      | (
+          Ast.LiteralExpression(Boolean(boolA)),
+          "==",
+          Ast.LiteralExpression(Boolean(boolB)),
+        ) =>
+        if (boolA == boolB) {
+          Ast.StatementListHelper(body);
+        } else {
+          Empty;
+        }
+      | (
+          Ast.LiteralExpression(Boolean(boolA)),
+          "!=",
+          Ast.LiteralExpression(Boolean(boolB)),
+        ) =>
+        if (boolA != boolB) {
+          Ast.StatementListHelper(body);
+        } else {
+          Empty;
+        }
       | (Ast.LiteralExpression(Boolean(true)), "==", condition)
       | (condition, "==", Ast.LiteralExpression(Boolean(true)))
           when !aIsOptional && !bIsOptional =>

--- a/compiler/core/src/swift/swiftRender.re
+++ b/compiler/core/src/swift/swiftRender.re
@@ -346,6 +346,10 @@ let rec render = ast: Prettier.Doc.t('a) =>
       concat([
         group(
           concat([
+            o##attributes
+            |> List.map(s)
+            |> List.map(x => x <+> s(" "))
+            |> concat,
             o##modifiers
             |> List.map(renderDeclarationModifier)
             |> join(s(" ")),

--- a/compiler/core/src/swift/swiftSvg.re
+++ b/compiler/core/src/swift/swiftSvg.re
@@ -484,6 +484,7 @@ let rec convertNode =
           }),
           FunctionDeclaration({
             "name": "transform",
+            "attributes": [],
             "modifiers": [],
             "parameters": [
               Parameter({

--- a/compiler/core/src/swift/swiftTypeSystem.re
+++ b/compiler/core/src/swift/swiftTypeSystem.re
@@ -528,6 +528,7 @@ module Ast = {
     let encodableFunction = (body: list(SwiftAst.node)) =>
       FunctionDeclaration({
         "name": "encode",
+        "attributes": [],
         "modifiers": [AccessLevelModifier(PublicModifier)],
         "parameters": [
           Parameter({

--- a/examples/LonaViewer/LonaViewer.xcodeproj/project.pbxproj
+++ b/examples/LonaViewer/LonaViewer.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		6B1086EF21780A890024AE56 /* VectorAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B1086EE21780A890024AE56 /* VectorAsset.swift */; };
 		6B1086F521793F5C0024AE56 /* VectorAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B1086F421793F5C0024AE56 /* VectorAsset.swift */; };
 		6B1086FF217A700B0024AE56 /* VectorLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B1086FE217A700A0024AE56 /* VectorLogic.swift */; };
+		6B291337219B94CB00A1DDB4 /* LonaControlView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B291336219B94CB00A1DDB4 /* LonaControlView.swift */; };
 		6B3916FD21601C5900B20F9E /* BoxModelConditional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3916FC21601C5900B20F9E /* BoxModelConditional.swift */; };
 		6B3916FF2160286D00B20F9E /* BoxModelConditional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3916FE2160286D00B20F9E /* BoxModelConditional.swift */; };
 		6B391702216422D400B20F9E /* Shadows.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B391701216422D400B20F9E /* Shadows.swift */; };
@@ -148,6 +149,7 @@
 		6B1086EE21780A890024AE56 /* VectorAsset.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VectorAsset.swift; sourceTree = "<group>"; };
 		6B1086F421793F5C0024AE56 /* VectorAsset.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VectorAsset.swift; sourceTree = "<group>"; };
 		6B1086FE217A700A0024AE56 /* VectorLogic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VectorLogic.swift; sourceTree = "<group>"; };
+		6B291336219B94CB00A1DDB4 /* LonaControlView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LonaControlView.swift; sourceTree = "<group>"; };
 		6B3916FC21601C5900B20F9E /* BoxModelConditional.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BoxModelConditional.swift; sourceTree = "<group>"; };
 		6B3916FE2160286D00B20F9E /* BoxModelConditional.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BoxModelConditional.swift; sourceTree = "<group>"; };
 		6B391701216422D400B20F9E /* Shadows.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Shadows.swift; sourceTree = "<group>"; };
@@ -346,18 +348,19 @@
 			isa = PBXGroup;
 			children = (
 				6B6D4428218F565C0016262C /* CGSize+Resizing.swift */,
-				6B39170521643C7C00B20F9E /* Shadows.swift */,
+				12BBFDFF206B02AC0041620C /* Colors.swift */,
+				6B291336219B94CB00A1DDB4 /* LonaControlView.swift */,
 				6B3917092164492600B20F9E /* Shadow.swift */,
-				12BBFDEB206B02AC0041620C /* TextStyles.swift */,
+				6B39170521643C7C00B20F9E /* Shadows.swift */,
 				301C262520C1C5A700F18F73 /* TextStyle.swift */,
+				12BBFDEB206B02AC0041620C /* TextStyles.swift */,
+				12BBFE00206B02AC0041620C /* assets */,
 				6BA69404208439DB0090CA74 /* components */,
 				12BBFDED206B02AC0041620C /* images */,
-				12BBFDEF206B02AC0041620C /* logic */,
-				12BBFDF2206B02AC0041620C /* style */,
 				12BBFDF7206B02AC0041620C /* interactivity */,
 				12BBFDF9206B02AC0041620C /* layouts */,
-				12BBFDFF206B02AC0041620C /* Colors.swift */,
-				12BBFE00206B02AC0041620C /* assets */,
+				12BBFDEF206B02AC0041620C /* logic */,
+				12BBFDF2206B02AC0041620C /* style */,
 			);
 			name = swift;
 			path = ../../generated/test/swift;
@@ -554,6 +557,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				301C262620C1C5A700F18F73 /* TextStyle.swift in Sources */,
+				6B291337219B94CB00A1DDB4 /* LonaControlView.swift in Sources */,
 				6B39170821643EF300B20F9E /* ShadowsTest.swift in Sources */,
 				12BBFE02206B02AC0041620C /* TextStyles.swift in Sources */,
 				6BA5BBD1216D4B6700F086A7 /* VisibilityTest.swift in Sources */,

--- a/examples/LonaViewer/MacOS/Generated.swift
+++ b/examples/LonaViewer/MacOS/Generated.swift
@@ -148,13 +148,14 @@ enum Generated: String {
 
     var constraints: [Constraint] {
         switch self {
-        case .localAsset, .pressableRootView:
+        case .localAsset:
             return [
                 equal(\.topAnchor),
                 equal(\.leftAnchor),
                 equal(\.widthAnchor),
             ]
         case .button,
+             .pressableRootView,
              .nestedComponent,
              .nestedButtons,
              .fixedParentFillAndFitChildren,

--- a/examples/LonaViewer/iOS/Generated.swift
+++ b/examples/LonaViewer/iOS/Generated.swift
@@ -148,12 +148,13 @@ enum Generated: String {
 
     var constraints: [Constraint] {
         switch self {
-        case .localAsset, .pressableRootView:
+        case .localAsset:
             return [
                 equal(\.topAnchor, \.safeAreaLayoutGuide.topAnchor),
                 equal(\.leftAnchor),
             ]
         case .button,
+             .pressableRootView,
              .nestedComponent,
              .nestedButtons,
              .fixedParentFillAndFitChildren,

--- a/examples/generated/test/swift/LonaControlView.swift
+++ b/examples/generated/test/swift/LonaControlView.swift
@@ -1,0 +1,18 @@
+import UIKit
+
+// MARK: - LonaControl
+
+protocol LonaControl {}
+
+// MARK: - LonaControlView
+
+public class LonaControlView: UIControl, LonaControl {
+
+  var onHighlight: (() -> Void)?
+
+  public override var isHighlighted: Bool {
+    didSet {
+      onHighlight?()
+    }
+  }
+}

--- a/examples/generated/test/swift/interactivity/Button.swift
+++ b/examples/generated/test/swift/interactivity/Button.swift
@@ -39,7 +39,7 @@ public class Button: LonaControlView {
 
   private var textViewTextStyle = TextStyles.button
 
-  private var viewViewOnTap: (() -> Void)?
+  private var onTapViewView: (() -> Void)?
 
   private func setUpViews() {
     textView.numberOfLines = 0
@@ -79,7 +79,7 @@ public class Button: LonaControlView {
   private func update() {
     backgroundColor = Colors.blue100
     textView.attributedText = textViewTextStyle.apply(to: label)
-    viewViewOnTap = onTap
+    onTapViewView = onTap
 
     if isHighlighted {
       backgroundColor = Colors.blue50
@@ -90,6 +90,6 @@ public class Button: LonaControlView {
   }
 
   @objc private func handleTapViewView() {
-    viewViewOnTap?()
+    onTapViewView?()
   }
 }

--- a/examples/generated/test/swift/interactivity/Button.swift
+++ b/examples/generated/test/swift/interactivity/Button.swift
@@ -3,7 +3,7 @@ import Foundation
 
 // MARK: - Button
 
-public class Button: UIView {
+public class Button: LonaControlView {
 
   // MARK: Lifecycle
 
@@ -39,8 +39,6 @@ public class Button: UIView {
 
   private var textViewTextStyle = TextStyles.button
 
-  private var hovered = false
-  private var pressed = false
   private var onPress: (() -> Void)?
 
   private func setUpViews() {
@@ -50,6 +48,9 @@ public class Button: UIView {
 
     textViewTextStyle = TextStyles.button
     textView.attributedText = textViewTextStyle.apply(to: textView.attributedText ?? NSAttributedString())
+
+    addTarget(self, action: #selector(handleTapViewView), for: .touchUpInside)
+    onHighlight = update
   }
 
   private func setUpConstraints() {
@@ -79,14 +80,18 @@ public class Button: UIView {
     backgroundColor = Colors.blue100
     textView.attributedText = textViewTextStyle.apply(to: label)
     onPress = onTap
-    if hovered {
+    if false {
       backgroundColor = Colors.blue200
     }
-    if pressed {
+    if isHighlighted {
       backgroundColor = Colors.blue50
     }
     if secondary {
       backgroundColor = Colors.lightblue100
     }
+  }
+
+  @objc private func handleTapViewView() {
+    onPress?()
   }
 }

--- a/examples/generated/test/swift/interactivity/Button.swift
+++ b/examples/generated/test/swift/interactivity/Button.swift
@@ -39,7 +39,7 @@ public class Button: LonaControlView {
 
   private var textViewTextStyle = TextStyles.button
 
-  private var onPress: (() -> Void)?
+  private var viewViewOnTap: (() -> Void)?
 
   private func setUpViews() {
     textView.numberOfLines = 0
@@ -79,7 +79,7 @@ public class Button: LonaControlView {
   private func update() {
     backgroundColor = Colors.blue100
     textView.attributedText = textViewTextStyle.apply(to: label)
-    onPress = onTap
+    viewViewOnTap = onTap
 
     if isHighlighted {
       backgroundColor = Colors.blue50
@@ -90,6 +90,6 @@ public class Button: LonaControlView {
   }
 
   @objc private func handleTapViewView() {
-    onPress?()
+    viewViewOnTap?()
   }
 }

--- a/examples/generated/test/swift/interactivity/Button.swift
+++ b/examples/generated/test/swift/interactivity/Button.swift
@@ -80,9 +80,7 @@ public class Button: LonaControlView {
     backgroundColor = Colors.blue100
     textView.attributedText = textViewTextStyle.apply(to: label)
     onPress = onTap
-    if false {
-      backgroundColor = Colors.blue200
-    }
+
     if isHighlighted {
       backgroundColor = Colors.blue50
     }

--- a/examples/generated/test/swift/interactivity/PressableRootView.swift
+++ b/examples/generated/test/swift/interactivity/PressableRootView.swift
@@ -32,8 +32,8 @@ public class PressableRootView: LonaControlView {
 
   private var innerTextViewTextStyle = TextStyles.headline
 
-  private var outerViewOnTap: (() -> Void)?
-  private var innerViewOnTap: (() -> Void)?
+  private var onTapOuterView: (() -> Void)?
+  private var onTapInnerView: (() -> Void)?
 
   private func setUpViews() {
     innerTextView.numberOfLines = 0
@@ -83,8 +83,8 @@ public class PressableRootView: LonaControlView {
     innerView.backgroundColor = Colors.blue500
     innerTextView.attributedText = innerTextViewTextStyle.apply(to: "")
     backgroundColor = Colors.grey50
-    outerViewOnTap = onPressOuter
-    innerViewOnTap = onPressInner
+    onTapOuterView = onPressOuter
+    onTapInnerView = onPressInner
 
     if isHighlighted {
       backgroundColor = Colors.grey300
@@ -98,9 +98,9 @@ public class PressableRootView: LonaControlView {
   }
 
   @objc private func handleTapOuterView() {
-    outerViewOnTap?()
+    onTapOuterView?()
   }
   @objc private func handleTapInnerView() {
-    innerViewOnTap?()
+    onTapInnerView?()
   }
 }

--- a/examples/generated/test/swift/interactivity/PressableRootView.swift
+++ b/examples/generated/test/swift/interactivity/PressableRootView.swift
@@ -3,7 +3,7 @@ import Foundation
 
 // MARK: - PressableRootView
 
-public class PressableRootView: UIView {
+public class PressableRootView: LonaControlView {
 
   // MARK: Lifecycle
 
@@ -27,16 +27,12 @@ public class PressableRootView: UIView {
 
   // MARK: Private
 
-  private var innerView = UIView(frame: .zero)
+  private var innerView = LonaControlView(frame: .zero)
   private var innerTextView = UILabel()
 
   private var innerTextViewTextStyle = TextStyles.headline
 
-  private var hovered = false
-  private var pressed = false
   private var onPress: (() -> Void)?
-  private var innerViewHovered = false
-  private var innerViewPressed = false
   private var innerViewOnPress: (() -> Void)?
 
   private func setUpViews() {
@@ -48,6 +44,11 @@ public class PressableRootView: UIView {
     innerTextViewTextStyle = TextStyles.headline
     innerTextView.attributedText =
       innerTextViewTextStyle.apply(to: innerTextView.attributedText ?? NSAttributedString())
+
+    addTarget(self, action: #selector(handleTapOuterView), for: .touchUpInside)
+    onHighlight = update
+    innerView.addTarget(self, action: #selector(handleTapInnerView), for: .touchUpInside)
+    innerView.onHighlight = update
   }
 
   private func setUpConstraints() {
@@ -84,24 +85,31 @@ public class PressableRootView: UIView {
     backgroundColor = Colors.grey50
     onPress = onPressOuter
     innerViewOnPress = onPressInner
-    if hovered {
+    if false {
       backgroundColor = Colors.grey100
     }
-    if pressed {
+    if isHighlighted {
       backgroundColor = Colors.grey300
     }
-    if innerViewHovered {
+    if false {
       innerView.backgroundColor = Colors.blue300
       innerTextView.attributedText = innerTextViewTextStyle.apply(to: "Hovered")
     }
-    if innerViewPressed {
+    if innerView.isHighlighted {
       innerView.backgroundColor = Colors.blue800
       innerTextView.attributedText = innerTextViewTextStyle.apply(to: "Pressed")
     }
-    if innerViewHovered {
-      if innerViewPressed {
+    if false {
+      if innerView.isHighlighted {
         innerTextView.attributedText = innerTextViewTextStyle.apply(to: "Hovered & Pressed")
       }
     }
+  }
+
+  @objc private func handleTapOuterView() {
+    onPress?()
+  }
+  @objc private func handleTapInnerView() {
+    innerViewOnPress?()
   }
 }

--- a/examples/generated/test/swift/interactivity/PressableRootView.swift
+++ b/examples/generated/test/swift/interactivity/PressableRootView.swift
@@ -85,25 +85,16 @@ public class PressableRootView: LonaControlView {
     backgroundColor = Colors.grey50
     onPress = onPressOuter
     innerViewOnPress = onPressInner
-    if false {
-      backgroundColor = Colors.grey100
-    }
+
     if isHighlighted {
       backgroundColor = Colors.grey300
     }
-    if false {
-      innerView.backgroundColor = Colors.blue300
-      innerTextView.attributedText = innerTextViewTextStyle.apply(to: "Hovered")
-    }
+
     if innerView.isHighlighted {
       innerView.backgroundColor = Colors.blue800
       innerTextView.attributedText = innerTextViewTextStyle.apply(to: "Pressed")
     }
-    if false {
-      if innerView.isHighlighted {
-        innerTextView.attributedText = innerTextViewTextStyle.apply(to: "Hovered & Pressed")
-      }
-    }
+
   }
 
   @objc private func handleTapOuterView() {

--- a/examples/generated/test/swift/interactivity/PressableRootView.swift
+++ b/examples/generated/test/swift/interactivity/PressableRootView.swift
@@ -32,8 +32,8 @@ public class PressableRootView: LonaControlView {
 
   private var innerTextViewTextStyle = TextStyles.headline
 
-  private var onPress: (() -> Void)?
-  private var innerViewOnPress: (() -> Void)?
+  private var outerViewOnTap: (() -> Void)?
+  private var innerViewOnTap: (() -> Void)?
 
   private func setUpViews() {
     innerTextView.numberOfLines = 0
@@ -83,8 +83,8 @@ public class PressableRootView: LonaControlView {
     innerView.backgroundColor = Colors.blue500
     innerTextView.attributedText = innerTextViewTextStyle.apply(to: "")
     backgroundColor = Colors.grey50
-    onPress = onPressOuter
-    innerViewOnPress = onPressInner
+    outerViewOnTap = onPressOuter
+    innerViewOnTap = onPressInner
 
     if isHighlighted {
       backgroundColor = Colors.grey300
@@ -98,9 +98,9 @@ public class PressableRootView: LonaControlView {
   }
 
   @objc private func handleTapOuterView() {
-    onPress?()
+    outerViewOnTap?()
   }
   @objc private func handleTapInnerView() {
-    innerViewOnPress?()
+    innerViewOnTap?()
   }
 }

--- a/examples/generated/test/swift/interactivity/PressableRootView.swift
+++ b/examples/generated/test/swift/interactivity/PressableRootView.swift
@@ -100,6 +100,7 @@ public class PressableRootView: LonaControlView {
   @objc private func handleTapOuterView() {
     onTapOuterView?()
   }
+
   @objc private func handleTapInnerView() {
     onTapInnerView?()
   }


### PR DESCRIPTION
## What

Support tap actions and pressed state on iOS.

If the component uses hover state, which is only supported on macOS at the moment, the `hovered` variable is set to `false`. This causes any dead conditionals, e.g. `if false { ... }` to be eliminated.

## Testing Plan

- [X] Tested this change locally
- [X] Checked that existing features work
