### PR TITLE
Add opacity support to LS and compiler

### DIFF
--- a/compiler/core/src/core/decode.re
+++ b/compiler/core/src/core/decode.re
@@ -12,6 +12,7 @@ let parameterType = key =>
   | Visible => Types.booleanType
   | NumberOfLines => Types.numberType
   | BackgroundColor => Types.colorType
+  | Opacity => Types.numberType
   | Image => Types.urlType
   /* Styles */
   | AlignItems => Types.stringType

--- a/compiler/core/src/core/layer.re
+++ b/compiler/core/src/core/layer.re
@@ -57,6 +57,7 @@ let getParameterCategory = (x: ParameterKey.t) =>
   | Height => Style
   | MaxHeight => Style
   | BackgroundColor => Style
+  | Opacity => Style
   | BorderColor => Style
   | BorderRadius => Style
   | BorderWidth => Style

--- a/compiler/core/src/core/lonaValue.re
+++ b/compiler/core/src/core/lonaValue.re
@@ -39,6 +39,7 @@ let parameterDefaultValue = key =>
   | ParameterKey.Visible => boolean(true)
   | ParameterKey.NumberOfLines => number(0.)
   | ParameterKey.BackgroundColor => color("transparent")
+  | ParameterKey.Opacity => number(1.)
   | ParameterKey.Image => url("")
   /* Styles */
   | ParameterKey.AlignItems => string("stretch")

--- a/compiler/core/src/core/parameterKey.re
+++ b/compiler/core/src/core/parameterKey.re
@@ -15,6 +15,7 @@ type t =
   | AlignItems
   | AlignSelf
   | BackgroundColor
+  | Opacity
   | Display
   | Flex
   | FlexDirection
@@ -59,6 +60,7 @@ let fromString = string =>
   | "alignItems" => AlignItems
   | "alignSelf" => AlignSelf
   | "backgroundColor" => BackgroundColor
+  | "opacity" => Opacity
   | "display" => Display
   | "flex" => Flex
   | "flexDirection" => FlexDirection
@@ -105,6 +107,7 @@ let toString = key =>
   | AlignItems => "alignItems"
   | AlignSelf => "alignSelf"
   | BackgroundColor => "backgroundColor"
+  | Opacity => "opacity"
   | Display => "display"
   | Flex => "flex"
   | FlexDirection => "flexDirection"

--- a/compiler/core/src/swift/swiftLogic.re
+++ b/compiler/core/src/swift/swiftLogic.re
@@ -90,6 +90,9 @@ let toSwiftAST =
         name |> Js.String.replace("borderRadius", "layer.cornerRadius"),
       )
     | (UIKit, Ast.SwiftIdentifier(name))
+        when name |> Js.String.endsWith(".opacity") || name == "opacity" =>
+      Ast.SwiftIdentifier(name |> Js.String.replace("opacity", "alpha"))
+    | (UIKit, Ast.SwiftIdentifier(name))
         when name |> Js.String.endsWith(".resizeMode") || name == "resizeMode" =>
       switch (layer) {
       | Some((layer: Types.layer)) when layer.typeName == Types.VectorGraphic =>
@@ -132,6 +135,9 @@ let toSwiftAST =
       Ast.SwiftIdentifier(
         name |> Js.String.replace("borderRadius", "cornerRadius"),
       )
+    | (AppKit, Ast.SwiftIdentifier(name))
+        when name |> Js.String.endsWith(".opacity") || name == "opacity" =>
+      Ast.SwiftIdentifier(name |> Js.String.replace("opacity", "alphaValue"))
     | (AppKit, Ast.SwiftIdentifier(name))
         when name |> Js.String.endsWith(".resizeMode") || name == "resizeMode" =>
       Ast.SwiftIdentifier(

--- a/examples/LonaViewer/LonaViewer.xcodeproj/project.pbxproj
+++ b/examples/LonaViewer/LonaViewer.xcodeproj/project.pbxproj
@@ -58,6 +58,8 @@
 		6B1086F521793F5C0024AE56 /* VectorAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B1086F421793F5C0024AE56 /* VectorAsset.swift */; };
 		6B1086FF217A700B0024AE56 /* VectorLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B1086FE217A700A0024AE56 /* VectorLogic.swift */; };
 		6B291337219B94CB00A1DDB4 /* LonaControlView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B291336219B94CB00A1DDB4 /* LonaControlView.swift */; };
+		6B29133B219CB84200A1DDB4 /* OpacityTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B29133A219CB84200A1DDB4 /* OpacityTest.swift */; };
+		6B29133D219CBC7A00A1DDB4 /* OpacityTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B29133C219CBC7A00A1DDB4 /* OpacityTest.swift */; };
 		6B3916FD21601C5900B20F9E /* BoxModelConditional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3916FC21601C5900B20F9E /* BoxModelConditional.swift */; };
 		6B3916FF2160286D00B20F9E /* BoxModelConditional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3916FE2160286D00B20F9E /* BoxModelConditional.swift */; };
 		6B391702216422D400B20F9E /* Shadows.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B391701216422D400B20F9E /* Shadows.swift */; };
