### PR TITLE
Defining enums/variants in component params

### DIFF
--- a/compiler/core/package.json
+++ b/compiler/core/package.json
@@ -4,7 +4,11 @@
   "description": "Lona cross-platform code compiler",
   "main": "build/index.js",
   "bin": "./build/index.js",
-  "files": ["build/index.js", "static", "README.md"],
+  "files": [
+    "build/index.js",
+    "static",
+    "README.md"
+  ],
   "scripts": {
     "build": "bsb -make-world",
     "start": "bsb -make-world -w",
@@ -12,26 +16,24 @@
     "bundle": "npm run clean && npm run build && webpack",
     "format": "bsrefmt --parse=re --print=re --in-place src/**/*.re",
     "prepublishOnly": "yarn clean && yarn build && yarn bundle",
-    "snapshotJsDom":
-      "node src/main.bs.js workspace js ../../examples/test ../../examples/generated/test/react-dom --framework=reactdom --styleFramework=styledcomponents",
+    "snapshotJsDom": "node src/main.bs.js workspace js ../../examples/test ../../examples/generated/test/react-dom --framework=reactdom --styleFramework=styledcomponents",
     "snapshotJsDom:watch": "nodemon --exec \"yarn snapshotJsDom\"",
-    "snapshotJsNative":
-      "node src/main.bs.js workspace js ../../examples/test ../../examples/generated/test/react-native --framework=reactnative",
+    "snapshotJsNative": "node src/main.bs.js workspace js ../../examples/test ../../examples/generated/test/react-native --framework=reactnative",
     "snapshotJsNative:watch": "nodemon --exec \"yarn snapshotJsNative\"",
-    "snapshotSketch":
-      "node src/main.bs.js workspace js ../../examples/test ../../examples/generated/test/sketchJs --framework=reactsketchapp",
+    "snapshotSketch": "node src/main.bs.js workspace js ../../examples/test ../../examples/generated/test/sketchJs --framework=reactsketchapp",
     "snapshotSketch:watch": "nodemon --exec \"yarn snapshotSketch\"",
-    "snapshotSwift":
-      "node src/main.bs.js workspace swift ../../examples/test ../../examples/generated/test/swift --generateCollectionView=1",
+    "snapshotSwift": "node src/main.bs.js workspace swift ../../examples/test ../../examples/generated/test/swift --generateCollectionView=1",
     "snapshotSwift:watch": "nodemon --exec \"yarn snapshotSwift\"",
-    "snapshotAppkit":
-      "node src/main.bs.js workspace swift ../../examples/test ../../examples/generated/test/appkit --framework=appkit",
+    "snapshotAppkit": "node src/main.bs.js workspace swift ../../examples/test ../../examples/generated/test/appkit --framework=appkit",
     "snapshotAppkit:watch": "nodemon --exec \"yarn snapshotAppkit\"",
-    "snapshot":
-      "yarn snapshotSwift && yarn snapshotAppkit && yarn snapshotJsDom && yarn snapshotJsNative && yarn snapshotSketch",
+    "snapshot": "yarn snapshotSwift && yarn snapshotAppkit && yarn snapshotJsDom && yarn snapshotJsNative && yarn snapshotSketch",
     "snapshot:watch": "nodemon --exec \"yarn snapshot\""
   },
