### PR TITLE
Fix meta field name

### DIFF
--- a/docs/file-formats/component.md
+++ b/docs/file-formats/component.md
@@ -27,7 +27,7 @@ Component metadata for documentation, indexing, and other miscellaneous purposes
 |Attribute|Type|Required|Description|
 |---|---|---|---|
 |`tags`|`string[]`|No|An array of tags for categorizing/indexing the component|
-|`name`|`string`|No|A description of the component, for documentation purposes. This field can contain markdown.|
+|`description`|`string`|No|A description of the component, for documentation purposes. This field can contain markdown.|
 
 ### Sample
 


### PR DESCRIPTION
## What

I've fixed the field name (from `name` to `description`).

## Why

It looks like it was wrongly named. Both the example and the description of the field seem to imply it shall be called "description". Plus, here it is used with that name: 
https://github.com/airbnb/Lona/blob/4a763634482b6da692aa188e301a28b6e122ed8a/studio/LonaStudio/Workspace/MetadataEditorView.swift#L37

## Major Changes

* Just updated an `.md` file.

## Requirements for Merging

- [ ] N/A

## Testing Plan

- [ ] N/A

## Feedback

I'm looking for feedback on:

* Whether I'm using the correct process to submit PRs, as I'd like to start contributing (with more relevant fixes/features).

<!-- Tag relevant people for example -->
cc: @dabbott as he is the one who wrote the doc and the usage in swift I mentioned.