@@ -150,6 +152,8 @@
 		6B1086F421793F5C0024AE56 /* VectorAsset.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VectorAsset.swift; sourceTree = "<group>"; };
 		6B1086FE217A700A0024AE56 /* VectorLogic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VectorLogic.swift; sourceTree = "<group>"; };
 		6B291336219B94CB00A1DDB4 /* LonaControlView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LonaControlView.swift; sourceTree = "<group>"; };
+		6B29133A219CB84200A1DDB4 /* OpacityTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpacityTest.swift; sourceTree = "<group>"; };
+		6B29133C219CBC7A00A1DDB4 /* OpacityTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpacityTest.swift; sourceTree = "<group>"; };
 		6B3916FC21601C5900B20F9E /* BoxModelConditional.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BoxModelConditional.swift; sourceTree = "<group>"; };
 		6B3916FE2160286D00B20F9E /* BoxModelConditional.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BoxModelConditional.swift; sourceTree = "<group>"; };
 		6B391701216422D400B20F9E /* Shadows.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Shadows.swift; sourceTree = "<group>"; };
@@ -303,10 +307,11 @@
 			children = (
 				12BBFDCC206B02720041620C /* BorderWidthColor.swift */,
 				6B3916FE2160286D00B20F9E /* BoxModelConditional.swift */,
-				6BD581DC208252250068FBC3 /* TextAlignment.swift */,
-				12BBFDCD206B02720041620C /* TextStylesTest.swift */,
-				12BBFDCE206B02720041620C /* TextStyleConditional.swift */,
+				6B29133C219CBC7A00A1DDB4 /* OpacityTest.swift */,
 				6B391703216423A000B20F9E /* ShadowsTest.swift */,
+				6BD581DC208252250068FBC3 /* TextAlignment.swift */,
+				12BBFDCE206B02720041620C /* TextStyleConditional.swift */,
+				12BBFDCD206B02720041620C /* TextStylesTest.swift */,
 				6BA5BBCE216D4A7D00F086A7 /* VisibilityTest.swift */,
 			);
 			path = style;
@@ -396,6 +401,7 @@
 				6BD581DA2082521A0068FBC3 /* TextAlignment.swift */,
 				12BBFDF5206B02AC0041620C /* TextStylesTest.swift */,
 				12BBFDF6206B02AC0041620C /* TextStyleConditional.swift */,
+				6B29133A219CB84200A1DDB4 /* OpacityTest.swift */,
 				6B39170721643EF300B20F9E /* ShadowsTest.swift */,
 				6BA5BBD0216D4B6700F086A7 /* VisibilityTest.swift */,
 			);
@@ -577,6 +583,7 @@
 				6BA69406208439DB0090CA74 /* NestedComponent.swift in Sources */,
 				12BBFE0E206B02AC0041620C /* SecondaryAxis.swift in Sources */,
 				6BA5BBD5217021A000F086A7 /* Optionals.swift in Sources */,
+				6B29133B219CB84200A1DDB4 /* OpacityTest.swift in Sources */,
 				12BBFE11206B02AC0041620C /* Colors.swift in Sources */,
 				30F870B920864A88007ADA5B /* NestedButtons.swift in Sources */,
 				12BBFE0D206B02AC0041620C /* FixedParentFitChild.swift in Sources */,
@@ -623,6 +630,7 @@
 				12BBFE14206B03FB0041620C /* LayoutExtension.swift in Sources */,
 				6B3916FF2160286D00B20F9E /* BoxModelConditional.swift in Sources */,
 				12869397204A1B4E00E5E26F /* ViewSelectionVc.swift in Sources */,
+				6B29133D219CBC7A00A1DDB4 /* OpacityTest.swift in Sources */,
 				12BBFDE4206B02720041620C /* FixedParentFitChild.swift in Sources */,
 				6B6D442F218F5D430016262C /* NSImage+Resizing.swift in Sources */,
 				6BA6940A208441120090CA74 /* NestedButtons.swift in Sources */,