-  "keywords": ["lona", "compiler", "react"],
+  "keywords": [
+    "lona",
+    "compiler",
+    "react"
+  ],
   "author": "Devin Abbott <devinabbott@gmail.com>",
   "license": "MIT",
   "repository": {
@@ -46,7 +48,7 @@
     "@glennsl/bs-json": "*",
     "bs-glob": "reasonml-community/bs-glob",
     "bs-node": "github:buckletypes/bs-node",
-    "bs-platform": "^4.0.5",
+    "bs-platform": "^4.0.7",
     "copy-webpack-plugin": "^4.5.1",
     "csscolorparser": "^1.0.3",
     "fs-extra": "^5.0.0",
@@ -58,6 +60,7 @@
     "webpack": "^3.10.0"
   },
   "dependencies": {
+    "lodash.snakecase": "^4.1.1",
     "memfs": "^2.8.0",
     "svg-transform-parser": "^0.0.1",
     "svgpath": "^2.2.1",

--- a/compiler/core/src/core/userTypes.re
+++ b/compiler/core/src/core/userTypes.re
@@ -58,6 +58,7 @@ module Decode = {
       let name = field("name", string, json);
       switch (name) {
       | "Named" => namedType(json)
+      | "Enum"
       | "Variant" => variantType(json)
       | "Function" => functionType(json)
       | "Array" => arrayType(json)

--- a/compiler/core/src/javaScript/javaScriptAst.re
+++ b/compiler/core/src/javaScript/javaScriptAst.re
@@ -95,6 +95,7 @@ and node =
   | ObjectLiteral(list(node))
   | Property(property)
   | ExportDefaultDeclaration(node)
+  | ExportNamedDeclaration(node)
   | Block(list(node))
   | Program(list(node))
   | LineEndComment(lineEndComment)
@@ -186,6 +187,8 @@ let rec map = (f: node => node, node) =>
     f(Property({key: o.key |> map(f), value: o.value |> map(f)}))
   | ExportDefaultDeclaration(value) =>
     f(ExportDefaultDeclaration(value |> map(f)))
+  | ExportNamedDeclaration(value) =>
+    f(ExportNamedDeclaration(value |> map(f)))
   | Block(body) => f(Block(body |> List.map(map(f))))
   | Program(body) => f(Program(body |> List.map(map(f))))
   | LineEndComment(o) =>

--- a/compiler/core/src/javaScript/javaScriptFormat.re
+++ b/compiler/core/src/javaScript/javaScriptFormat.re
@@ -1,6 +1,9 @@
 let styleVariableName = name => Format.camelCase(name);
 let elementName = name => Format.safeVariableName(name);
 
+let enumName = name => name |> Format.snakeCase |> Js.String.toUpperCase;
+let enumCaseName = name => name |> Format.snakeCase |> Js.String.toUpperCase;
+
 let wrapperElementName = (componentName, layerName) =>
   elementName(componentName)
   ++ Format.upperFirst(

--- a/compiler/core/src/javaScript/javaScriptRender.re
+++ b/compiler/core/src/javaScript/javaScriptRender.re
@@ -210,6 +210,8 @@ let rec render = ast: Prettier.Doc.t('a) =>
     }
   | ExportDefaultDeclaration(value) =>
     s("export default ") <+> render(value) <+> s(";")
+  | ExportNamedDeclaration(value) =>
+    s("export ") <+> render(value) <+> s(";")
   | Program(body) => body |> List.map(render) |> join(hardline)
   | Block(body) => body |> List.map(render) |> Render.prefixAll(hardline)
   | LineEndComment(o) =>

--- a/compiler/core/src/swift/swiftDocument.re
+++ b/compiler/core/src/swift/swiftDocument.re
@@ -143,6 +143,8 @@ let rec typeAnnotationDoc =
   | Named("Color", _) => TypeName(colorTypeName(framework))
   | Named(name, _) => TypeName(name)
   | Function(_, _) => TypeName("(() -> Void)?")
+  | Array(_) => TypeName("ARRAY PLACEHOLDER")
+  | Variant(_) => TypeName("VARIANT PLACEHOLDER")
   };
 
 let rec lonaValue =
@@ -192,6 +194,7 @@ let rec lonaValue =
       };
     }
   | Variant(_) => SwiftIdentifier("." ++ (value.data |> Json.Decode.string))
+  | Array(_) => SwiftIdentifier("PLACEHOLDER")
   | Function(_) => SwiftIdentifier("PLACEHOLDER")
   | Named(alias, subtype) =>
     switch (alias) {
@@ -257,7 +260,7 @@ let rec lonaValue =
           SwiftIdentifier(shadows.defaultStyle.id),
         ])
       };
-    | _ => SwiftIdentifier("UnknownNamedTypeAlias" ++ alias)
+    | _ => lonaValue(framework, config, {ltype: subtype, data: value.data})
     }
   };
 
@@ -301,7 +304,7 @@ let rec defaultValueForLonaType =
   | Array(_) => LiteralExpression(Array([]))
   | Variant(cases) => SwiftIdentifier("." ++ List.nth(cases, 0))
   | Function(_) => SwiftIdentifier("PLACEHOLDER")
