### PR TITLE
Improve compiler.js

### DIFF
--- a/compiler/core/src/core/config.re
+++ b/compiler/core/src/core/config.re
@@ -137,7 +137,9 @@ let load = (options: Options.options, path): Js.Promise.t(t) =>
   switch (Workspace.find(path)) {
   | None =>
     exit(
-      "Couldn't find workspace directory. A workspace must contain a `lona.json` file.",
+      "Couldn't find workspace directory starting from '"
+      ++ path
+      ++ "'. A workspace must contain a `lona.json` file.",
     )
   | Some(workspacePath) =>
     Js.Promise.(

--- a/compiler/core/src/core/config.re
+++ b/compiler/core/src/core/config.re
@@ -12,6 +12,7 @@ type t = {
   userTypesFile: file(UserTypes.file),
   svgFiles: list(file(Svg.node)),
   workspacePath: string,
+  options: Options.options,
 };
 
 module Compiler = {
@@ -132,7 +133,7 @@ let exit = message => {
   {|process.exit(1)|};
 };
 
-let load = path: Js.Promise.t(t) =>
+let load = (options: Options.options, path): Js.Promise.t(t) =>
   switch (Workspace.find(path)) {
   | None =>
     exit(
@@ -143,6 +144,7 @@ let load = path: Js.Promise.t(t) =>
       Workspace.svgFiles(workspacePath)
       |> then_(svgFiles =>
            resolve({
+             options,
              componentNames: Workspace.componentNames(workspacePath),
              plugins: Workspace.compilerFile(workspacePath),
              colorsFile: Workspace.colorsFile(workspacePath),

--- a/compiler/core/src/core/options.re
+++ b/compiler/core/src/core/options.re
@@ -7,4 +7,6 @@ type preset =
 type options = {
   preset,
   filterComponents: option(string),
+  swift: SwiftOptions.options,
+  javaScript: JavaScriptOptions.options,
 };

--- a/compiler/core/src/main.re
+++ b/compiler/core/src/main.re
@@ -21,15 +21,6 @@ let getArgument = name => {
   };
 };
 
-let options: LonaCompilerCore.Options.options = {
-  preset:
-    switch (getArgument("preset")) {
-    | Some("airbnb") => Airbnb
-    | _ => Standard
-    },
-  filterComponents: getArgument("filterComponents"),
-};
-
 let swiftOptions: Swift.Options.options = {
   framework:
     switch (getArgument("framework")) {
@@ -65,6 +56,17 @@ let javaScriptOptions: JavaScriptOptions.options = {
     | Some("styledcomponents") => JavaScriptOptions.StyledComponents
     | _ => JavaScriptOptions.None
     },
+};
+
+let options: LonaCompilerCore.Options.options = {
+  preset:
+    switch (getArgument("preset")) {
+    | Some("airbnb") => Airbnb
+    | _ => Standard
+    },
+  filterComponents: getArgument("filterComponents"),
+  swift: swiftOptions,
+  javaScript: javaScriptOptions,
 };
 
 let exit = message => {
@@ -317,7 +319,7 @@ let findContentsBelow = contents => {
 };
 
 let convertWorkspace = (workspace, output) =>
-  Config.load(workspace)
+  Config.load(options, workspace)
   |> Js.Promise.then_((config: Config.t) => {
        let colors = config.colorsFile.contents;
        let textStyles = config.textStylesFile.contents;
@@ -501,7 +503,7 @@ switch (command) {
     exit("No filename given");
   };
   let filename = List.nth(positionalArguments, 4);
-  Config.load(filename)
+  Config.load(options, filename)
   |> Js.Promise.then_(config => {
        convertComponent(config, filename) |> Js.log;
        Js.Promise.resolve();

--- a/compiler/core/src/swift/swiftColor.re
+++ b/compiler/core/src/swift/swiftColor.re
@@ -1,7 +1,7 @@
 open SwiftAst;
 
-let render =
-    (options: Options.options, swiftOptions: SwiftOptions.options, colors) => {
+let render = (config: Config.t) => {
+  let colors = config.colorsFile.contents;
   let doc = () => {
     let colorConstantDoc = (color: Color.t) =>
       LineEndComment({
@@ -29,7 +29,7 @@ let render =
       });
     TopLevelDeclaration({
       "statements": [
-        SwiftDocument.importFramework(swiftOptions.framework),
+        SwiftDocument.importFramework(config),
         Empty,
         EnumDeclaration({
           "name": "Colors",
@@ -80,8 +80,7 @@ let render =
             "defaultValue": None,
           }),
           Parameter({
-            "annotation":
-              TypeName(SwiftDocument.colorTypeName(swiftOptions.framework)),
+            "annotation": TypeName(SwiftDocument.colorTypeName(config)),
             "externalName": None,
             "localName": "preview",
             "defaultValue": None,
@@ -91,10 +90,7 @@ let render =
           ReturnStatement(
             Some(
               FunctionCallExpression({
-                "name":
-                  SwiftIdentifier(
-                    SwiftDocument.colorTypeName(swiftOptions.framework),
-                  ),
+                "name": SwiftIdentifier(SwiftDocument.colorTypeName(config)),
                 "arguments": [
                   FunctionCallArgument({
                     "name": Some(SwiftIdentifier("hex")),
@@ -105,15 +101,12 @@ let render =
             ),
           ),
         ],
-        "result":
-          Some(
-            TypeName(SwiftDocument.colorTypeName(swiftOptions.framework)),
-          ),
+        "result": Some(TypeName(SwiftDocument.colorTypeName(config))),
         "throws": false,
       });
     TopLevelDeclaration({
       "statements": [
-        SwiftDocument.importFramework(swiftOptions.framework),
+        SwiftDocument.importFramework(config),
         Empty,
         DocComment("DLS-defined color values"),
         EnumDeclaration({
@@ -131,5 +124,5 @@ let render =
       ],
     });
   };
-  SwiftRender.toString(options.preset == Airbnb ? airbnbDoc() : doc());
+  SwiftRender.toString(config.options.preset == Airbnb ? airbnbDoc() : doc());
 };

--- a/compiler/core/src/swift/swiftComponent.re
+++ b/compiler/core/src/swift/swiftComponent.re
@@ -1337,10 +1337,7 @@ let generate =
         containsImageWithBackgroundColor() ?
           [
             [LineComment("MARK: - " ++ "ImageWithBackgroundColor"), Empty],
-            SwiftHelperClass.generateImageWithBackgroundColor(
-              options,
-              swiftOptions,
-            ),
+            SwiftHelperClass.generateImageWithBackgroundColor(config),
           ]
           |> List.concat :
           []
@@ -1397,7 +1394,7 @@ let generate =
         Empty,
         [
           [
-            SwiftDocument.importFramework(swiftOptions.framework),
+            SwiftDocument.importFramework(config),
             ImportDeclaration("Foundation"),
           ],
           helperClasses,

--- a/compiler/core/src/swift/swiftConstraint.re
+++ b/compiler/core/src/swift/swiftConstraint.re
@@ -227,27 +227,13 @@ let generateConstraintConstant =
     let float = value |> LonaValue.decodeNumber;
     let float = float *. direction;
     float == 0.0 ?
-      None :
-      Some(
-        SwiftDocument.lonaValue(
-          swiftOptions.framework,
-          config,
-          LonaValue.number(float),
-        ),
-      );
+      None : Some(SwiftDocument.lonaValue(config, LonaValue.number(float)));
   | _ =>
     let floats = lonaValues |> List.map(LonaValue.decodeNumber);
     let float = List.fold_left((a, b) => a +. b, 0.0, floats);
     let float = float *. direction;
     float == 0.0 ?
-      None :
-      Some(
-        SwiftDocument.lonaValue(
-          swiftOptions.framework,
-          config,
-          LonaValue.number(float),
-        ),
-      );
+      None : Some(SwiftDocument.lonaValue(config, LonaValue.number(float)));
   };
 };
 

--- a/compiler/core/src/swift/swiftDocument.re
+++ b/compiler/core/src/swift/swiftDocument.re
@@ -24,20 +24,20 @@ let nameWithoutExtension = path => {
 let nameWithoutPixelDensitySuffix = path =>
   Js.String.replaceByRe([%re "/@\\d+x$/g"], "", path);
 
-let importFramework = framework =>
-  switch (framework) {
+let importFramework = (config: Config.t) =>
+  switch (config.options.swift.framework) {
   | SwiftOptions.UIKit => ImportDeclaration("UIKit")
   | SwiftOptions.AppKit => ImportDeclaration("AppKit")
   };
 
-let colorTypeName = framework =>
-  switch (framework) {
+let colorTypeName = (config: Config.t) =>
+  switch (config.options.swift.framework) {
   | SwiftOptions.UIKit => "UIColor"
   | SwiftOptions.AppKit => "NSColor"
   };
 
-let fontTypeName = framework =>
-  switch (framework) {
+let fontTypeName = (config: Config.t) =>
+  switch (config.options.swift.framework) {
   | SwiftOptions.UIKit => "UIFont"
   | SwiftOptions.AppKit => "NSFont"
   };
@@ -51,20 +51,20 @@ let imageTypeName = (config: Config.t) =>
   )
   |> SwiftPlugin.applyTransformType(config, None);
 
-let bezierPathTypeName = framework =>
-  switch (framework) {
+let bezierPathTypeName = (config: Config.t) =>
+  switch (config.options.swift.framework) {
   | SwiftOptions.UIKit => "UIBezierPath"
   | SwiftOptions.AppKit => "NSBezierPath"
   };
 
-let sizeTypeName = framework =>
-  switch (framework) {
+let sizeTypeName = (config: Config.t) =>
+  switch (config.options.swift.framework) {
   | SwiftOptions.UIKit => "CGSize"
   | SwiftOptions.AppKit => "NSSize"
   };
 
-let shadowTypeName = framework =>
-  switch (framework) {
+let shadowTypeName = (config: Config.t) =>
+  switch (config.options.swift.framework) {
   | SwiftOptions.UIKit => "Shadow"
   | SwiftOptions.AppKit => "NSShadow"
   };
@@ -144,7 +144,7 @@ let rec typeAnnotationDoc = (config: Config.t, ltype: Types.lonaType) => {
     | _ => TypeName(typeName)
     }
   | Named("URL", _) => TypeName(imageTypeName(config))
-  | Named("Color", _) => TypeName(colorTypeName(framework))
+  | Named("Color", _) => TypeName(colorTypeName(config))
   | Named(name, _) => TypeName(name)
   | Function(arguments, _) =>
     OptionalType(
@@ -313,7 +313,7 @@ let rec defaultValueForLonaType = (config: Config.t, ltype: Types.lonaType) => {
     switch (alias) {
     | "Color" =>
       MemberExpression([
-        SwiftIdentifier(colorTypeName(framework)),
+        SwiftIdentifier(colorTypeName(config)),
         SwiftIdentifier("clear"),
       ])
     | "URL" =>

--- a/compiler/core/src/swift/swiftHelperClass.re
+++ b/compiler/core/src/swift/swiftHelperClass.re
@@ -7,8 +7,7 @@
          super.draw(dirtyRect)
      }
    } */
-let generateImageWithBackgroundColor =
-    (options: Options.options, swiftOptions: SwiftOptions.options) =>
+let generateImageWithBackgroundColor = (config: Config.t) =>
   SwiftAst.[
     ClassDeclaration({
       "name": "ImageWithBackgroundColor",
@@ -26,9 +25,7 @@ let generateImageWithBackgroundColor =
           "init":
             Some(
               MemberExpression([
-                SwiftIdentifier(
-                  SwiftDocument.colorTypeName(swiftOptions.framework),
-                ),
+                SwiftIdentifier(SwiftDocument.colorTypeName(config)),
                 SwiftIdentifier("clear"),
               ]),
             ),
@@ -380,7 +377,7 @@ let generateVectorGraphic =
                       Empty,
                     ] :
                     [],
-                  SwiftSvg.convertNode(swiftOptions, vectorAssignments, svg),
+                  SwiftSvg.convertNode(config, vectorAssignments, svg),
                 ]
                 |> List.concat,
               "result": None,

--- a/compiler/core/src/swift/swiftLogic.re
+++ b/compiler/core/src/swift/swiftLogic.re
@@ -68,8 +68,7 @@ let toSwiftAST =
     let initialValue =
       switch (x) {
       | Logic.Identifier(_) => identifierName(x)
-      | Literal(value) =>
-        Document.lonaValue(options.framework, config, value)
+      | Literal(value) => Document.lonaValue(config, value)
       };
     /* Here is the only place we should handle Logic -> Swift identifier conversion */
     switch (options.framework, initialValue) {
@@ -497,9 +496,7 @@ let toSwiftAST =
             Ast.IdentifierPattern({
               "identifier": identifier |> logicValueToSwiftAST,
               "annotation":
-                Some(
-                  ltype |> SwiftDocument.typeAnnotationDoc(options.framework),
-                ),
+                Some(ltype |> SwiftDocument.typeAnnotationDoc(config)),
             }),
           "init": (None: option(Ast.node)),
           "block": (None: option(Ast.initializerBlock)),

--- a/compiler/core/src/swift/swiftPlugin.re
+++ b/compiler/core/src/swift/swiftPlugin.re
@@ -1,0 +1,16 @@
+let getContext = (config: Config.t): Plugin.context => {
+  "target": "swift",
+  "framework": SwiftOptions.frameworkToString(config.options.swift.framework),
+};
+
+let applyTransformType =
+    (config: Config.t, componentName: option(string), typeName: string) =>
+  Plugin.applyTransformTypePlugins(
+    config.plugins,
+    getContext(config),
+    switch (componentName) {
+    | Some(value) => value
+    | None => ""
+    },
+    typeName,
+  );

--- a/studio/LonaStudio/Workspace/CodeEditorViewController.swift
+++ b/studio/LonaStudio/Workspace/CodeEditorViewController.swift
@@ -72,6 +72,7 @@ class CodeEditorViewController: NSViewController {
                 LonaNode.run(
                     arguments: [compilerPath, "colors", fileExtension],
                     inputData: data,
+                    currentDirectoryPath: CSUserPreferences.workspaceURL.path,
                     onSuccess: { output in
                         guard let result = output.utf8String() else { return }
                         DispatchQueue.main.async {
@@ -92,6 +93,7 @@ class CodeEditorViewController: NSViewController {
                 LonaNode.run(
                     arguments: [compilerPath, "textStyles", fileExtension],
                     inputData: data,
+                    currentDirectoryPath: CSUserPreferences.workspaceURL.path,
                     onSuccess: { output in
                         guard let result = output.utf8String() else { return }
                         DispatchQueue.main.async {


### PR DESCRIPTION
## What

The compiler.js file can be used to transform more types now. 

This also modifies the behavior of the compiler for non-`workspace` commands to _require_ a workspace to exist, and use the `cwd` if none is given.

## Testing Plan

- [X] Tested this change locally
- [X] Checked that existing features work

cc @outdooricon 