--- a/examples/LonaViewer/MacOS/Generated.swift
+++ b/examples/LonaViewer/MacOS/Generated.swift
@@ -37,6 +37,7 @@ enum Generated: String {
     case boxModelConditionalSmall = "Box Model Conditional Small"
     case boxModelConditionalLarge = "Box Model Conditional Large"
     case shadowsTest = "Shadow Test"
+    case opacityTest = "Opacity Test"
     case visibilityTest = "Visibility Test"
     case optionals = "Optionals"
 
@@ -70,6 +71,7 @@ enum Generated: String {
             boxModelConditionalSmall,
             boxModelConditionalLarge,
             shadowsTest,
+            opacityTest,
             visibilityTest,
             optionals,
         ]
@@ -125,6 +127,8 @@ enum Generated: String {
             return BoxModelConditional(margin: 20, size: 120)
         case .shadowsTest:
             return ShadowsTest()
+        case .opacityTest:
+            return OpacityTest(selected: true)
         case .visibilityTest:
             return VisibilityTest(enabled: true)
         case .optionals:
@@ -170,6 +174,7 @@ enum Generated: String {
              .boxModelConditionalSmall,
              .boxModelConditionalLarge,
              .shadowsTest,
+             .opacityTest,
              .visibilityTest,
              .optionals,
              .vectorAsset,

--- a/examples/LonaViewer/iOS/Generated.swift
+++ b/examples/LonaViewer/iOS/Generated.swift
@@ -37,6 +37,7 @@ enum Generated: String {
     case boxModelConditionalSmall = "Box Model Conditional Small"
     case boxModelConditionalLarge = "Box Model Conditional Large"
     case shadowsTest = "Shadow Test"
+    case opacityTest = "Opacity Test"
     case visibilityTest = "Visibility Test"
     case optionals = "Optionals"
 
@@ -70,8 +71,9 @@ enum Generated: String {
             boxModelConditionalSmall,
             boxModelConditionalLarge,
             shadowsTest,
-            visibilityTest,
-            optionals
+            opacityTest,
+            optionals,
+            visibilityTest
         ]
     }
     
@@ -125,6 +127,8 @@ enum Generated: String {
             return BoxModelConditional(margin: 20, size: 120)
         case .shadowsTest:
             return ShadowsTest()
+        case .opacityTest:
+            return OpacityTest(selected: true)
         case .visibilityTest:
             return VisibilityTest(enabled: true)
         case .optionals:
@@ -169,6 +173,7 @@ enum Generated: String {
              .boxModelConditionalSmall,
              .boxModelConditionalLarge,
              .shadowsTest,
+             .opacityTest,
              .visibilityTest,
              .optionals,
              .vectorAsset,

--- a/examples/generated/test/appkit/style/OpacityTest.swift
+++ b/examples/generated/test/appkit/style/OpacityTest.swift
@@ -1,0 +1,106 @@
+import AppKit
+import Foundation
+
+// MARK: - OpacityTest
+
+public class OpacityTest: NSBox {
+
+  // MARK: Lifecycle
+
+  public init(selected: Bool) {
+    self.selected = selected
+
+    super.init(frame: .zero)
+
+    setUpViews()
+    setUpConstraints()
+
+    update()
+  }
+
+  public convenience init() {
+    self.init(selected: false)
+  }
+
+  public required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: Public
+
+  public var selected: Bool { didSet { update() } }
+
+  // MARK: Private
+
+  private var view1View = NSBox()
+  private var textView = LNATextField(labelWithString: "")
+  private var imageView = LNAImageView()
+
+  private var textViewTextStyle = TextStyles.body1
+
+  private func setUpViews() {
+    boxType = .custom
+    borderType = .lineBorder
+    contentViewMargins = .zero
+    view1View.boxType = .custom
+    view1View.borderType = .noBorder
+    view1View.contentViewMargins = .zero
+    textView.lineBreakMode = .byWordWrapping
+
+    addSubview(view1View)
+    view1View.addSubview(textView)
+    view1View.addSubview(imageView)
+
+    fillColor = Colors.blue500
+    borderWidth = 10
+    borderColor = Colors.pink300
+    view1View.fillColor = Colors.red900
+    view1View.alphaValue = 0.8
+    textView.attributedStringValue = textViewTextStyle.apply(to: "Text goes here")
+    textView.alphaValue = 0.8
+    imageView.image = #imageLiteral(resourceName: "icon_128x128")
+    imageView.alphaValue = 0.5
+  }
+
+  private func setUpConstraints() {
+    translatesAutoresizingMaskIntoConstraints = false
+    view1View.translatesAutoresizingMaskIntoConstraints = false
+    textView.translatesAutoresizingMaskIntoConstraints = false
+    imageView.translatesAutoresizingMaskIntoConstraints = false
+
+    let view1ViewTopAnchorConstraint = view1View.topAnchor.constraint(equalTo: topAnchor, constant: 10)
+    let view1ViewBottomAnchorConstraint = view1View.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -10)
+    let view1ViewLeadingAnchorConstraint = view1View.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10)
+    let view1ViewHeightAnchorConstraint = view1View.heightAnchor.constraint(equalToConstant: 100)
+    let view1ViewWidthAnchorConstraint = view1View.widthAnchor.constraint(equalToConstant: 100)
+    let textViewTopAnchorConstraint = textView.topAnchor.constraint(equalTo: view1View.topAnchor)
+    let textViewLeadingAnchorConstraint = textView.leadingAnchor.constraint(equalTo: view1View.leadingAnchor)
+    let textViewTrailingAnchorConstraint = textView.trailingAnchor.constraint(equalTo: view1View.trailingAnchor)
+    let imageViewTopAnchorConstraint = imageView.topAnchor.constraint(equalTo: textView.bottomAnchor)
+    let imageViewLeadingAnchorConstraint = imageView.leadingAnchor.constraint(equalTo: view1View.leadingAnchor)
+    let imageViewHeightAnchorConstraint = imageView.heightAnchor.constraint(equalToConstant: 60)
+    let imageViewWidthAnchorConstraint = imageView.widthAnchor.constraint(equalToConstant: 90)
+
+    NSLayoutConstraint.activate([
+      view1ViewTopAnchorConstraint,
+      view1ViewBottomAnchorConstraint,
+      view1ViewLeadingAnchorConstraint,
+      view1ViewHeightAnchorConstraint,
+      view1ViewWidthAnchorConstraint,
+      textViewTopAnchorConstraint,
+      textViewLeadingAnchorConstraint,
+      textViewTrailingAnchorConstraint,
+      imageViewTopAnchorConstraint,
+      imageViewLeadingAnchorConstraint,
+      imageViewHeightAnchorConstraint,
+      imageViewWidthAnchorConstraint
+    ])
+  }
+
+  private func update() {
+    alphaValue = 1
+    if selected {
+      alphaValue = 0.7
+    }
+  }
+}

--- a/examples/generated/test/react-dom/style/OpacityTest.js
+++ b/examples/generated/test/react-dom/style/OpacityTest.js
@@ -1,0 +1,74 @@
+import React from "react"
+import styled from "styled-components"
+
+import colors from "../colors"
+import shadows from "../shadows"
+import textStyles from "../textStyles"
+
+export default class OpacityTest extends React.Component {
+  render() {
+
+    let View$opacity
+    View$opacity = 1
+
+    if (this.props.selected) {
+      View$opacity = 0.7
+    }
+    return (
+      <View style={{ opacity: View$opacity }}>
+        <View1>
+          <Text>
+            {"Text goes here"}
+          </Text>
+          <Image src={require("../assets/icon_128x128.png")} />
+        </View1>
+      </View>
+    );
+  }
+};
+
+let View = styled.div({
+  alignItems: "flex-start",
+  backgroundColor: colors.blue500,
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  borderWidth: "10px",
+  borderColor: colors.pink300
+})
+
+let View1 = styled.div({
+  alignItems: "flex-start",
+  backgroundColor: colors.red900,
+  opacity: 0.8,
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  width: "100px",
+  height: "100px"
+})
+
+let Text = styled.span({
+  textAlign: "left",
+  ...textStyles.body1,
+  alignItems: "flex-start",
+  opacity: 0.8,
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let Image = styled.img({
+  alignItems: "flex-start",
+  opacity: 0.5,
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  overflow: "hidden",
+  width: "90px",
+  height: "60px",
+  objectFit: "cover",
+  position: "relative"
+})

--- a/examples/generated/test/react-native/style/OpacityTest.js
+++ b/examples/generated/test/react-native/style/OpacityTest.js
@@ -1,0 +1,77 @@
+import React from "react"
+import { Image, Text, View, StyleSheet } from "react-native"
+
+import colors from "../colors"
+import shadows from "../shadows"
+import textStyles from "../textStyles"
+
+export default class OpacityTest extends React.Component {
+  render() {
+
+    let View$opacity
+    View$opacity = 1
+
+    if (this.props.selected) {
+      View$opacity = 0.7
+    }
+    return (
+      <View style={[ styles.view, { opacity: View$opacity } ]}>
+        <View style={styles.view1}>
+          <Text style={styles.text}>
+            {"Text goes here"}
+          </Text>
+          <Image
+            style={styles.image}
+            source={require("../assets/icon_128x128.png")}
+
+          />
+        </View>
+      </View>
+    );
+  }
+};
+
+let styles = StyleSheet.create({
+  view: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    backgroundColor: colors.blue500,
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    borderWidth: 10,
+    borderColor: colors.pink300
+  },
+  view1: {
+    alignItems: "flex-start",
+    backgroundColor: colors.red900,
+    opacity: 0.8,
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: 100,
+    height: 100
+  },
+  text: {
+    ...textStyles.body1,
+    alignItems: "flex-start",
+    opacity: 0.8,
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  image: {
+    alignItems: "flex-start",
+    opacity: 0.5,
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: 90,
+    height: 60,
+    resizeMode: "cover"
+  },
+  imageResizeModeCover: {
+    width: "100%",
+    height: "100%",
+    resizeMode: "cover",
+    position: "absolute"
+  }
+})

--- a/examples/generated/test/sketchJs/style/OpacityTest.js
+++ b/examples/generated/test/sketchJs/style/OpacityTest.js
@@ -1,0 +1,78 @@
+import React from "react"
+import { Image, Text, View, StyleSheet, TextStyles } from
+  "@mathieudutour/react-sketchapp"
+
+import colors from "../colors"
+import shadows from "../shadows"
+import textStyles from "../textStyles"
+
+export default class OpacityTest extends React.Component {
+  render() {
+
+    let View$opacity
+    View$opacity = 1
+
+    if (this.props.selected) {
+      View$opacity = 0.7
+    }
+    return (
+      <View style={[ styles.view, { opacity: View$opacity } ]}>
+        <View style={styles.view1}>
+          <Text style={styles.text}>
+            {"Text goes here"}
+          </Text>
+          <Image
+            style={styles.image}
+            source={require("../assets/icon_128x128.png")}
+
+          />
+        </View>
+      </View>
+    );
+  }
+};
+
+let styles = StyleSheet.create({
+  view: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    backgroundColor: colors.blue500,
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    borderWidth: 10,
+    borderColor: colors.pink300
+  },
+  view1: {
+    alignItems: "flex-start",
+    backgroundColor: colors.red900,
+    opacity: 0.8,
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: 100,
+    height: 100
+  },
+  text: {
+    ...TextStyles.get("body1"),
+    alignItems: "flex-start",
+    opacity: 0.8,
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  image: {
+    alignItems: "flex-start",
+    opacity: 0.5,
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: 90,
+    height: 60,
+    resizeMode: "cover"
+  },
+  imageResizeModeCover: {
+    width: "100%",
+    height: "100%",
+    resizeMode: "cover",
+    position: "absolute"
+  }
+})

--- a/examples/generated/test/swift/style/OpacityTest.swift
+++ b/examples/generated/test/swift/style/OpacityTest.swift
@@ -1,0 +1,110 @@
+import UIKit
+import Foundation
+
+// MARK: - BackgroundImageView
+
+private class BackgroundImageView: UIImageView {
+  override var intrinsicContentSize: CGSize {
+    return CGSize(width: UIViewNoIntrinsicMetric, height: UIViewNoIntrinsicMetric)
+  }
+}
+
+// MARK: - OpacityTest
+
+public class OpacityTest: UIView {
+
+  // MARK: Lifecycle
+
+  public init(selected: Bool) {
+    self.selected = selected
+
+    super.init(frame: .zero)
+
+    setUpViews()
+    setUpConstraints()
+
+    update()
+  }
+
+  public convenience init() {
+    self.init(selected: false)
+  }
+
+  public required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: Public
+
+  public var selected: Bool { didSet { update() } }
+
+  // MARK: Private
+
+  private var view1View = UIView(frame: .zero)
+  private var textView = UILabel()
+  private var imageView = BackgroundImageView(frame: .zero)
+
+  private var textViewTextStyle = TextStyles.body1
+
+  private func setUpViews() {
+    textView.numberOfLines = 0
+    imageView.contentMode = .scaleAspectFill
+    imageView.layer.masksToBounds = true
+
+    addSubview(view1View)
+    view1View.addSubview(textView)
+    view1View.addSubview(imageView)
+
+    backgroundColor = Colors.blue500
+    layer.borderWidth = 10
+    layer.borderColor = Colors.pink300.cgColor
+    view1View.backgroundColor = Colors.red900
+    view1View.alpha = 0.8
+    textView.attributedText = textViewTextStyle.apply(to: "Text goes here")
+    textView.alpha = 0.8
+    imageView.image = #imageLiteral(resourceName: "icon_128x128")
+    imageView.alpha = 0.5
+  }
+
+  private func setUpConstraints() {
+    translatesAutoresizingMaskIntoConstraints = false
+    view1View.translatesAutoresizingMaskIntoConstraints = false
+    textView.translatesAutoresizingMaskIntoConstraints = false
+    imageView.translatesAutoresizingMaskIntoConstraints = false
+
+    let view1ViewTopAnchorConstraint = view1View.topAnchor.constraint(equalTo: topAnchor, constant: 10)
+    let view1ViewBottomAnchorConstraint = view1View.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -10)
+    let view1ViewLeadingAnchorConstraint = view1View.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10)
+    let view1ViewHeightAnchorConstraint = view1View.heightAnchor.constraint(equalToConstant: 100)
+    let view1ViewWidthAnchorConstraint = view1View.widthAnchor.constraint(equalToConstant: 100)
+    let textViewTopAnchorConstraint = textView.topAnchor.constraint(equalTo: view1View.topAnchor)
+    let textViewLeadingAnchorConstraint = textView.leadingAnchor.constraint(equalTo: view1View.leadingAnchor)
+    let textViewTrailingAnchorConstraint = textView.trailingAnchor.constraint(equalTo: view1View.trailingAnchor)
+    let imageViewTopAnchorConstraint = imageView.topAnchor.constraint(equalTo: textView.bottomAnchor)
+    let imageViewLeadingAnchorConstraint = imageView.leadingAnchor.constraint(equalTo: view1View.leadingAnchor)
+    let imageViewHeightAnchorConstraint = imageView.heightAnchor.constraint(equalToConstant: 60)
+    let imageViewWidthAnchorConstraint = imageView.widthAnchor.constraint(equalToConstant: 90)
+
+    NSLayoutConstraint.activate([
+      view1ViewTopAnchorConstraint,
+      view1ViewBottomAnchorConstraint,
+      view1ViewLeadingAnchorConstraint,
+      view1ViewHeightAnchorConstraint,
+      view1ViewWidthAnchorConstraint,
+      textViewTopAnchorConstraint,
+      textViewLeadingAnchorConstraint,
+      textViewTrailingAnchorConstraint,
+      imageViewTopAnchorConstraint,
+      imageViewLeadingAnchorConstraint,
+      imageViewHeightAnchorConstraint,
+      imageViewWidthAnchorConstraint
+    ])
+  }
+
+  private func update() {
+    alpha = 1
+    if selected {
+      alpha = 0.7
+    }
+  }
+}

--- a/examples/test/style/OpacityTest.component
+++ b/examples/test/style/OpacityTest.component
@@ -1,0 +1,111 @@
+{
+  "devices" : [
+    {
+      "height" : 100,
+      "heightMode" : "At Least",
+      "name" : "iPhone SE",
+      "width" : 320
+    }
+  ],
+  "examples" : [
+    {
+      "id" : "Default",
+      "name" : "Default",
+      "params" : {
+        "selected" : false
+      }
+    },
+    {
+      "id" : "name",
+      "name" : "name",
+      "params" : {
+        "selected" : true
+      }
+    }
+  ],
+  "logic" : [
+    {
+      "body" : [
+        {
+          "assignee" : [
+            "layers",
+            "View",
+            "opacity"
+          ],
+          "content" : {
+            "type" : "LitExpr",
+            "value" : {
+              "data" : 0.69999999999999996,
+              "type" : "Number"
+            }
+          },
+          "type" : "AssignExpr"
+        }
+      ],
+      "condition" : {
+        "left" : [
+          "parameters",
+          "selected"
+        ],
+        "op" : "==",
+        "right" : {
+          "type" : "LitExpr",
+          "value" : {
+            "data" : true,
+            "type" : "Boolean"
+          }
+        },
+        "type" : "BinExpr"
+      },
+      "type" : "IfExpr"
+    }
+  ],
+  "params" : [
+    {
+      "name" : "selected",
+      "type" : "Boolean"
+    }
+  ],
+  "root" : {
+    "children" : [
+      {
+        "children" : [
+          {
+            "id" : "Text",
+            "params" : {
+              "opacity" : 0.80000000000000004,
+              "text" : "Text goes here"
+            },
+            "type" : "Lona:Text"
+          },
+          {
+            "id" : "Image",
+            "params" : {
+              "height" : 60,
+              "image" : "file:\/\/.\/assets\/icon_128x128.png",
+              "opacity" : 0.5,
+              "width" : 90
+            },
+            "type" : "Lona:Image"
+          }
+        ],
+        "id" : "View 1",
+        "params" : {
+          "backgroundColor" : "red900",
+          "height" : 100,
+          "opacity" : 0.80000000000000004,
+          "width" : 100
+        },
+        "type" : "Lona:View"
+      }
+    ],
+    "id" : "View",
+    "params" : {
+      "alignSelf" : "stretch",
+      "backgroundColor" : "blue500",
+      "borderColor" : "pink300",
+      "borderWidth" : 10
+    },
+    "type" : "Lona:View"
+  }
+}

--- a/studio/LonaStudio.xcodeproj/project.pbxproj
+++ b/studio/LonaStudio.xcodeproj/project.pbxproj
@@ -166,6 +166,7 @@
 		6B1086F7217955120024AE56 /* SVG.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B1086F6217955120024AE56 /* SVG.swift */; };
 		6B1086FB217A34340024AE56 /* Data+String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B1086FA217A34340024AE56 /* Data+String.swift */; };
 		6B1086FD217A38110024AE56 /* LRUCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B1086FC217A38110024AE56 /* LRUCache.swift */; };