-  | Named(alias, _) =>
+  | Named(alias, subtype) =>
     switch (alias) {
     | "Color" =>
       MemberExpression([
@@ -318,7 +321,7 @@ let rec defaultValueForLonaType =
         SwiftIdentifier("TextStyles"),
         SwiftIdentifier(config.textStylesFile.contents.defaultStyle.id),
       ])
-    | _ => SwiftIdentifier("TypeUnknown" ++ alias)
+    | _ => defaultValueForLonaType(framework, config, subtype)
     }
   };
 

--- a/compiler/core/src/swift/swiftTypeSystem.re
+++ b/compiler/core/src/swift/swiftTypeSystem.re
@@ -1061,6 +1061,7 @@ module Build = {
                   "modifier": Some(PublicModifier),
                   "body":
                     enumCases
+                    @ [Empty]
                     @ linkedListCodable(
                         swiftOptions,
                         genericType.cases,
@@ -1086,6 +1087,7 @@ module Build = {
                   "modifier": Some(PublicModifier),
                   "body":
                     enumCases
+                    @ [Empty]
                     @ nullaryCodable(
                         swiftOptions,
                         TypeSystem.Access.typeCaseName(constantCase),
@@ -1106,6 +1108,7 @@ module Build = {
                   "modifier": Some(PublicModifier),
                   "body":
                     enumCases
+                    @ [Empty]
                     @ constantCodable(
                         swiftOptions,
                         BooleanEncoding,
@@ -1135,7 +1138,9 @@ module Build = {
                   "inherits": [TypeName("Codable")],
                   "modifier": Some(PublicModifier),
                   "body":
-                    enumCases @ enumCodable(swiftOptions, genericType.cases),
+                    enumCases
+                    @ [Empty]
+                    @ enumCodable(swiftOptions, genericType.cases),
                 }),
             };
           };

--- a/compiler/core/src/utils/format.re
+++ b/compiler/core/src/utils/format.re
@@ -2,6 +2,8 @@
 
 [@bs.module] external upperFirst: string => string = "lodash.upperfirst";
 
+[@bs.module] external snakeCase: string => string = "lodash.snakecase";
+
 let safeVariableName = (name: string): string =>
   name
   |> Js.String.replaceByRe([%re "/ /g"], "")

--- a/compiler/core/yarn.lock
+++ b/compiler/core/yarn.lock
@@ -337,9 +337,9 @@ bs-glob@reasonml-community/bs-glob:
   version "0.0.1"
   resolved "https://codeload.github.com/buckletypes/bs-node/tar.gz/20ef6d2d7c00e923aba33b0629ca5623a4460712"
 
-bs-platform@^4.0.5:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-4.0.6.tgz#e7f156c77ad3efafb0c0291b41dcf1b06f93c192"
+bs-platform@^4.0.7:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-4.0.7.tgz#1a0bbf0fef439fef5f1a88ba60d5ac8a6d73570c"
 
 buffer-from@^1.0.0:
   version "1.1.1"
@@ -1839,6 +1839,10 @@ lodash.isempty@^4.4.0:
 lodash.isplainobject@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+
+lodash.snakecase@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz#39d714a35357147837aefd64b5dcbb16becd8f8d"
 
 lodash.transform@^4.6.0:
   version "4.6.0"

--- a/examples/LonaViewer/LonaViewer.xcodeproj/project.pbxproj
+++ b/examples/LonaViewer/LonaViewer.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 		6BA6940A208441120090CA74 /* NestedButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA69409208441120090CA74 /* NestedButtons.swift */; };
 		6BD581DB2082521A0068FBC3 /* TextAlignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BD581DA2082521A0068FBC3 /* TextAlignment.swift */; };
 		6BD581DD208252260068FBC3 /* TextAlignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BD581DC208252250068FBC3 /* TextAlignment.swift */; };
+		6BE89BBA21B6114600F35AC3 /* InlineVariantTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE89BB921B6114600F35AC3 /* InlineVariantTest.swift */; };
 		6BFE720B21821A7300F8BEA0 /* RepeatedVector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFE720A21821A7300F8BEA0 /* RepeatedVector.swift */; };
 		6BFE720D21821CF100F8BEA0 /* VectorLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFE720C21821CF100F8BEA0 /* VectorLogic.swift */; };
 		6BFE720F21821CFF00F8BEA0 /* RepeatedVector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFE720E21821CFE00F8BEA0 /* RepeatedVector.swift */; };
