### PR TITLE
Remove extra image wrapper when using styled components

### DIFF
--- a/compiler/core/src/javaScript/javaScriptComponent.re
+++ b/compiler/core/src/javaScript/javaScriptComponent.re
@@ -242,7 +242,17 @@ module StyledComponents = {
       ) => {
     let imageResizingComponents =
       rootLayer
-      |> Layer.imageResizingModes
+      |> Layer.flatten
+      |> List.filter(layer =>
+           imageNeedsWrapper(Layer.findParent(rootLayer, layer), layer)
+         )
+      |> List.map((layer: Types.layer) =>
+           switch (Layer.getStringParameterOpt(ResizeMode, layer.parameters)) {
+           | Some(value) => value
+           | None => "cover"
+           }
+         )
+      |> Sequence.dedupeMem
       |> List.map(imageResizingStyledComponentAst(config, options));
     let layerComponents =
       rootLayer

--- a/examples/generated/test/react-dom/images/LocalAsset.js
+++ b/examples/generated/test/react-dom/images/LocalAsset.js
@@ -13,13 +13,6 @@ export default class LocalAsset extends React.Component {
   }
 };
 
-let ImageResizeModeCover = styled.img({
-  width: "100%",
-  height: "100%",
-  objectFit: "cover",
-  position: "absolute"
-})
-
 let View = styled.div({
   alignItems: "flex-start",
   backgroundColor: colors.red400,

--- a/examples/generated/test/react-dom/style/TextAlignment.js
+++ b/examples/generated/test/react-dom/style/TextAlignment.js
@@ -64,13 +64,6 @@ export default class TextAlignment extends React.Component {
   }
 };
 
-let ImageResizeModeCover = styled.img({
-  width: "100%",
-  height: "100%",
-  objectFit: "cover",
-  position: "absolute"
-})
-
 let View = styled.div({
   alignItems: "flex-start",
   display: "flex",


### PR DESCRIPTION
## What

Removes extra image wrapper components.

Note: I only fixed this for styled-components for now.

## Testing Plan

- [X] Tested this change locally
- [X] Checked that existing features work

cc @outdooricon 