+		6B291339219CAC9600A1DDB4 /* CSRendering.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B291338219CAC9600A1DDB4 /* CSRendering.swift */; };
 		6B2DC1AB21361C4700679668 /* ColorPicker.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B2DC1A921361C4700679668 /* ColorPicker.framework */; };
 		6B2DC1AC21361C4700679668 /* ColorPicker.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6B2DC1A921361C4700679668 /* ColorPicker.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		6B2DC1AD21361C4700679668 /* Colors.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B2DC1AA21361C4700679668 /* Colors.framework */; };
@@ -422,6 +423,7 @@
 		6B1086F6217955120024AE56 /* SVG.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SVG.swift; sourceTree = "<group>"; };
 		6B1086FA217A34340024AE56 /* Data+String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+String.swift"; sourceTree = "<group>"; };
 		6B1086FC217A38110024AE56 /* LRUCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LRUCache.swift; sourceTree = "<group>"; };
+		6B291338219CAC9600A1DDB4 /* CSRendering.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CSRendering.swift; sourceTree = "<group>"; };
 		6B2DC1A921361C4700679668 /* ColorPicker.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ColorPicker.framework; path = Carthage/Build/Mac/ColorPicker.framework; sourceTree = "<group>"; };
 		6B2DC1AA21361C4700679668 /* Colors.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Colors.framework; path = Carthage/Build/Mac/Colors.framework; sourceTree = "<group>"; };
 		6B2DC1B121362E8400679668 /* CoreColorPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreColorPicker.swift; sourceTree = "<group>"; };
@@ -624,6 +626,7 @@
 			children = (
 				30902A271F7B208A00B938BE /* CanvasCollectionView.swift */,
 				301493A61EC0F415005BC573 /* CanvasView.swift */,