@@ -198,6 +199,7 @@
 		6BA69409208441120090CA74 /* NestedButtons.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NestedButtons.swift; sourceTree = "<group>"; };
 		6BD581DA2082521A0068FBC3 /* TextAlignment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextAlignment.swift; sourceTree = "<group>"; };
 		6BD581DC208252250068FBC3 /* TextAlignment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextAlignment.swift; sourceTree = "<group>"; };
+		6BE89BB921B6114600F35AC3 /* InlineVariantTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InlineVariantTest.swift; sourceTree = "<group>"; };
 		6BFE720A21821A7300F8BEA0 /* RepeatedVector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RepeatedVector.swift; sourceTree = "<group>"; };
 		6BFE720C21821CF100F8BEA0 /* VectorLogic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VectorLogic.swift; sourceTree = "<group>"; };
 		6BFE720E21821CFE00F8BEA0 /* RepeatedVector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RepeatedVector.swift; sourceTree = "<group>"; };
@@ -415,6 +417,7 @@
 			children = (
 				12BBFDF4206B02AC0041620C /* BorderWidthColor.swift */,
 				6B3916FC21601C5900B20F9E /* BoxModelConditional.swift */,
+				6BE89BB921B6114600F35AC3 /* InlineVariantTest.swift */,
 				6BD581DA2082521A0068FBC3 /* TextAlignment.swift */,
 				12BBFDF5206B02AC0041620C /* TextStylesTest.swift */,
 				12BBFDF6206B02AC0041620C /* TextStyleConditional.swift */,
@@ -605,6 +608,7 @@
 				6B6D44372190B76B0016262C /* PrimaryAxisFillSiblings.swift in Sources */,
 				6BA69406208439DB0090CA74 /* NestedComponent.swift in Sources */,
 				12BBFE0E206B02AC0041620C /* SecondaryAxis.swift in Sources */,
+				6BE89BBA21B6114600F35AC3 /* InlineVariantTest.swift in Sources */,
 				6BA5BBD5217021A000F086A7 /* Optionals.swift in Sources */,
 				6B29133B219CB84200A1DDB4 /* OpacityTest.swift in Sources */,
 				6B29134D219E504E00A1DDB4 /* LonaViewModel.swift in Sources */,

--- a/examples/LonaViewer/iOS/Generated.swift
+++ b/examples/LonaViewer/iOS/Generated.swift
@@ -41,6 +41,7 @@ enum Generated: String {
     case opacityTest = "Opacity Test"
     case visibilityTest = "Visibility Test"
     case optionals = "Optionals"
+    case inlineVariantTest = "Inline Variant Test"
 
     static func allValues() -> [Generated] {
         return [
@@ -75,7 +76,8 @@ enum Generated: String {
             shadowsTest,
             opacityTest,
             optionals,
-            visibilityTest
+            visibilityTest,
+            inlineVariantTest
         ]
     }
     
@@ -177,6 +179,8 @@ enum Generated: String {
             return PrimaryAxisFillSiblings()
         case .primaryAxisFillNestedSiblings:
             return PrimaryAxisFillNestedSiblings()
+        case .inlineVariantTest:
+            return InlineVariantTest(type: .error)
         }
     }
 
@@ -211,7 +215,8 @@ enum Generated: String {
              .vectorLogicInactive,
              .repeatedVector,
              .textStylesTest,
-             .imageCropping:
+             .imageCropping,
+             .inlineVariantTest:
             return [
                 equal(\.topAnchor, \.safeAreaLayoutGuide.topAnchor),
                 equal(\.leftAnchor),

--- a/examples/generated/test/appkit/style/InlineVariantTest.swift
+++ b/examples/generated/test/appkit/style/InlineVariantTest.swift
@@ -1,0 +1,182 @@
+import AppKit
+import Foundation
+
+// MARK: - InlineVariantTest
+
+public class InlineVariantTest: NSBox {
+
+  // MARK: Lifecycle
+
+  public init(_ parameters: Parameters) {
+    self.parameters = parameters
+
+    super.init(frame: .zero)
+
+    setUpViews()
+    setUpConstraints()
+
+    update()
+  }
+
+  public convenience init(type: ItemType) {
+    self.init(Parameters(type: type))
+  }
+
+  public convenience init() {
+    self.init(Parameters())
+  }
+
+  public required init?(coder aDecoder: NSCoder) {
+    self.parameters = Parameters()
+
+    super.init(coder: aDecoder)
+
+    setUpViews()
+    setUpConstraints()
+
+    update()
+  }
+
+  // MARK: Public
+
+  public var type: ItemType {
+    get { return parameters.type }
+    set {
+      if parameters.type != newValue {
+        parameters.type = newValue
+      }
+    }
+  }
+
+  public var parameters: Parameters {
+    didSet {
+      if parameters != oldValue {
+        update()
+      }
+    }
+  }
+
+  // MARK: Private
+
+  private var textView = LNATextField(labelWithString: "")
+
+  private var textViewTextStyle = TextStyles.body1
+
+  private func setUpViews() {
+    boxType = .custom
+    borderType = .noBorder
+    contentViewMargins = .zero
+    textView.lineBreakMode = .byWordWrapping
+
+    addSubview(textView)
+
+    textView.attributedStringValue = textViewTextStyle.apply(to: "Text")
+  }
+
+  private func setUpConstraints() {
+    translatesAutoresizingMaskIntoConstraints = false
+    textView.translatesAutoresizingMaskIntoConstraints = false
+
+    let textViewTopAnchorConstraint = textView.topAnchor.constraint(equalTo: topAnchor, constant: 4)
+    let textViewBottomAnchorConstraint = textView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -4)
+    let textViewLeadingAnchorConstraint = textView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 8)
+    let textViewTrailingAnchorConstraint = textView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8)
+
+    NSLayoutConstraint.activate([
+      textViewTopAnchorConstraint,
+      textViewBottomAnchorConstraint,
+      textViewLeadingAnchorConstraint,
+      textViewTrailingAnchorConstraint
+    ])
+  }
+
+  private func update() {
+    fillColor = Colors.blue100
+    if type == .error {
+      fillColor = Colors.red100
+    }
+  }
+}
+
+// MARK: - Parameters
+
+extension InlineVariantTest {
+  public struct Parameters: Equatable {
+    public var type: ItemType
+
+    public init(type: ItemType) {
+      self.type = type
+    }
+
+    public init() {
+      self.init(type: .standard)
+    }
+
+    public static func ==(lhs: Parameters, rhs: Parameters) -> Bool {
+      return lhs.type == rhs.type
+    }
+  }
+}
+
+// MARK: - Model
+
+extension InlineVariantTest {
+  public struct Model: LonaViewModel, Equatable {
+    public var id: String?
+    public var parameters: Parameters
+    public var type: String {
+      return "InlineVariantTest"
+    }
+
+    public init(id: String? = nil, parameters: Parameters) {
+      self.id = id
+      self.parameters = parameters
+    }
+
+    public init(_ parameters: Parameters) {
+      self.parameters = parameters
+    }
+
+    public init(type: ItemType) {
+      self.init(Parameters(type: type))
+    }
+
+    public init() {
+      self.init(type: .standard)
+    }
+  }
+}
+
+// MARK: - ItemType
+
+extension InlineVariantTest {
+  public enum ItemType: Codable {
+    case standard
+    case error
+
+    // MARK: Codable
+
+    public init(from decoder: Decoder) throws {
+      let container = try decoder.singleValueContainer()
+      let type = try container.decode(Bool.self)
+
+      switch type {
+        case false:
+          self = .standard
+        case true:
+          self = .error
+      }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+      var container = encoder.singleValueContainer()
+
+      switch self {
+        case .standard:
+          try container.encode(false)
+        case .error:
+          try container.encode(true)
+      }
+    }
+  }
+}