+				6B291338219CAC9600A1DDB4 /* CSRendering.swift */,
 				306DA4F01F33EA74002772DC /* CSTextView.swift */,
 				306DA4EE1F33E1CD002772DC /* CSView.swift */,
 				305589421EC4E4D600420BBD /* RenderSurface.swift */,
@@ -1345,6 +1348,7 @@
 				30B5B1A31EC3AE44002068CE /* ColorPickerView.swift in Sources */,
 				30C8BC361EDB7AC400B99F1B /* ParameterListEditorView.swift in Sources */,
 				306DA4EF1F33E1CD002772DC /* CSView.swift in Sources */,
+				6B291339219CAC9600A1DDB4 /* CSRendering.swift in Sources */,
 				3069E09E1F3254D30005E9A8 /* CSColors.swift in Sources */,
 				3003027E1EDCE3790085E140 /* ComponentConfiguration.swift in Sources */,
 				30EFC95A1EF43C900087711D /* CheckboxField.swift in Sources */,

--- a/studio/LonaStudio/Canvas/CSRendering.swift
+++ b/studio/LonaStudio/Canvas/CSRendering.swift
@@ -1,0 +1,37 @@
+//
+//  CSRendering.swift
+//  LonaStudio
+//
+//  Created by Devin Abbott on 11/14/18.
+//  Copyright © 2018 Devin Abbott. All rights reserved.
+//
+
+import AppKit
+
+protocol CSRendering where Self: NSView {
+    var csViewAncestors: [CSView] { get }
+    var multipliedAlpha: CGFloat { get }
+}
+
+extension CSRendering {
+    var csViewAncestors: [CSView] {
+        var views: [CSView] = []
+        var currentView: NSView? = self
+
+        while currentView != nil {
+            if let currentView = currentView as? CSView {
+                views.append(currentView)
+            }
+
+            currentView = currentView?.superview
+        }
+
+        return views
+    }
+
+    var multipliedAlpha: CGFloat {
+        return csViewAncestors.reduce(1) { acc, view in
+            return acc * view.opacity
+        }
+    }
+}