--- a/examples/generated/test/react-dom/style/InlineVariantTest.js
+++ b/examples/generated/test/react-dom/style/InlineVariantTest.js
@@ -1,0 +1,51 @@
+import React from "react"
+import styled from "styled-components"
+
+import colors from "../colors"
+import shadows from "../shadows"
+import textStyles from "../textStyles"
+
+export let ITEM_TYPE = { STANDARD: "standard", ERROR: "error" };
+
+export default class InlineVariantTest extends React.Component {
+  render() {
+
+    let View$backgroundColor
+    View$backgroundColor = colors.blue100
+
+    if (this.props.type === "error") {
+      View$backgroundColor = colors.red100
+    }
+    return (
+      <View style={{ backgroundColor: View$backgroundColor }}>
+        <Text>
+          {"Text"}
+        </Text>
+      </View>
+    );
+  }
+};
+
+let View = styled.div({
+  alignItems: "flex-start",
+  backgroundColor: colors.blue100,
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  paddingTop: "4px",
+  paddingRight: "8px",
+  paddingBottom: "4px",
+  paddingLeft: "8px"
+})
+
+let Text = styled.span({
+  textAlign: "left",
+  ...textStyles.body1,
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})

--- a/examples/generated/test/react-native/style/InlineVariantTest.js
+++ b/examples/generated/test/react-native/style/InlineVariantTest.js
@@ -1,0 +1,50 @@
+import React from "react"
+import { Text, View, StyleSheet } from "react-native"
+
+import colors from "../colors"
+import shadows from "../shadows"
+import textStyles from "../textStyles"
+
+export let ITEM_TYPE = { STANDARD: "standard", ERROR: "error" };
+
+export default class InlineVariantTest extends React.Component {
+  render() {
+
+    let View$backgroundColor
+    View$backgroundColor = colors.blue100
+
+    if (this.props.type === "error") {
+      View$backgroundColor = colors.red100
+    }
+    return (
+      <View style={[ styles.view, { backgroundColor: View$backgroundColor } ]}>
+        <Text style={styles.text}>
+          {"Text"}
+        </Text>
+      </View>
+    );
+  }
+};
+
+let styles = StyleSheet.create({
+  view: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    backgroundColor: colors.blue100,
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    paddingTop: 4,
+    paddingRight: 8,
+    paddingBottom: 4,
+    paddingLeft: 8
+  },
+  text: {
+    ...textStyles.body1,
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  }
+})

--- a/examples/generated/test/sketchJs/style/InlineVariantTest.js
+++ b/examples/generated/test/sketchJs/style/InlineVariantTest.js
@@ -1,0 +1,51 @@
+import React from "react"
+import { Text, View, StyleSheet, TextStyles } from
+  "@mathieudutour/react-sketchapp"
+
+import colors from "../colors"
+import shadows from "../shadows"
+import textStyles from "../textStyles"
+
+export let ITEM_TYPE = { STANDARD: "standard", ERROR: "error" };
+
+export default class InlineVariantTest extends React.Component {
+  render() {
+
+    let View$backgroundColor
+    View$backgroundColor = colors.blue100
+
+    if (this.props.type === "error") {
+      View$backgroundColor = colors.red100
+    }
+    return (
+      <View style={[ styles.view, { backgroundColor: View$backgroundColor } ]}>
+        <Text style={styles.text}>
+          {"Text"}
+        </Text>
+      </View>
+    );
+  }
+};
+
+let styles = StyleSheet.create({
+  view: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    backgroundColor: colors.blue100,
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    paddingTop: 4,
+    paddingRight: 8,
+    paddingBottom: 4,
+    paddingLeft: 8
+  },
+  text: {
+    ...TextStyles.get("body1"),
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  }
+})

--- a/examples/generated/test/swift/LonaCollectionView.swift
+++ b/examples/generated/test/swift/LonaCollectionView.swift
@@ -178,6 +178,7 @@ public class LonaCollectionView: UICollectionView,
     register(VectorLogicCell.self, forCellWithReuseIdentifier: VectorLogicCell.identifier)
     register(BorderWidthColorCell.self, forCellWithReuseIdentifier: BorderWidthColorCell.identifier)
     register(BoxModelConditionalCell.self, forCellWithReuseIdentifier: BoxModelConditionalCell.identifier)
+    register(InlineVariantTestCell.self, forCellWithReuseIdentifier: InlineVariantTestCell.identifier)
     register(OpacityTestCell.self, forCellWithReuseIdentifier: OpacityTestCell.identifier)
     register(ShadowsTestCell.self, forCellWithReuseIdentifier: ShadowsTestCell.identifier)
     register(TextAlignmentCell.self, forCellWithReuseIdentifier: TextAlignmentCell.identifier)
@@ -385,6 +386,11 @@ public class LonaCollectionView: UICollectionView,
       }
     case BoxModelConditionalCell.identifier:
       if let cell = cell as? BoxModelConditionalCell, let item = item as? BoxModelConditional.Model {
+        cell.parameters = item.parameters
+        cell.scrollDirection = scrollDirection
+      }
+    case InlineVariantTestCell.identifier:
+      if let cell = cell as? InlineVariantTestCell, let item = item as? InlineVariantTest.Model {
         cell.parameters = item.parameters
         cell.scrollDirection = scrollDirection
       }
@@ -867,6 +873,16 @@ public class BoxModelConditionalCell: LonaCollectionViewCell<BoxModelConditional
   }
   public static var identifier: String {
     return "BoxModelConditional"
+  }
+}
+
+public class InlineVariantTestCell: LonaCollectionViewCell<InlineVariantTest> {
+  public var parameters: InlineVariantTest.Parameters {
+    get { return view.parameters }
+    set { view.parameters = newValue }
+  }
+  public static var identifier: String {
+    return "InlineVariantTest"
   }
 }
 

--- a/examples/generated/test/swift/style/InlineVariantTest.swift
+++ b/examples/generated/test/swift/style/InlineVariantTest.swift
@@ -1,0 +1,180 @@
+import UIKit
+import Foundation
+
+// MARK: - InlineVariantTest
+
+public class InlineVariantTest: UIView {
+
+  // MARK: Lifecycle
+
+  public init(_ parameters: Parameters) {
+    self.parameters = parameters
+
+    super.init(frame: .zero)
+
+    setUpViews()
+    setUpConstraints()
+
+    update()
+  }
+
+  public convenience init(type: ItemType) {
+    self.init(Parameters(type: type))
+  }
+
+  public convenience init() {
+    self.init(Parameters())
+  }
+
+  public required init?(coder aDecoder: NSCoder) {
+    self.parameters = Parameters()
+
+    super.init(coder: aDecoder)
+
+    setUpViews()
+    setUpConstraints()
+
+    update()
+  }
+
+  // MARK: Public
+
+  public var type: ItemType {
+    get { return parameters.type }
+    set {
+      if parameters.type != newValue {
+        parameters.type = newValue
+      }
+    }
+  }
+
+  public var parameters: Parameters {
+    didSet {
+      if parameters != oldValue {
+        update()
+      }
+    }
+  }
+
+  // MARK: Private
+
+  private var textView = UILabel()
+
+  private var textViewTextStyle = TextStyles.body1
+
+  private func setUpViews() {
+    textView.isUserInteractionEnabled = false
+    textView.numberOfLines = 0
+
+    addSubview(textView)
+
+    textView.attributedText = textViewTextStyle.apply(to: "Text")
+  }
+
+  private func setUpConstraints() {
+    translatesAutoresizingMaskIntoConstraints = false
+    textView.translatesAutoresizingMaskIntoConstraints = false
+
+    let textViewTopAnchorConstraint = textView.topAnchor.constraint(equalTo: topAnchor, constant: 4)
+    let textViewBottomAnchorConstraint = textView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -4)
+    let textViewLeadingAnchorConstraint = textView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 8)
+    let textViewTrailingAnchorConstraint = textView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8)
+
+    NSLayoutConstraint.activate([
+      textViewTopAnchorConstraint,
+      textViewBottomAnchorConstraint,
+      textViewLeadingAnchorConstraint,
+      textViewTrailingAnchorConstraint
+    ])
+  }
+
+  private func update() {
+    backgroundColor = Colors.blue100
+    if type == .error {
+      backgroundColor = Colors.red100
+    }
+  }
+}
+
+// MARK: - Parameters
+
+extension InlineVariantTest {
+  public struct Parameters: Equatable {
+    public var type: ItemType
+
+    public init(type: ItemType) {
+      self.type = type
+    }
+
+    public init() {
+      self.init(type: .standard)
+    }
+
+    public static func ==(lhs: Parameters, rhs: Parameters) -> Bool {
+      return lhs.type == rhs.type
+    }
+  }
+}
+
+// MARK: - Model
+
+extension InlineVariantTest {
+  public struct Model: LonaViewModel, Equatable {
+    public var id: String?
+    public var parameters: Parameters
+    public var type: String {
+      return "InlineVariantTest"
+    }
+
+    public init(id: String? = nil, parameters: Parameters) {
+      self.id = id
+      self.parameters = parameters
+    }
+
+    public init(_ parameters: Parameters) {
+      self.parameters = parameters
+    }
+
+    public init(type: ItemType) {
+      self.init(Parameters(type: type))
+    }
+
+    public init() {
+      self.init(type: .standard)
+    }
+  }
+}
+
+// MARK: - ItemType
+
+extension InlineVariantTest {
+  public enum ItemType: Codable {
+    case standard
+    case error
+
+    // MARK: Codable
+
+    public init(from decoder: Decoder) throws {
+      let container = try decoder.singleValueContainer()
+      let type = try container.decode(Bool.self)
+
+      switch type {
+        case false:
+          self = .standard
+        case true:
+          self = .error
+      }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+      var container = encoder.singleValueContainer()
+
+      switch self {
+        case .standard:
+          try container.encode(false)
+        case .error:
+          try container.encode(true)
+      }
+    }
+  }
+}