--- a/studio/LonaStudio/Canvas/CSTextView.swift
+++ b/studio/LonaStudio/Canvas/CSTextView.swift
@@ -9,8 +9,15 @@
 import Foundation
 import AppKit
 
-class CSTextView: NSTextView {
+class CSTextView: NSTextView, CSRendering {
     override func hitTest(_ point: NSPoint) -> NSView? {
         return nil
+    }
+
+    override var alphaValue: CGFloat {
+        get {
+            return multipliedAlpha
+        }
+        set {}
     }
 }

--- a/studio/LonaStudio/Canvas/CanvasView.swift
+++ b/studio/LonaStudio/Canvas/CanvasView.swift
@@ -179,8 +179,11 @@ func renderBox(configuredLayer: ConfiguredLayer, node: YGNodeRef, options: Rende
     box.onClick = handleClick
 
     if layer.text == nil, let color = config.get(attribute: "backgroundColor", for: layer.name).string ?? layer.backgroundColor {
-        box.fillColor = CSColors.parse(css: color, withDefault: NSColor.clear).color
+        box.multipliedFillColor = CSColors.parse(css: color, withDefault: NSColor.clear).color
     }
+
+    let opacity = config.get(attribute: "opacity", for: layer.name).number ?? layer.opacity ?? 1
+    box.opacity = CGFloat(opacity)
 
 //    if let id = layer.backgroundGradient, let gradient = CSGradients.gradient(withId: id) {
 //        box.layer = gradient.caGradientLayer
@@ -201,7 +204,7 @@ func renderBox(configuredLayer: ConfiguredLayer, node: YGNodeRef, options: Rende
     }
 
     if let borderColor = borderColor {
-        box.borderColor = borderColor
+        box.multipliedBorderColor = borderColor
     }
 
     box.shadow = configuredLayer.shadow()?.nsShadow

--- a/studio/LonaStudio/Models/CSLayer.swift
+++ b/studio/LonaStudio/Models/CSLayer.swift
@@ -379,6 +379,10 @@ class CSLayer: CSDataDeserializable, CSDataSerializable, DataNode, NSCopying {
         get { return parameters["aspectRatio"]?.number }
         set { parameters["aspectRatio"] = newValue?.toData() }
     }
+    var opacity: Double? {
+        get { return parameters["opacity"]?.number }
+        set { parameters["opacity"] = newValue?.toData() }
+    }
 
     // Border
     var borderRadius: Double? {
@@ -556,6 +560,7 @@ class CSLayer: CSDataDeserializable, CSDataSerializable, DataNode, NSCopying {
         "marginRight": CSData.Number(0),
         "marginBottom": CSData.Number(0),
         "marginLeft": CSData.Number(0),
+        "opacity": CSData.Number(1),
         "paddingTop": CSData.Number(0),
         "paddingRight": CSData.Number(0),
         "paddingBottom": CSData.Number(0),
@@ -676,7 +681,8 @@ class CSLayer: CSDataDeserializable, CSDataSerializable, DataNode, NSCopying {
             "paddingBottom": CSData.Number(paddingBottom ?? 0),
             "paddingLeft": CSData.Number(paddingLeft ?? 0),
 
-            // Color
+            // Content
+            "opacity": CSData.Number(opacity ?? 1),
             "backgroundColor": CSData.String(backgroundColor ?? "transparent"),
 
             // Border

--- a/studio/LonaStudio/Models/CSType.swift
+++ b/studio/LonaStudio/Models/CSType.swift
@@ -486,7 +486,8 @@ let CSLayerType = CSType.dictionary([
     "borderColor": (type: CSColorType, access: .write),
     "borderRadius": (type: .number, access: .write),
 
-    // Color
+    // Content
+    "opacity": (type: .number, access: .write),
     "backgroundColor": (type: CSColorType, access: .write),
 
     // Shadow

--- a/studio/LonaStudio/Workspace/Inspector View/CoreComponentInspectorView.swift
+++ b/studio/LonaStudio/Workspace/Inspector View/CoreComponentInspectorView.swift
@@ -72,7 +72,8 @@ class CoreComponentInspectorView: NSStackView {
         case borderColorEnabled
         case borderWidth
 
-        // Color
+        // Contents
+        case opacity
         case backgroundColor
         case backgroundColorEnabled
         case backgroundGradient
@@ -164,6 +165,7 @@ class CoreComponentInspectorView: NSStackView {
     var bottomView = NumberField(frame: NSRect.zero)
     var leftView = NumberField(frame: NSRect.zero)
 
+    var opacityView = NumberField(frame: NSRect.zero)
     var backgroundColorButton = ColorPickerButton(frame: NSRect.zero)
     var backgroundColorEnabledView = CheckboxField(frame: NSRect.zero)
     var borderColorButton = ColorPickerButton(frame: NSRect.zero)
@@ -547,10 +549,18 @@ class CoreComponentInspectorView: NSStackView {
             stretched: true
         )
 
-        let backgroundSection = renderSection(title: "Background", views: [
+        let backgroundSection = renderSection(title: "Opacity & Background", views: [
+            NSTextField(labelWithStringCompat: "Opacity"),
+            opacityView,
+            NSTextField(labelWithStringCompat: "Background Color"),
             backgroundColorContainer,
+            NSTextField(labelWithStringCompat: "Gradient"),
             backgroundGradientView
         ])
+
+        [opacityView, backgroundColorContainer, backgroundGradientView].forEach {
+            backgroundSection.addContentSpacing(of: 14, after: $0)
+        }
 
         return backgroundSection
     }
@@ -824,7 +834,8 @@ class CoreComponentInspectorView: NSStackView {
             (borderColorEnabledView, .borderColorEnabled),
             (borderWidthView, .borderWidth),
 
-            // Color
+            // Contents
+            (opacityView, .opacity),
             (backgroundColorButton, .backgroundColor),
             (backgroundColorEnabledView, .backgroundColorEnabled),
             (backgroundGradientView, .backgroundGradient),

--- a/studio/LonaStudio/Workspace/Inspector View/LayerInspectorView.swift
+++ b/studio/LonaStudio/Workspace/Inspector View/LayerInspectorView.swift
@@ -53,7 +53,8 @@ class LayerInspectorView: CoreComponentInspectorView {
             CoreComponentInspectorView.Property.borderColorEnabled: CSData.Bool(layer.borderColor != nil),
             CoreComponentInspectorView.Property.borderWidth: CSData.Number(layer.borderWidth ?? 0),
 
-            // Color
+            // Contents
+            CoreComponentInspectorView.Property.opacity: CSData.Number(100 * (layer.opacity ?? 1)),
             CoreComponentInspectorView.Property.backgroundColor: CSData.String(layer.backgroundColor ?? "transparent"),
             CoreComponentInspectorView.Property.backgroundColorEnabled: CSData.Bool(layer.backgroundColor != nil),
             CoreComponentInspectorView.Property.backgroundGradient: CSData.String(layer.backgroundGradient ?? ""),
@@ -130,7 +131,8 @@ class LayerInspectorView: CoreComponentInspectorView {
             case .borderColorEnabled: layer.borderColor = value.boolValue ? "transparent" : nil
             case .borderWidth: layer.borderWidth = value.numberValue
 
-            // Color
+            // Content
+            case .opacity: layer.opacity = max(min(value.numberValue / 100, 1), 0)
             case .backgroundColor: layer.backgroundColor = value.stringValue
             case .backgroundColorEnabled: layer.backgroundColor = value.boolValue ? "transparent" : nil
             case .backgroundGradient: layer.backgroundGradient = value.string

--- a/studio/LonaStudio/Workspace/Inspector View/LayerInspectorView.swift
+++ b/studio/LonaStudio/Workspace/Inspector View/LayerInspectorView.swift
@@ -54,7 +54,7 @@ class LayerInspectorView: CoreComponentInspectorView {
             CoreComponentInspectorView.Property.borderWidth: CSData.Number(layer.borderWidth ?? 0),
 
             // Contents
-            CoreComponentInspectorView.Property.opacity: CSData.Number(100 * (layer.opacity ?? 1)),
+            CoreComponentInspectorView.Property.opacity: CSData.Number(layer.opacity ?? 1),
             CoreComponentInspectorView.Property.backgroundColor: CSData.String(layer.backgroundColor ?? "transparent"),
             CoreComponentInspectorView.Property.backgroundColorEnabled: CSData.Bool(layer.backgroundColor != nil),
             CoreComponentInspectorView.Property.backgroundGradient: CSData.String(layer.backgroundGradient ?? ""),
@@ -132,7 +132,7 @@ class LayerInspectorView: CoreComponentInspectorView {
             case .borderWidth: layer.borderWidth = value.numberValue
 
             // Content
-            case .opacity: layer.opacity = max(min(value.numberValue / 100, 1), 0)
+            case .opacity: layer.opacity = max(min(value.numberValue, 1), 0)
             case .backgroundColor: layer.backgroundColor = value.stringValue
             case .backgroundColorEnabled: layer.backgroundColor = value.boolValue ? "transparent" : nil
             case .backgroundGradient: layer.backgroundGradient = value.string


### PR DESCRIPTION
## What

Support generating components with opacity.

A few quirks/limitations:
- Opacity should be between 0 and 1. However, the LS number picker doesn't work very well with decimals at the moment. First type the number, e.g. "3", then type the "." in front of it
- NSBox doesn't support rendering with `alphaValue` on macOS, and alphaValue doesn't affect subviews. We can work around this but it'll be more effort. Consider `MultipliedAlphaProviding` and `MultipliedAlphaConsuming` protocols.

## Testing Plan

- [X] Tested this change locally
- [X] Checked that existing features work