--- a/examples/test/style/InlineVariantTest.component
+++ b/examples/test/style/InlineVariantTest.component
@@ -1,0 +1,111 @@
+{
+  "devices" : [
+    {
+      "height" : 0,
+      "heightMode" : "At Least",
+      "name" : "iPhone SE",
+      "width" : 320
+    }
+  ],
+  "examples" : [
+    {
+      "id" : "standard",
+      "name" : "standard",
+      "params" : {
+        "type" : null
+      }
+    },
+    {
+      "id" : "error",
+      "name" : "error",
+      "params" : {
+        "type" : "error"
+      }
+    }
+  ],
+  "logic" : [
+    {
+      "body" : [
+        {
+          "assignee" : [
+            "layers",
+            "View",
+            "backgroundColor"
+          ],
+          "content" : {
+            "type" : "LitExpr",
+            "value" : {
+              "data" : "red100",
+              "type" : "Color"
+            }
+          },
+          "type" : "AssignExpr"
+        }
+      ],
+      "condition" : {
+        "left" : [
+          "parameters",
+          "type"
+        ],
+        "op" : "==",
+        "right" : {
+          "type" : "LitExpr",
+          "value" : {
+            "data" : "error",
+            "type" : {
+              "alias" : "ItemType",
+              "name" : "Named",
+              "of" : {
+                "cases" : [
+                  "standard",
+                  "error"
+                ],
+                "name" : "Enum"
+              }
+            }
+          }
+        },
+        "type" : "BinExpr"
+      },
+      "type" : "IfExpr"
+    }
+  ],
+  "params" : [
+    {
+      "name" : "type",
+      "type" : {
+        "alias" : "ItemType",
+        "name" : "Named",
+        "of" : {
+          "cases" : [
+            "standard",
+            "error"
+          ],
+          "name" : "Enum"
+        }
+      }
+    }
+  ],
+  "root" : {
+    "children" : [
+      {
+        "id" : "Text",
+        "params" : {
+          "alignSelf" : "stretch",
+          "text" : "Text"
+        },
+        "type" : "Lona:Text"
+      }
+    ],
+    "id" : "View",
+    "params" : {
+      "alignSelf" : "stretch",
+      "backgroundColor" : "blue100",
+      "paddingBottom" : 4,
+      "paddingLeft" : 8,
+      "paddingRight" : 8,
+      "paddingTop" : 4
+    },
+    "type" : "Lona:View"
+  }
+}


### PR DESCRIPTION
## What

It's now possible to define enum/variant types directly in component params. This will generate a scoped type definition or named export in the same file as the component.

Note: there are still some limitations for now. These variant types can't contain data, so the `type` must be set to `Unit` when defining the type in Lona Studio. Also, the type can't currently be used in logic outside of the component (it can be set in the inspector when used in other components though).

## Testing Plan

- [X] Tested this change locally
- [X] Checked that existing features work

cc @outdooricon @ryngonzalez 