### PR TITLE
Add canvas inspector

### DIFF
--- a/compiler/core/src/core/decode.re
+++ b/compiler/core/src/core/decode.re
@@ -308,6 +308,10 @@ let rec logicNode = json => {
         let content = o##content |> logicValueFromExpr;
         let assignee = o##assignee |> logicValueFromExpr;
         Logic.Assign(content, assignee);
+      | VariableDeclarationExpression(o) =>
+        let id = o##identifier |> identifierFromExpr;
+        let content = o##content |> logicValueFromExpr;
+        Logic.LetEqual(Logic.Identifier(undefinedType, [id]), content);
       | IfExpression(o) =>
         let body = o##body |> List.map(fromExpr);
         switch (o##condition) {

--- a/examples/generated/test/appkit/style/InlineVariantTest.swift
+++ b/examples/generated/test/appkit/style/InlineVariantTest.swift
@@ -150,7 +150,7 @@ extension InlineVariantTest {
 // MARK: - ItemType
 
 extension InlineVariantTest {
-  public enum ItemType: Codable {
+  public enum ItemType: Codable, Equatable {
     case standard
     case error
 

--- a/examples/generated/test/swift/style/InlineVariantTest.swift
+++ b/examples/generated/test/swift/style/InlineVariantTest.swift
@@ -148,7 +148,7 @@ extension InlineVariantTest {
 // MARK: - ItemType
 
 extension InlineVariantTest {
-  public enum ItemType: Codable {
+  public enum ItemType: Codable, Equatable {
     case standard
     case error
 

--- a/examples/material-design/components/Card.component
+++ b/examples/material-design/components/Card.component
@@ -1,22 +1,16 @@
 {
   "devices" : [
     {
-      "height" : 100,
-      "heightMode" : "At Least",
-      "name" : "iPhone SE",
-      "width" : 320
+      "deviceId" : "iPhone SE",
+      "heightMode" : "At Least"
     },
     {
-      "height" : 100,
-      "heightMode" : "At Least",
-      "name" : "iPhone 7",
-      "width" : 375
+      "deviceId" : "iPhone 8",
+      "heightMode" : "At Least"
     },
     {
-      "height" : 100,
-      "heightMode" : "At Least",
-      "name" : "iPhone 7+",
-      "width" : 414
+      "deviceId" : "iPhone XS Max",
+      "heightMode" : "At Least"
     }
   ],
   "examples" : [

--- a/examples/material-design/components/ListItem.component
+++ b/examples/material-design/components/ListItem.component
@@ -1,26 +1,21 @@
 {
   "devices" : [
     {
-      "height" : 0,
-      "heightMode" : "At Least",
-      "name" : "iPhone SE",
-      "width" : 320
+      "deviceId" : "iPhone SE",
+      "heightMode" : "At Least"
     },
     {
-      "height" : 0,
-      "heightMode" : "At Least",
-      "name" : "iPhone 7",
-      "width" : 375
+      "deviceId" : "iPhone 8",
+      "heightMode" : "At Least"
     },
     {
-      "height" : 0,
-      "heightMode" : "At Least",
-      "name" : "iPhone 7+",
-      "width" : 414
+      "deviceId" : "iPhone XS Max",
+      "heightMode" : "At Least"
     }
   ],
   "examples" : [
     {
+      "id" : "Default",
       "name" : "Default",
       "params" : {
 

--- a/examples/material-design/screens/Team.component
+++ b/examples/material-design/screens/Team.component
@@ -1,22 +1,16 @@
 {
   "devices" : [
     {
-      "height" : 100,
-      "heightMode" : "At Least",
-      "name" : "iPhone SE",
-      "width" : 320
+      "deviceId" : "iPhone SE",
+      "heightMode" : "Exactly"
     },
     {
-      "height" : 100,
-      "heightMode" : "At Least",
-      "name" : "iPhone 7",
-      "width" : 375
+      "deviceId" : "iPhone 8",
+      "heightMode" : "Exactly"
     },
     {
-      "height" : 100,
-      "heightMode" : "At Least",
-      "name" : "iPhone 7+",
-      "width" : 414
+      "deviceId" : "iPhone XS Max",
+      "heightMode" : "Exactly"
     }
   ],
   "examples" : [

--- a/studio/LonaStudio.xcodeproj/project.pbxproj
+++ b/studio/LonaStudio.xcodeproj/project.pbxproj
@@ -201,6 +201,7 @@
 		6B6D4427218F55B50016262C /* CGSize+Resizing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6D4426218F55B50016262C /* CGSize+Resizing.swift */; };
 		6B6D4434218F6B070016262C /* NSImage+Resizing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6D4432218F6B070016262C /* NSImage+Resizing.swift */; };
 		6B6D4435218F6B070016262C /* LNAImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6D4433218F6B070016262C /* LNAImageView.swift */; };
+		6B80645A21D8322B006560C7 /* CanvasTableHeaderExtra.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B80645921D8322A006560C7 /* CanvasTableHeaderExtra.swift */; };
 		6B8D7DA021BED32E0087A3F7 /* LayoutInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8D7D9D21BED32E0087A3F7 /* LayoutInspector.swift */; };
 		6B8D7DA321BF04B60087A3F7 /* InspectorSectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8D7DA221BF04B60087A3F7 /* InspectorSectionHeader.swift */; };
 		6BA5BBD72173A7F600F086A7 /* Shadows.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA5BBD62173A7F600F086A7 /* Shadows.swift */; };
@@ -468,6 +469,7 @@
 		6B6D4426218F55B50016262C /* CGSize+Resizing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CGSize+Resizing.swift"; sourceTree = "<group>"; };
 		6B6D4432218F6B070016262C /* NSImage+Resizing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSImage+Resizing.swift"; sourceTree = "<group>"; };
 		6B6D4433218F6B070016262C /* LNAImageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LNAImageView.swift; sourceTree = "<group>"; };
+		6B80645921D8322A006560C7 /* CanvasTableHeaderExtra.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CanvasTableHeaderExtra.swift; sourceTree = "<group>"; };
 		6B8D7D9D21BED32E0087A3F7 /* LayoutInspector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LayoutInspector.swift; sourceTree = "<group>"; };
 		6B8D7DA221BF04B60087A3F7 /* InspectorSectionHeader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InspectorSectionHeader.swift; sourceTree = "<group>"; };
 		6BA5BBD62173A7F600F086A7 /* Shadows.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Shadows.swift; sourceTree = "<group>"; };
@@ -837,6 +839,7 @@
 		30F870C120865858007ADA5B /* components */ = {
 			isa = PBXGroup;
 			children = (
+				6B80645921D8322A006560C7 /* CanvasTableHeaderExtra.swift */,
 				6B4203E421BB117B00D59317 /* CanvasTableHeaderItem.swift */,
 				6B5886892134D9E800CCA69F /* ColorInspector.swift */,
 				6B4DFCEA20A75B900048BB43 /* ColorPreviewCard.swift */,
@@ -1435,6 +1438,7 @@
 				303C3FEE20A396C3008E1541 /* OpenProjectButton.swift in Sources */,
 				30DE880D1FBA22FB00D62A50 /* ComponentEditorButton.swift in Sources */,
 				6BA6E89921307D65009CD33C /* WorkspaceWindowController.swift in Sources */,
+				6B80645A21D8322B006560C7 /* CanvasTableHeaderExtra.swift in Sources */,
 				303C3FE820A375E8008E1541 /* VirtualFileSystem.swift in Sources */,
 				30F4FD531F76ADC70048691C /* AnimationUtils.swift in Sources */,
 				6B0F5B86213862A0007DBBB2 /* ColorEditorViewController.swift in Sources */,

--- a/studio/LonaStudio.xcodeproj/project.pbxproj
+++ b/studio/LonaStudio.xcodeproj/project.pbxproj
@@ -227,6 +227,7 @@
 		6BD96653217FB0DB0012F173 /* default-workspace-thumbnail@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6BD96651217FB0DB0012F173 /* default-workspace-thumbnail@2x.png */; };
 		6BDF4D2E20A67272006E99C4 /* BrowserToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDF4D2D20A67272006E99C4 /* BrowserToolbar.swift */; };
 		6BE89BBC21B7452800F35AC3 /* LonaViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE89BBB21B7452800F35AC3 /* LonaViewModel.swift */; };
+		6BFC4E0621C9C5A10030938B /* CanvasInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFC4E0521C9C5A10030938B /* CanvasInspector.swift */; };
 		76AB58E053220594F098A3C5 /* Pods_LonaStudioTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EDA2F7370DB15639E08B399A /* Pods_LonaStudioTests.framework */; };
 		783A74CD337C61784E60C467 /* Pods_LonaStudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7949560983378CFD6EC6FFD5 /* Pods_LonaStudio.framework */; };
 		BA0D85E41FD5AC2000D817C3 /* NSViewHoverExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA0D85E31FD5AC2000D817C3 /* NSViewHoverExtensions.swift */; };
@@ -491,6 +492,7 @@
 		6BD96651217FB0DB0012F173 /* default-workspace-thumbnail@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "default-workspace-thumbnail@2x.png"; sourceTree = "<group>"; };
 		6BDF4D2D20A67272006E99C4 /* BrowserToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserToolbar.swift; sourceTree = "<group>"; };
 		6BE89BBB21B7452800F35AC3 /* LonaViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LonaViewModel.swift; sourceTree = "<group>"; };
+		6BFC4E0521C9C5A10030938B /* CanvasInspector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CanvasInspector.swift; sourceTree = "<group>"; };
 		7949560983378CFD6EC6FFD5 /* Pods_LonaStudio.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_LonaStudio.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		834F922A5808C8E689B2FD19 /* Pods-LonaStudioTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LonaStudioTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-LonaStudioTests/Pods-LonaStudioTests.debug.xcconfig"; sourceTree = "<group>"; };
 		918CC9C994C57DEF6340692F /* Pods-LonaStudioTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LonaStudioTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-LonaStudioTests/Pods-LonaStudioTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -963,6 +965,7 @@
 		6B8D7D9C21BED32E0087A3F7 /* inspector */ = {
 			isa = PBXGroup;
 			children = (
+				6BFC4E0521C9C5A10030938B /* CanvasInspector.swift */,
 				6BA775C821C59E2A0033C03C /* DimensionsInspector.swift */,
 				6B8D7DA221BF04B60087A3F7 /* InspectorSectionHeader.swift */,
 				6B8D7D9D21BED32E0087A3F7 /* LayoutInspector.swift */,
@@ -1474,6 +1477,7 @@
 				306DA4F41F34E416002772DC /* DataNode.swift in Sources */,
 				3069E0A21F32585A0005E9A8 /* CSPreferences.swift in Sources */,
 				30C8BC2B1EDB641E00B99F1B /* NSViewExtensions.swift in Sources */,
+				6BFC4E0621C9C5A10030938B /* CanvasInspector.swift in Sources */,
 				306672C21F7D4C6400941554 /* CSGradients.swift in Sources */,
 				307719001F3CD3F1003A597B /* MultilevelPopupField.swift in Sources */,
 				307718F01F365BA3003A597B /* CSType.swift in Sources */,

--- a/studio/LonaStudio/Canvas/CanvasAreaView.swift
+++ b/studio/LonaStudio/Canvas/CanvasAreaView.swift
@@ -40,6 +40,8 @@ public class CanvasAreaView: NSBox {
 
     public var onAddCanvas: (() -> Void)?
 
+    public var onMoveCanvasHeaderItem: ((Int, Int) -> Void)?
+
     public var selectedHeaderItem: Int? {
         get { return outlineView.selectedHeaderItem }
         set { outlineView.selectedHeaderItem = newValue }
@@ -66,6 +68,9 @@ public class CanvasAreaView: NSBox {
         }
         outlineView.onClickHeaderPlus = { [unowned self] in
             self.onAddCanvas?()
+        }
+        outlineView.onMoveHeaderItem = { [unowned self] index, newIndex in
+            self.onMoveCanvasHeaderItem?(index, newIndex)
         }
 
         scrollView.hasVerticalScroller = true

--- a/studio/LonaStudio/Canvas/CanvasAreaView.swift
+++ b/studio/LonaStudio/Canvas/CanvasAreaView.swift
@@ -36,6 +36,8 @@ public class CanvasAreaView: NSBox {
 
     public var onSelectCanvasHeaderItem: ((Int) -> Void)?
 
+    public var onDeleteCanvasHeaderItem: ((Int) -> Void)?
+
     public var selectedHeaderItem: Int? {
         get { return outlineView.selectedHeaderItem }
         set { outlineView.selectedHeaderItem = newValue }
@@ -56,6 +58,9 @@ public class CanvasAreaView: NSBox {
         outlineView.delegate = outlineView
         outlineView.onClickHeaderItem = { [unowned self] index in
             self.onSelectCanvasHeaderItem?(index)
+        }
+        outlineView.onDeleteHeaderItem = { [unowned self] index in
+            self.onDeleteCanvasHeaderItem?(index)
         }
 
         scrollView.hasVerticalScroller = true

--- a/studio/LonaStudio/Canvas/CanvasAreaView.swift
+++ b/studio/LonaStudio/Canvas/CanvasAreaView.swift
@@ -36,6 +36,11 @@ public class CanvasAreaView: NSBox {
 
     public var onSelectCanvasHeaderItem: ((Int) -> Void)?
 
+    public var selectedHeaderItem: Int? {
+        get { return outlineView.selectedHeaderItem }
+        set { outlineView.selectedHeaderItem = newValue }
+    }
+
     // MARK: Private
 
     private var scrollView = NSScrollView(frame: .zero)

--- a/studio/LonaStudio/Canvas/CanvasAreaView.swift
+++ b/studio/LonaStudio/Canvas/CanvasAreaView.swift
@@ -32,6 +32,10 @@ public class CanvasAreaView: NSBox {
         setUpConstraints()
     }
 
+    // MARK: Public
+
+    public var onSelectCanvasHeaderItem: ((Int) -> Void)?
+
     // MARK: Private
 
     private var scrollView = NSScrollView(frame: .zero)
@@ -45,6 +49,9 @@ public class CanvasAreaView: NSBox {
 
         outlineView.dataSource = outlineView
         outlineView.delegate = outlineView
+        outlineView.onClickHeaderItem = { [unowned self] index in
+            self.onSelectCanvasHeaderItem?(index)
+        }
 
         scrollView.hasVerticalScroller = true
         scrollView.hasHorizontalScroller = true

--- a/studio/LonaStudio/Canvas/CanvasAreaView.swift
+++ b/studio/LonaStudio/Canvas/CanvasAreaView.swift
@@ -38,6 +38,8 @@ public class CanvasAreaView: NSBox {
 
     public var onDeleteCanvasHeaderItem: ((Int) -> Void)?
 
+    public var onAddCanvas: (() -> Void)?
+
     public var selectedHeaderItem: Int? {
         get { return outlineView.selectedHeaderItem }
         set { outlineView.selectedHeaderItem = newValue }
@@ -61,6 +63,9 @@ public class CanvasAreaView: NSBox {
         }
         outlineView.onDeleteHeaderItem = { [unowned self] index in
             self.onDeleteCanvasHeaderItem?(index)
+        }
+        outlineView.onClickHeaderPlus = { [unowned self] in
+            self.onAddCanvas?()
         }
 
         scrollView.hasVerticalScroller = true

--- a/studio/LonaStudio/Canvas/CanvasTableHeaderView.swift
+++ b/studio/LonaStudio/Canvas/CanvasTableHeaderView.swift
@@ -26,6 +26,10 @@ class CanvasTableHeaderView: NSTableHeaderView {
         fatalError("init(coder:) has not been implemented")
     }
 
+    // MARK: Public
+
+    var onClickItem: ((Int) -> Void)?
+
     // MARK: Private
 
     var segmentViews: [NSView] = []
@@ -58,7 +62,8 @@ class CanvasTableHeaderView: NSTableHeaderView {
             segmentViews.forEach { $0.removeFromSuperview() }
 
             tableView.tableColumns.enumerated().forEach { index, column in
-                let view = CanvasTableHeaderItem(titleText: column.title, dividerColor: NSSplitView.defaultDividerColor)
+                let view = CanvasTableHeaderItem(titleText: column.title, dividerColor: NSSplitView.defaultDividerColor, selected: false)
+                view.onClick = { [unowned self] in self.onClickItem?(index) }
                 view.frame = headerRect(ofColumn: index)
                 view.translatesAutoresizingMaskIntoConstraints = true
 

--- a/studio/LonaStudio/Canvas/CanvasTableHeaderView.swift
+++ b/studio/LonaStudio/Canvas/CanvasTableHeaderView.swift
@@ -30,6 +30,8 @@ class CanvasTableHeaderView: NSTableHeaderView {
 
     var onClickItem: ((Int) -> Void)?
 
+    var onDeleteItem: ((Int) -> Void)?
+
     var selectedItem: Int? {
         didSet {
             if oldValue != selectedItem {
@@ -63,6 +65,16 @@ class CanvasTableHeaderView: NSTableHeaderView {
         bottomDividerView.trailingAnchor.constraint(equalTo: trailingAnchor).isActive = true
     }
 
+    override func keyDown(with event: NSEvent) {
+        guard let selectedItem = selectedItem else { return }
+
+        let characters = event.charactersIgnoringModifiers!
+
+        if characters == String(Character(UnicodeScalar(NSDeleteCharacter)!)) {
+            onDeleteItem?(selectedItem)
+        }
+    }
+
     func update() {
         guard let tableView = tableView else { return }
 
@@ -71,7 +83,10 @@ class CanvasTableHeaderView: NSTableHeaderView {
 
             tableView.tableColumns.enumerated().forEach { index, column in
                 let view = CanvasTableHeaderItem(titleText: column.title, dividerColor: NSSplitView.defaultDividerColor, selected: index == selectedItem)
-                view.onClick = { [unowned self] in self.onClickItem?(index) }
+                view.onClick = { [unowned self] in
+                    self.window?.makeFirstResponder(self)
+                    self.onClickItem?(index)
+                }
                 view.frame = headerRect(ofColumn: index)
                 view.translatesAutoresizingMaskIntoConstraints = true
 

--- a/studio/LonaStudio/Canvas/CanvasTableHeaderView.swift
+++ b/studio/LonaStudio/Canvas/CanvasTableHeaderView.swift
@@ -30,6 +30,14 @@ class CanvasTableHeaderView: NSTableHeaderView {
 
     var onClickItem: ((Int) -> Void)?
 
+    var selectedItem: Int? {
+        didSet {
+            if oldValue != selectedItem {
+                update()
+            }
+        }
+    }
+
     // MARK: Private
 
     var segmentViews: [NSView] = []
@@ -62,7 +70,7 @@ class CanvasTableHeaderView: NSTableHeaderView {
             segmentViews.forEach { $0.removeFromSuperview() }
 
             tableView.tableColumns.enumerated().forEach { index, column in
-                let view = CanvasTableHeaderItem(titleText: column.title, dividerColor: NSSplitView.defaultDividerColor, selected: false)
+                let view = CanvasTableHeaderItem(titleText: column.title, dividerColor: NSSplitView.defaultDividerColor, selected: index == selectedItem)
                 view.onClick = { [unowned self] in self.onClickItem?(index) }
                 view.frame = headerRect(ofColumn: index)
                 view.translatesAutoresizingMaskIntoConstraints = true
@@ -75,6 +83,7 @@ class CanvasTableHeaderView: NSTableHeaderView {
         tableView.tableColumns.enumerated().forEach { index, column in
             if let segmentView = segmentViews[index] as? CanvasTableHeaderItem {
                 segmentView.titleText = column.title
+                segmentView.selected = index == selectedItem
             }
 
             segmentViews[index].frame = headerRect(ofColumn: index)

--- a/studio/LonaStudio/Canvas/CanvasTableHeaderView.swift
+++ b/studio/LonaStudio/Canvas/CanvasTableHeaderView.swift
@@ -32,6 +32,8 @@ class CanvasTableHeaderView: NSTableHeaderView {
 
     var onDeleteItem: ((Int) -> Void)?
 
+    var onClickPlus: (() -> Void)?
+
     var selectedItem: Int? {
         didSet {
             if oldValue != selectedItem {
@@ -82,16 +84,28 @@ class CanvasTableHeaderView: NSTableHeaderView {
             segmentViews.forEach { $0.removeFromSuperview() }
 
             tableView.tableColumns.enumerated().forEach { index, column in
-                let view = CanvasTableHeaderItem(titleText: column.title, dividerColor: NSSplitView.defaultDividerColor, selected: index == selectedItem)
-                view.onClick = { [unowned self] in
-                    self.window?.makeFirstResponder(self)
-                    self.onClickItem?(index)
-                }
-                view.frame = headerRect(ofColumn: index)
-                view.translatesAutoresizingMaskIntoConstraints = true
+                if index == tableView.tableColumns.count - 1 {
+                    let view = CanvasTableHeaderExtra(dividerColor: NSSplitView.defaultDividerColor)
+                    view.onClickPlus = { [unowned self] in
+                        self.onClickPlus?()
+                    }
+                    view.frame = headerRect(ofColumn: index)
+                    view.translatesAutoresizingMaskIntoConstraints = true
 
-                addSubview(view)
-                segmentViews.append(view)
+                    addSubview(view)
+                    segmentViews.append(view)
+                } else {
+                    let view = CanvasTableHeaderItem(titleText: column.title, dividerColor: NSSplitView.defaultDividerColor, selected: index == selectedItem)
+                    view.onClick = { [unowned self] in
+                        self.window?.makeFirstResponder(self)
+                        self.onClickItem?(index)
+                    }
+                    view.frame = headerRect(ofColumn: index)
+                    view.translatesAutoresizingMaskIntoConstraints = true
+
+                    addSubview(view)
+                    segmentViews.append(view)
+                }
             }
         }
 

--- a/studio/LonaStudio/Canvas/CanvasTableView.swift
+++ b/studio/LonaStudio/Canvas/CanvasTableView.swift
@@ -73,6 +73,11 @@ class CanvasTableView: NSTableView, NSTableViewDataSource, NSTableViewDelegate {
 
     var onClickHeaderItem: ((Int) -> Void)?
 
+    var selectedHeaderItem: Int? {
+        get { return header.selectedItem }
+        set { header.selectedItem = newValue }
+    }
+
     private func handleClickHeaderItem(_ index: Int) {
         onClickHeaderItem?(index)
     }

--- a/studio/LonaStudio/Canvas/CanvasTableView.swift
+++ b/studio/LonaStudio/Canvas/CanvasTableView.swift
@@ -28,6 +28,7 @@ class CanvasTableView: NSTableView, NSTableViewDataSource, NSTableViewDelegate {
         headerView = header
 
         header.onClickItem = handleClickHeaderItem
+        header.onDeleteItem = handleDeleteHeaderItem
 
         // A hack to let us reuse the same cell view every render:
         //
@@ -73,6 +74,8 @@ class CanvasTableView: NSTableView, NSTableViewDataSource, NSTableViewDelegate {
 
     var onClickHeaderItem: ((Int) -> Void)?
 
+    var onDeleteHeaderItem: ((Int) -> Void)?
+
     var selectedHeaderItem: Int? {
         get { return header.selectedItem }
         set { header.selectedItem = newValue }
@@ -80,6 +83,10 @@ class CanvasTableView: NSTableView, NSTableViewDataSource, NSTableViewDelegate {
 
     private func handleClickHeaderItem(_ index: Int) {
         onClickHeaderItem?(index)
+    }
+
+    private func handleDeleteHeaderItem(_ index: Int) {
+        onDeleteHeaderItem?(index)
     }
 
     @objc fileprivate func doubleClick(sender: AnyObject) {

--- a/studio/LonaStudio/Canvas/CanvasTableView.swift
+++ b/studio/LonaStudio/Canvas/CanvasTableView.swift
@@ -30,6 +30,7 @@ class CanvasTableView: NSTableView, NSTableViewDataSource, NSTableViewDelegate {
         header.onClickItem = handleClickHeaderItem
         header.onDeleteItem = handleDeleteHeaderItem
         header.onClickPlus = handleClickHeaderPlus
+        header.onMoveItem = handleMoveHeaderItem
 
         // A hack to let us reuse the same cell view every render:
         //
@@ -79,6 +80,8 @@ class CanvasTableView: NSTableView, NSTableViewDataSource, NSTableViewDelegate {
 
     var onClickHeaderPlus: (() -> Void)?
 
+    var onMoveHeaderItem: ((Int, Int) -> Void)?
+
     var selectedHeaderItem: Int? {
         get { return header.selectedItem }
         set { header.selectedItem = newValue }
@@ -94,6 +97,10 @@ class CanvasTableView: NSTableView, NSTableViewDataSource, NSTableViewDelegate {
 
     private func handleClickHeaderPlus() {
         onClickHeaderPlus?()
+    }
+
+    private func handleMoveHeaderItem(_ index: Int, _ newIndex: Int) {
+        onMoveHeaderItem?(index, newIndex)
     }
 
     @objc fileprivate func doubleClick(sender: AnyObject) {

--- a/studio/LonaStudio/Canvas/CanvasTableView.swift
+++ b/studio/LonaStudio/Canvas/CanvasTableView.swift
@@ -29,6 +29,7 @@ class CanvasTableView: NSTableView, NSTableViewDataSource, NSTableViewDelegate {
 
         header.onClickItem = handleClickHeaderItem
         header.onDeleteItem = handleDeleteHeaderItem
+        header.onClickPlus = handleClickHeaderPlus
 
         // A hack to let us reuse the same cell view every render:
         //
@@ -76,6 +77,8 @@ class CanvasTableView: NSTableView, NSTableViewDataSource, NSTableViewDelegate {
 
     var onDeleteHeaderItem: ((Int) -> Void)?
 
+    var onClickHeaderPlus: (() -> Void)?
+
     var selectedHeaderItem: Int? {
         get { return header.selectedItem }
         set { header.selectedItem = newValue }
@@ -89,6 +92,10 @@ class CanvasTableView: NSTableView, NSTableViewDataSource, NSTableViewDelegate {
         onDeleteHeaderItem?(index)
     }
 
+    private func handleClickHeaderPlus() {
+        onClickHeaderPlus?()
+    }
+
     @objc fileprivate func doubleClick(sender: AnyObject) {
         if clickedColumn == -1 { return }
 
@@ -97,11 +104,13 @@ class CanvasTableView: NSTableView, NSTableViewDataSource, NSTableViewDelegate {
         }
     }
 
+    let extraColumn = NSTableColumn(title: "Add Canvas", width: 42)
+
     // Call this after changing canvases to update the labels
     func updateHeader() {
         let columns: [NSTableColumn] = canvases.map { canvas in
             return NSTableColumn(title: canvas.computedName, width: CGFloat(canvas.width) + CanvasView.margin * 2)
-        }
+        } + [extraColumn]
 
         if columns.count == tableColumns.count && zip(columns, tableColumns).allSatisfy({ a, b in
             return a.title == b.title && a.width == b.width

--- a/studio/LonaStudio/Canvas/CanvasTableView.swift
+++ b/studio/LonaStudio/Canvas/CanvasTableView.swift
@@ -27,6 +27,8 @@ class CanvasTableView: NSTableView, NSTableViewDataSource, NSTableViewDelegate {
         rowSizeStyle = .custom
         headerView = header
 
+        header.onClickItem = handleClickHeaderItem
+
         // A hack to let us reuse the same cell view every render:
         //
         // Normally NSTableView doesn't give us control over which view gets reused.
@@ -68,6 +70,12 @@ class CanvasTableView: NSTableView, NSTableViewDataSource, NSTableViewDelegate {
     var cases: [CSCaseEntry] = []
 
     var component: CSComponent?
+
+    var onClickHeaderItem: ((Int) -> Void)?
+
+    private func handleClickHeaderItem(_ index: Int) {
+        onClickHeaderItem?(index)
+    }
 
     @objc fileprivate func doubleClick(sender: AnyObject) {
         if clickedColumn == -1 { return }

--- a/studio/LonaStudio/Canvas/CanvasTableView.swift
+++ b/studio/LonaStudio/Canvas/CanvasTableView.swift
@@ -93,7 +93,7 @@ class CanvasTableView: NSTableView, NSTableViewDataSource, NSTableViewDelegate {
     // Call this after changing canvases to update the labels
     func updateHeader() {
         let columns: [NSTableColumn] = canvases.map { canvas in
-            return NSTableColumn(title: canvas.name, width: CGFloat(canvas.width) + CanvasView.margin * 2)
+            return NSTableColumn(title: canvas.computedName, width: CGFloat(canvas.width) + CanvasView.margin * 2)
         }
 
         if columns.count == tableColumns.count && zip(columns, tableColumns).allSatisfy({ a, b in

--- a/studio/LonaStudio/Canvas/CanvasView.swift
+++ b/studio/LonaStudio/Canvas/CanvasView.swift
@@ -427,6 +427,7 @@ extension CanvasView {
 
         if useExactHeight {
             wrapper.height = CGFloat(canvas.computedHeight)
+            child.height = CGFloat(canvas.computedHeight)
         } else {
             let verticalMargins = child.marginTop + child.marginBottom
             let minHeight = CGFloat(canvas.computedHeight) - verticalMargins

--- a/studio/LonaStudio/Canvas/CanvasView.swift
+++ b/studio/LonaStudio/Canvas/CanvasView.swift
@@ -423,13 +423,13 @@ extension CanvasView {
 
         // Use an extra child which can have a height greater than the root layer, allowing the root to expand
         guard var wrapper = YGNodeNew() else { return nil }
-        wrapper.width = CGFloat(canvas.width)
+        wrapper.width = CGFloat(canvas.computedWidth)
 
         if useExactHeight {
-            wrapper.height = CGFloat(canvas.height)
+            wrapper.height = CGFloat(canvas.computedHeight)
         } else {
             let verticalMargins = child.marginTop + child.marginBottom
-            let minHeight = CGFloat(canvas.height) - verticalMargins
+            let minHeight = CGFloat(canvas.computedHeight) - verticalMargins
 
             wrapper.minHeight = minHeight
 
@@ -448,7 +448,7 @@ extension CanvasView {
         rootNode.calculateLayout(width: CGFloat(canvas.width), height: CGFloat(canvasHeight))
 
         // Create the canvas based on the calculated height of the layout
-        let calculatedHeight = useExactHeight ? CGFloat(canvas.height) : wrapper.layout.height
+        let calculatedHeight = useExactHeight ? CGFloat(canvas.computedHeight) : wrapper.layout.height
 
         return (child, rootNode, calculatedHeight)
     }

--- a/studio/LonaStudio/Controls/ControlledDropdown.swift
+++ b/studio/LonaStudio/Controls/ControlledDropdown.swift
@@ -82,6 +82,8 @@ public class ControlledDropdown: NSPopUpButton {
     private func setup() {
         action = #selector(handleChange)
         target = self
+
+        heightAnchor.constraint(equalToConstant: 22).isActive = true
     }
 
     @objc func handleChange() {

--- a/studio/LonaStudio/Extensions/NSViewExtensions.swift
+++ b/studio/LonaStudio/Extensions/NSViewExtensions.swift
@@ -9,12 +9,17 @@
 import Foundation
 import Cocoa
 
-private func imageData(from pixelBuffer: CVPixelBuffer) -> Data? {
+private func image(from pixelBuffer: CVPixelBuffer) -> NSImage {
     let imageRep = NSCIImageRep(ciImage: CIImage(cvPixelBuffer: pixelBuffer, options: nil))
     let image = NSImage(size: imageRep.size)
     image.addRepresentation(imageRep)
+    return image
+}
 
-    guard let bitmapData = image.tiffRepresentation else {
+private func imageData(from pixelBuffer: CVPixelBuffer) -> Data? {
+    let nsImage = image(from: pixelBuffer)
+
+    guard let bitmapData = nsImage.tiffRepresentation else {
         Swift.print("Failed to convert to tiff")
         return nil
     }
@@ -243,6 +248,11 @@ public extension NSView {
         NSGraphicsContext.restoreGraphicsState()
 
         return pixelBuffer
+    }
+
+    func imageRepresentation(scaledBy scale: CGFloat = 1) -> NSImage? {
+        guard let buffer = pixelBuffer(scaledBy: scale) else { return nil }
+        return image(from: buffer)
     }
 
     func dataRepresentation(scaledBy scale: CGFloat = 1) -> Data? {

--- a/studio/LonaStudio/ForeignTypes.swift
+++ b/studio/LonaStudio/ForeignTypes.swift
@@ -49,6 +49,15 @@ class TextInput: ControlledComponents.TextInput {
 
 typealias NumberInput = NumberField
 extension NumberInput {
+    var disabled: Bool {
+        get { return isEnabled }
+        set {
+            if isEnabled != newValue {
+                isEnabled = newValue
+            }
+        }
+    }
+
     var numberValue: CGFloat {
         get { return CGFloat(value) }
         set { value = Double(newValue) }

--- a/studio/LonaStudio/ForeignTypes.swift
+++ b/studio/LonaStudio/ForeignTypes.swift
@@ -22,7 +22,7 @@ public typealias ColorPickerHandler = ((Color) -> Void)?
 public typealias ItemMoveHandler = ((Int, Int) -> Void)?
 
 // Alias imported components for use in generated code
-public typealias TextInput = ControlledComponents.TextInput
+//public typealias TextInput = ControlledComponents.TextInput
 public typealias Button = ControlledComponents.Button
 public typealias ColorWellPicker = ColorPicker.ColorWellPicker
 
@@ -31,6 +31,21 @@ public typealias ColorWellPicker = ColorPicker.ColorWellPicker
 // to disambiguate.
 public typealias SwiftColor = Color
 extension Color: Equatable {}
+
+class TextInput: ControlledComponents.TextInput {
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+
+        // This lets us use fittingSize to determine total view height (e.g. in the inspector)
+        let heightConstraint = heightAnchor.constraint(greaterThanOrEqualToConstant: 22)
+        heightConstraint.priority = .defaultHigh
+        heightConstraint.isActive = true
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
 
 typealias NumberInput = NumberField
 extension NumberInput {

--- a/studio/LonaStudio/Generated/Colors.swift
+++ b/studio/LonaStudio/Generated/Colors.swift
@@ -8,6 +8,7 @@ public enum Colors {
   public static let selectedIcon = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 0.35) // RGBA(255,255,255,0.35) -
   public static let selectedIconStroke = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 0.8) // RGBA(255,255,255,0.8) -
   public static let transparent = #colorLiteral(red: 0, green: 0, blue: 0, alpha: 0) // RGBA(0,0,0,0.0) -
+  public static let systemSelection = #colorLiteral(red: 0.0156862745098, green: 0.388235294118, blue: 0.882352941176, alpha: 1) // RGB(4,99,225) - MacOS system selection color
   public static let red50 = #colorLiteral(red: 1, green: 0.921568627451, blue: 0.933333333333, alpha: 1) // #FFEBEE -
   public static let red100 = #colorLiteral(red: 1, green: 0.803921568627, blue: 0.823529411765, alpha: 1) // #FFCDD2 -
   public static let red200 = #colorLiteral(red: 0.937254901961, green: 0.603921568627, blue: 0.603921568627, alpha: 1) // #EF9A9A -

--- a/studio/LonaStudio/Generated/TextStyles.swift
+++ b/studio/LonaStudio/Generated/TextStyles.swift
@@ -17,4 +17,5 @@ class TextStyles {
   public static let monospacedMicro = TextStyle(family: "Menlo", weight: NSFont.Weight.bold, size: 10, color: #colorLiteral(red: 0, green: 0, blue: 0, alpha: 0.85))
   public static let monospacedMicroInverse = TextStyle(family: "Menlo", weight: NSFont.Weight.bold, size: 10, color: #colorLiteral(red: 1, green: 1, blue: 1, alpha: 0.85))
   public static let sectionTitle = TextStyle(weight: NSFont.Weight.medium, size: 12, color: #colorLiteral(red: 0.329411764706, green: 0.329411764706, blue: 0.329411764706, alpha: 1))
+  public static let sectionTitleInverse = TextStyle(weight: NSFont.Weight.semibold, size: 12, color: Colors.white)
 }

--- a/studio/LonaStudio/Generated/components/CanvasTableHeaderExtra.swift
+++ b/studio/LonaStudio/Generated/components/CanvasTableHeaderExtra.swift
@@ -1,0 +1,265 @@
+import AppKit
+import Foundation
+
+// MARK: - CanvasTableHeaderExtra
+
+public class CanvasTableHeaderExtra: NSBox {
+
+  // MARK: Lifecycle
+
+  public init(_ parameters: Parameters) {
+    self.parameters = parameters
+
+    super.init(frame: .zero)
+
+    setUpViews()
+    setUpConstraints()
+
+    update()
+
+    addTrackingArea(trackingArea)
+  }
+
+  public convenience init(dividerColor: NSColor) {
+    self.init(Parameters(dividerColor: dividerColor))
+  }
+
+  public convenience init() {
+    self.init(Parameters())
+  }
+
+  public required init?(coder aDecoder: NSCoder) {
+    self.parameters = Parameters()
+
+    super.init(coder: aDecoder)
+
+    setUpViews()
+    setUpConstraints()
+
+    update()
+
+    addTrackingArea(trackingArea)
+  }
+
+  deinit {
+    removeTrackingArea(trackingArea)
+  }
+
+  // MARK: Public
+
+  public var dividerColor: NSColor {
+    get { return parameters.dividerColor }
+    set {
+      if parameters.dividerColor != newValue {
+        parameters.dividerColor = newValue
+      }
+    }
+  }
+
+  public var onClickPlus: (() -> Void)? {
+    get { return parameters.onClickPlus }
+    set { parameters.onClickPlus = newValue }
+  }
+
+  public var parameters: Parameters {
+    didSet {
+      if parameters != oldValue {
+        update()
+      }
+    }
+  }
+
+  // MARK: Private
+
+  private lazy var trackingArea = NSTrackingArea(
+    rect: self.frame,
+    options: [.mouseEnteredAndExited, .activeAlways, .mouseMoved, .inVisibleRect],
+    owner: self)
+
+  private var buttonView = NSBox()
+  private var titleView = LNATextField(labelWithString: "")
+  private var hDividerView = NSBox()
+
+  private var titleViewTextStyle = TextStyles.large.with(alignment: .center)
+
+  private var buttonViewHovered = false
+  private var buttonViewPressed = false
+  private var buttonViewOnPress: (() -> Void)?
+
+  private func setUpViews() {
+    boxType = .custom
+    borderType = .noBorder
+    contentViewMargins = .zero
+    buttonView.boxType = .custom
+    buttonView.borderType = .noBorder
+    buttonView.contentViewMargins = .zero
+    hDividerView.boxType = .custom
+    hDividerView.borderType = .noBorder
+    hDividerView.contentViewMargins = .zero
+    titleView.lineBreakMode = .byWordWrapping
+
+    addSubview(buttonView)
+    addSubview(hDividerView)
+    buttonView.addSubview(titleView)
+
+    fillColor = Colors.white
+    buttonView.cornerRadius = 11
+    titleView.attributedStringValue = titleViewTextStyle.apply(to: "+")
+    titleViewTextStyle = TextStyles.large.with(alignment: .center)
+    titleView.attributedStringValue = titleViewTextStyle.apply(to: titleView.attributedStringValue)
+  }
+
+  private func setUpConstraints() {
+    translatesAutoresizingMaskIntoConstraints = false
+    buttonView.translatesAutoresizingMaskIntoConstraints = false
+    hDividerView.translatesAutoresizingMaskIntoConstraints = false
+    titleView.translatesAutoresizingMaskIntoConstraints = false
+
+    let heightAnchorConstraint = heightAnchor.constraint(equalToConstant: 38)
+    let buttonViewTopAnchorConstraint = buttonView.topAnchor.constraint(equalTo: topAnchor, constant: 7)
+    let buttonViewCenterXAnchorConstraint = buttonView.centerXAnchor.constraint(equalTo: centerXAnchor)
+    let hDividerViewTopAnchorConstraint = hDividerView
+      .topAnchor
+      .constraint(equalTo: buttonView.bottomAnchor, constant: 8)
+    let hDividerViewLeadingAnchorConstraint = hDividerView.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let hDividerViewCenterXAnchorConstraint = hDividerView.centerXAnchor.constraint(equalTo: centerXAnchor)
+    let hDividerViewTrailingAnchorConstraint = hDividerView.trailingAnchor.constraint(equalTo: trailingAnchor)
+    let buttonViewHeightAnchorConstraint = buttonView.heightAnchor.constraint(equalToConstant: 22)
+    let buttonViewWidthAnchorConstraint = buttonView.widthAnchor.constraint(equalToConstant: 22)
+    let titleViewTopAnchorConstraint = titleView.topAnchor.constraint(equalTo: buttonView.topAnchor)
+    let titleViewLeadingAnchorConstraint = titleView.leadingAnchor.constraint(equalTo: buttonView.leadingAnchor)
+    let titleViewCenterXAnchorConstraint = titleView.centerXAnchor.constraint(equalTo: buttonView.centerXAnchor)
+    let titleViewTrailingAnchorConstraint = titleView.trailingAnchor.constraint(equalTo: buttonView.trailingAnchor)
+    let hDividerViewHeightAnchorConstraint = hDividerView.heightAnchor.constraint(equalToConstant: 1)
+
+    NSLayoutConstraint.activate([
+      heightAnchorConstraint,
+      buttonViewTopAnchorConstraint,
+      buttonViewCenterXAnchorConstraint,
+      hDividerViewTopAnchorConstraint,
+      hDividerViewLeadingAnchorConstraint,
+      hDividerViewCenterXAnchorConstraint,
+      hDividerViewTrailingAnchorConstraint,
+      buttonViewHeightAnchorConstraint,
+      buttonViewWidthAnchorConstraint,
+      titleViewTopAnchorConstraint,
+      titleViewLeadingAnchorConstraint,
+      titleViewCenterXAnchorConstraint,
+      titleViewTrailingAnchorConstraint,
+      hDividerViewHeightAnchorConstraint
+    ])
+  }
+
+  private func update() {
+    buttonView.fillColor = Colors.grey200
+    hDividerView.fillColor = dividerColor
+    buttonViewOnPress = handleOnClickPlus
+    if buttonViewPressed {
+      buttonView.fillColor = Colors.headerBackground
+    }
+  }
+
+  private func handleOnClickPlus() {
+    onClickPlus?()
+  }
+
+  private func updateHoverState(with event: NSEvent) {
+    let buttonViewHovered = buttonView.bounds.contains(buttonView.convert(event.locationInWindow, from: nil))
+    if buttonViewHovered != self.buttonViewHovered {
+      self.buttonViewHovered = buttonViewHovered
+
+      update()
+    }
+  }
+
+  public override func mouseEntered(with event: NSEvent) {
+    updateHoverState(with: event)
+  }
+
+  public override func mouseMoved(with event: NSEvent) {
+    updateHoverState(with: event)
+  }
+
+  public override func mouseDragged(with event: NSEvent) {
+    updateHoverState(with: event)
+  }
+
+  public override func mouseExited(with event: NSEvent) {
+    updateHoverState(with: event)
+  }
+
+  public override func mouseDown(with event: NSEvent) {
+    let buttonViewPressed = buttonView.bounds.contains(buttonView.convert(event.locationInWindow, from: nil))
+    if buttonViewPressed != self.buttonViewPressed {
+      self.buttonViewPressed = buttonViewPressed
+
+      update()
+    }
+  }
+
+  public override func mouseUp(with event: NSEvent) {
+    let buttonViewClicked = buttonViewPressed &&
+      buttonView.bounds.contains(buttonView.convert(event.locationInWindow, from: nil))
+
+    if buttonViewPressed {
+      buttonViewPressed = false
+
+      update()
+    }
+
+    if buttonViewClicked {
+      buttonViewOnPress?()
+    }
+  }
+}
+
+// MARK: - Parameters
+
+extension CanvasTableHeaderExtra {
+  public struct Parameters: Equatable {
+    public var dividerColor: NSColor
+    public var onClickPlus: (() -> Void)?
+
+    public init(dividerColor: NSColor, onClickPlus: (() -> Void)? = nil) {
+      self.dividerColor = dividerColor
+      self.onClickPlus = onClickPlus
+    }
+
+    public init() {
+      self.init(dividerColor: NSColor.clear)
+    }
+
+    public static func ==(lhs: Parameters, rhs: Parameters) -> Bool {
+      return lhs.dividerColor == rhs.dividerColor
+    }
+  }
+}
+
+// MARK: - Model
+
+extension CanvasTableHeaderExtra {
+  public struct Model: LonaViewModel, Equatable {
+    public var id: String?
+    public var parameters: Parameters
+    public var type: String {
+      return "CanvasTableHeaderExtra"
+    }
+
+    public init(id: String? = nil, parameters: Parameters) {
+      self.id = id
+      self.parameters = parameters
+    }
+
+    public init(_ parameters: Parameters) {
+      self.parameters = parameters
+    }
+
+    public init(dividerColor: NSColor, onClickPlus: (() -> Void)? = nil) {
+      self.init(Parameters(dividerColor: dividerColor, onClickPlus: onClickPlus))
+    }
+
+    public init() {
+      self.init(dividerColor: NSColor.clear)
+    }
+  }
+}

--- a/studio/LonaStudio/Generated/components/CanvasTableHeaderItem.swift
+++ b/studio/LonaStudio/Generated/components/CanvasTableHeaderItem.swift
@@ -20,8 +20,19 @@ public class CanvasTableHeaderItem: NSBox {
     addTrackingArea(trackingArea)
   }
 
-  public convenience init(titleText: String, dividerColor: NSColor, selected: Bool) {
-    self.init(Parameters(titleText: titleText, dividerColor: dividerColor, selected: selected))
+  public convenience init(
+    titleText: String,
+    dividerColor: NSColor,
+    selected: Bool,
+    dropTargetIndicator: DropTargetIndicator)
+  {
+    self
+      .init(
+        Parameters(
+          titleText: titleText,
+          dividerColor: dividerColor,
+          selected: selected,
+          dropTargetIndicator: dropTargetIndicator))
   }
 
   public convenience init() {
@@ -79,6 +90,15 @@ public class CanvasTableHeaderItem: NSBox {
     }
   }
 
+  public var dropTargetIndicator: DropTargetIndicator {
+    get { return parameters.dropTargetIndicator }
+    set {
+      if parameters.dropTargetIndicator != newValue {
+        parameters.dropTargetIndicator = newValue
+      }
+    }
+  }
+
   public var parameters: Parameters {
     didSet {
       if parameters != oldValue {
@@ -95,6 +115,7 @@ public class CanvasTableHeaderItem: NSBox {
     owner: self)
 
   private var innerView = NSBox()
+  private var vDividerLeftView = NSBox()
   private var titleView = LNATextField(labelWithString: "")
   private var vDividerView = NSBox()
   private var hDividerView = NSBox()
@@ -115,6 +136,9 @@ public class CanvasTableHeaderItem: NSBox {
     hDividerView.boxType = .custom
     hDividerView.borderType = .noBorder
     hDividerView.contentViewMargins = .zero
+    vDividerLeftView.boxType = .custom
+    vDividerLeftView.borderType = .noBorder
+    vDividerLeftView.contentViewMargins = .zero
     titleView.lineBreakMode = .byWordWrapping
     vDividerView.boxType = .custom
     vDividerView.borderType = .noBorder
@@ -122,6 +146,7 @@ public class CanvasTableHeaderItem: NSBox {
 
     addSubview(innerView)
     addSubview(hDividerView)
+    innerView.addSubview(vDividerLeftView)
     innerView.addSubview(titleView)
     innerView.addSubview(vDividerView)
   }
@@ -130,6 +155,7 @@ public class CanvasTableHeaderItem: NSBox {
     translatesAutoresizingMaskIntoConstraints = false
     innerView.translatesAutoresizingMaskIntoConstraints = false
     hDividerView.translatesAutoresizingMaskIntoConstraints = false
+    vDividerLeftView.translatesAutoresizingMaskIntoConstraints = false
     titleView.translatesAutoresizingMaskIntoConstraints = false
     vDividerView.translatesAutoresizingMaskIntoConstraints = false
 
@@ -143,7 +169,17 @@ public class CanvasTableHeaderItem: NSBox {
     let hDividerViewLeadingAnchorConstraint = hDividerView.leadingAnchor.constraint(equalTo: leadingAnchor)
     let hDividerViewCenterXAnchorConstraint = hDividerView.centerXAnchor.constraint(equalTo: centerXAnchor)
     let hDividerViewTrailingAnchorConstraint = hDividerView.trailingAnchor.constraint(equalTo: trailingAnchor)
-    let titleViewLeadingAnchorConstraint = titleView.leadingAnchor.constraint(equalTo: innerView.leadingAnchor)
+    let vDividerLeftViewLeadingAnchorConstraint = vDividerLeftView
+      .leadingAnchor
+      .constraint(equalTo: innerView.leadingAnchor)
+    let vDividerLeftViewTopAnchorConstraint = vDividerLeftView.topAnchor.constraint(equalTo: innerView.topAnchor)
+    let vDividerLeftViewCenterYAnchorConstraint = vDividerLeftView
+      .centerYAnchor
+      .constraint(equalTo: innerView.centerYAnchor)
+    let vDividerLeftViewBottomAnchorConstraint = vDividerLeftView
+      .bottomAnchor
+      .constraint(equalTo: innerView.bottomAnchor)
+    let titleViewLeadingAnchorConstraint = titleView.leadingAnchor.constraint(equalTo: vDividerLeftView.trailingAnchor)
     let titleViewTopAnchorConstraint = titleView.topAnchor.constraint(greaterThanOrEqualTo: innerView.topAnchor)
     let titleViewCenterYAnchorConstraint = titleView.centerYAnchor.constraint(equalTo: innerView.centerYAnchor)
     let titleViewBottomAnchorConstraint = titleView.bottomAnchor.constraint(lessThanOrEqualTo: innerView.bottomAnchor)
@@ -153,6 +189,7 @@ public class CanvasTableHeaderItem: NSBox {
     let vDividerViewCenterYAnchorConstraint = vDividerView.centerYAnchor.constraint(equalTo: innerView.centerYAnchor)
     let vDividerViewBottomAnchorConstraint = vDividerView.bottomAnchor.constraint(equalTo: innerView.bottomAnchor)
     let hDividerViewHeightAnchorConstraint = hDividerView.heightAnchor.constraint(equalToConstant: 1)
+    let vDividerLeftViewWidthAnchorConstraint = vDividerLeftView.widthAnchor.constraint(equalToConstant: 1)
     let vDividerViewWidthAnchorConstraint = vDividerView.widthAnchor.constraint(equalToConstant: 1)
 
     NSLayoutConstraint.activate([
@@ -166,6 +203,10 @@ public class CanvasTableHeaderItem: NSBox {
       hDividerViewLeadingAnchorConstraint,
       hDividerViewCenterXAnchorConstraint,
       hDividerViewTrailingAnchorConstraint,
+      vDividerLeftViewLeadingAnchorConstraint,
+      vDividerLeftViewTopAnchorConstraint,
+      vDividerLeftViewCenterYAnchorConstraint,
+      vDividerLeftViewBottomAnchorConstraint,
       titleViewLeadingAnchorConstraint,
       titleViewTopAnchorConstraint,
       titleViewCenterYAnchorConstraint,
@@ -176,6 +217,7 @@ public class CanvasTableHeaderItem: NSBox {
       vDividerViewCenterYAnchorConstraint,
       vDividerViewBottomAnchorConstraint,
       hDividerViewHeightAnchorConstraint,
+      vDividerLeftViewWidthAnchorConstraint,
       vDividerViewWidthAnchorConstraint
     ])
   }
@@ -184,19 +226,28 @@ public class CanvasTableHeaderItem: NSBox {
     fillColor = Colors.white
     titleViewTextStyle = TextStyles.sectionTitle.with(alignment: .center)
     titleView.attributedStringValue = titleViewTextStyle.apply(to: titleView.attributedStringValue)
+    vDividerLeftView.fillColor = Colors.white
     hDividerView.fillColor = dividerColor
     vDividerView.fillColor = dividerColor
     titleView.attributedStringValue = titleViewTextStyle.apply(to: titleText)
     onPress = handleOnClick
     if pressed {
       fillColor = Colors.headerBackground
+      vDividerLeftView.fillColor = Colors.headerBackground
     }
     if selected {
       fillColor = Colors.systemSelection
       hDividerView.fillColor = Colors.systemSelection
       vDividerView.fillColor = Colors.systemSelection
+      vDividerLeftView.fillColor = Colors.systemSelection
       titleViewTextStyle = TextStyles.sectionTitleInverse.with(alignment: .center)
       titleView.attributedStringValue = titleViewTextStyle.apply(to: titleView.attributedStringValue)
+    }
+    if dropTargetIndicator == .left {
+      vDividerLeftView.fillColor = Colors.blue400
+    }
+    if dropTargetIndicator == .right {
+      vDividerView.fillColor = Colors.blue400
     }
   }
 
@@ -260,21 +311,31 @@ extension CanvasTableHeaderItem {
     public var titleText: String
     public var dividerColor: NSColor
     public var selected: Bool
+    public var dropTargetIndicator: DropTargetIndicator
     public var onClick: (() -> Void)?
 
-    public init(titleText: String, dividerColor: NSColor, selected: Bool, onClick: (() -> Void)? = nil) {
+    public init(
+      titleText: String,
+      dividerColor: NSColor,
+      selected: Bool,
+      dropTargetIndicator: DropTargetIndicator,
+      onClick: (() -> Void)? = nil)
+    {
       self.titleText = titleText
       self.dividerColor = dividerColor
       self.selected = selected
+      self.dropTargetIndicator = dropTargetIndicator
       self.onClick = onClick
     }
 
     public init() {
-      self.init(titleText: "", dividerColor: NSColor.clear, selected: false)
+      self.init(titleText: "", dividerColor: NSColor.clear, selected: false, dropTargetIndicator: .none)
     }
 
     public static func ==(lhs: Parameters, rhs: Parameters) -> Bool {
-      return lhs.titleText == rhs.titleText && lhs.dividerColor == rhs.dividerColor && lhs.selected == rhs.selected
+      return lhs.titleText == rhs.titleText &&
+        lhs.dividerColor == rhs.dividerColor &&
+          lhs.selected == rhs.selected && lhs.dropTargetIndicator == rhs.dropTargetIndicator
     }
   }
 }
@@ -298,12 +359,35 @@ extension CanvasTableHeaderItem {
       self.parameters = parameters
     }
 
-    public init(titleText: String, dividerColor: NSColor, selected: Bool, onClick: (() -> Void)? = nil) {
-      self.init(Parameters(titleText: titleText, dividerColor: dividerColor, selected: selected, onClick: onClick))
+    public init(
+      titleText: String,
+      dividerColor: NSColor,
+      selected: Bool,
+      dropTargetIndicator: DropTargetIndicator,
+      onClick: (() -> Void)? = nil)
+    {
+      self
+        .init(
+          Parameters(
+            titleText: titleText,
+            dividerColor: dividerColor,
+            selected: selected,
+            dropTargetIndicator: dropTargetIndicator,
+            onClick: onClick))
     }
 
     public init() {
-      self.init(titleText: "", dividerColor: NSColor.clear, selected: false)
+      self.init(titleText: "", dividerColor: NSColor.clear, selected: false, dropTargetIndicator: .none)
     }
+  }
+}
+
+// MARK: - DropTargetIndicator
+
+extension CanvasTableHeaderItem {
+  public enum DropTargetIndicator: String, Codable, Equatable {
+    case none
+    case left
+    case right
   }
 }

--- a/studio/LonaStudio/Generated/components/CanvasTableHeaderItem.swift
+++ b/studio/LonaStudio/Generated/components/CanvasTableHeaderItem.swift
@@ -192,7 +192,9 @@ public class CanvasTableHeaderItem: NSBox {
       fillColor = Colors.headerBackground
     }
     if selected {
-      fillColor = Colors.blue600
+      fillColor = Colors.systemSelection
+      hDividerView.fillColor = Colors.systemSelection
+      vDividerView.fillColor = Colors.systemSelection
       titleViewTextStyle = TextStyles.sectionTitleInverse.with(alignment: .center)
       titleView.attributedStringValue = titleViewTextStyle.apply(to: titleView.attributedStringValue)
     }

--- a/studio/LonaStudio/Generated/components/TextInput.swift
+++ b/studio/LonaStudio/Generated/components/TextInput.swift
@@ -18,8 +18,8 @@ public class TextInput: NSBox {
     update()
   }
 
-  public convenience init(textValue: String) {
-    self.init(Parameters(textValue: textValue))
+  public convenience init(textValue: String, placeholderString: String?) {
+    self.init(Parameters(textValue: textValue, placeholderString: placeholderString))
   }
 
   public convenience init() {
@@ -51,6 +51,15 @@ public class TextInput: NSBox {
   public var onChangeTextValue: StringHandler {
     get { return parameters.onChangeTextValue }
     set { parameters.onChangeTextValue = newValue }
+  }
+
+  public var placeholderString: String? {
+    get { return parameters.placeholderString }
+    set {
+      if parameters.placeholderString != newValue {
+        parameters.placeholderString = newValue
+      }
+    }
   }
 
   public var parameters: Parameters {
@@ -112,19 +121,21 @@ public class TextInput: NSBox {
 extension TextInput {
   public struct Parameters: Equatable {
     public var textValue: String
+    public var placeholderString: String?
     public var onChangeTextValue: StringHandler
 
-    public init(textValue: String, onChangeTextValue: StringHandler = nil) {
+    public init(textValue: String, placeholderString: String? = nil, onChangeTextValue: StringHandler = nil) {
       self.textValue = textValue
+      self.placeholderString = placeholderString
       self.onChangeTextValue = onChangeTextValue
     }
 
     public init() {
-      self.init(textValue: "")
+      self.init(textValue: "", placeholderString: nil)
     }
 
     public static func ==(lhs: Parameters, rhs: Parameters) -> Bool {
-      return lhs.textValue == rhs.textValue
+      return lhs.textValue == rhs.textValue && lhs.placeholderString == rhs.placeholderString
     }
   }
 }
@@ -148,12 +159,14 @@ extension TextInput {
       self.parameters = parameters
     }
 
-    public init(textValue: String, onChangeTextValue: StringHandler = nil) {
-      self.init(Parameters(textValue: textValue, onChangeTextValue: onChangeTextValue))
+    public init(textValue: String, placeholderString: String? = nil, onChangeTextValue: StringHandler = nil) {
+      self
+        .init(
+          Parameters(textValue: textValue, placeholderString: placeholderString, onChangeTextValue: onChangeTextValue))
     }
 
     public init() {
-      self.init(textValue: "")
+      self.init(textValue: "", placeholderString: nil)
     }
   }
 }

--- a/studio/LonaStudio/Generated/ghosts/NumberInput.swift
+++ b/studio/LonaStudio/Generated/ghosts/NumberInput.swift
@@ -18,8 +18,8 @@ public class NumberInput: NSBox {
     update()
   }
 
-  public convenience init(numberValue: CGFloat) {
-    self.init(Parameters(numberValue: numberValue))
+  public convenience init(numberValue: CGFloat, disabled: Bool) {
+    self.init(Parameters(numberValue: numberValue, disabled: disabled))
   }
 
   public convenience init() {
@@ -51,6 +51,15 @@ public class NumberInput: NSBox {
   public var onChangeNumberValue: ((CGFloat) -> Void)? {
     get { return parameters.onChangeNumberValue }
     set { parameters.onChangeNumberValue = newValue }
+  }
+
+  public var disabled: Bool {
+    get { return parameters.disabled }
+    set {
+      if parameters.disabled != newValue {
+        parameters.disabled = newValue
+      }
+    }
   }
 
   public var parameters: Parameters {
@@ -110,19 +119,21 @@ public class NumberInput: NSBox {
 extension NumberInput {
   public struct Parameters: Equatable {
     public var numberValue: CGFloat
+    public var disabled: Bool
     public var onChangeNumberValue: ((CGFloat) -> Void)?
 
-    public init(numberValue: CGFloat, onChangeNumberValue: ((CGFloat) -> Void)? = nil) {
+    public init(numberValue: CGFloat, disabled: Bool, onChangeNumberValue: ((CGFloat) -> Void)? = nil) {
       self.numberValue = numberValue
+      self.disabled = disabled
       self.onChangeNumberValue = onChangeNumberValue
     }
 
     public init() {
-      self.init(numberValue: 0)
+      self.init(numberValue: 0, disabled: false)
     }
 
     public static func ==(lhs: Parameters, rhs: Parameters) -> Bool {
-      return lhs.numberValue == rhs.numberValue
+      return lhs.numberValue == rhs.numberValue && lhs.disabled == rhs.disabled
     }
   }
 }
@@ -146,12 +157,12 @@ extension NumberInput {
       self.parameters = parameters
     }
 
-    public init(numberValue: CGFloat, onChangeNumberValue: ((CGFloat) -> Void)? = nil) {
-      self.init(Parameters(numberValue: numberValue, onChangeNumberValue: onChangeNumberValue))
+    public init(numberValue: CGFloat, disabled: Bool, onChangeNumberValue: ((CGFloat) -> Void)? = nil) {
+      self.init(Parameters(numberValue: numberValue, disabled: disabled, onChangeNumberValue: onChangeNumberValue))
     }
 
     public init() {
-      self.init(numberValue: 0)
+      self.init(numberValue: 0, disabled: false)
     }
   }
 }

--- a/studio/LonaStudio/Generated/inspector/CanvasInspector.swift
+++ b/studio/LonaStudio/Generated/inspector/CanvasInspector.swift
@@ -789,7 +789,6 @@ public class CanvasInspector: NSBox {
     let customDimensionsContainerViewIsHidden = customDimensionsContainerView.isHidden
 
     layoutDropdownView.selectedIndex = 0
-    nameInputView.textValue = ""
     customDimensionsContainerView.isHidden = !showsDimensionInputs
     deviceDropdownView.values = availableDevices
     deviceDropdownView.selectedIndex = deviceIndex
@@ -804,9 +803,11 @@ public class CanvasInspector: NSBox {
     if heightMode == .fixedHeight {
       layoutDropdownView.selectedIndex = 1
     }
+    var intermediateCanvasName = ""
     if let canvasName = canvasName {
-      nameInputView.textValue = canvasName
+      intermediateCanvasName = canvasName
     }
+    nameInputView.textValue = intermediateCanvasName
     nameInputView.onChangeTextValue = handleOnChangeCanvasName
     heightInputView.onChangeNumberValue = handleOnChangeCanvasHeight
     widthInputView.onChangeNumberValue = handleOnChangeCanvasWidth

--- a/studio/LonaStudio/Generated/inspector/CanvasInspector.swift
+++ b/studio/LonaStudio/Generated/inspector/CanvasInspector.swift
@@ -177,6 +177,11 @@ public class CanvasInspector: NSBox {
     set { parameters.onChangeHeightModeIndex = newValue }
   }
 
+  public var onChangeBackgroundColorId: StringHandler {
+    get { return parameters.onChangeBackgroundColorId }
+    set { parameters.onChangeBackgroundColorId = newValue }
+  }
+
   public var parameters: Parameters {
     didSet {
       if parameters != oldValue {
@@ -681,6 +686,7 @@ public class CanvasInspector: NSBox {
     widthInputView.numberValue = canvasWidth
     heightInputView.numberValue = canvasHeight
     backgroundColorInputView.textValue = backgroundColorId
+    backgroundColorInputView.onChangeTextValue = handleOnChangeBackgroundColorId
     nameInputView.placeholderString = canvasNamePlaceholder
     if heightMode == .flexibleHeight {
       layoutDropdownView.selectedIndex = 0
@@ -718,6 +724,10 @@ public class CanvasInspector: NSBox {
   private func handleOnChangeHeightModeIndex(_ arg0: Int) {
     onChangeHeightModeIndex?(arg0)
   }
+
+  private func handleOnChangeBackgroundColorId(_ arg0: String) {
+    onChangeBackgroundColorId?(arg0)
+  }
 }
 
 // MARK: - Parameters
@@ -739,6 +749,7 @@ extension CanvasInspector {
     public var onChangeCanvasWidth: ((CGFloat) -> Void)?
     public var onChangeCanvasHeight: ((CGFloat) -> Void)?
     public var onChangeHeightModeIndex: ((Int) -> Void)?
+    public var onChangeBackgroundColorId: StringHandler
 
     public init(
       showsDimensionInputs: Bool,
@@ -755,7 +766,8 @@ extension CanvasInspector {
       onChangeCanvasName: StringHandler = nil,
       onChangeCanvasWidth: ((CGFloat) -> Void)? = nil,
       onChangeCanvasHeight: ((CGFloat) -> Void)? = nil,
-      onChangeHeightModeIndex: ((Int) -> Void)? = nil)
+      onChangeHeightModeIndex: ((Int) -> Void)? = nil,
+      onChangeBackgroundColorId: StringHandler = nil)
     {
       self.showsDimensionInputs = showsDimensionInputs
       self.availableDevices = availableDevices
@@ -772,6 +784,7 @@ extension CanvasInspector {
       self.onChangeCanvasWidth = onChangeCanvasWidth
       self.onChangeCanvasHeight = onChangeCanvasHeight
       self.onChangeHeightModeIndex = onChangeHeightModeIndex
+      self.onChangeBackgroundColorId = onChangeBackgroundColorId
     }
 
     public init() {
@@ -838,7 +851,8 @@ extension CanvasInspector {
       onChangeCanvasName: StringHandler = nil,
       onChangeCanvasWidth: ((CGFloat) -> Void)? = nil,
       onChangeCanvasHeight: ((CGFloat) -> Void)? = nil,
-      onChangeHeightModeIndex: ((Int) -> Void)? = nil)
+      onChangeHeightModeIndex: ((Int) -> Void)? = nil,
+      onChangeBackgroundColorId: StringHandler = nil)
     {
       self
         .init(
@@ -857,7 +871,8 @@ extension CanvasInspector {
             onChangeCanvasName: onChangeCanvasName,
             onChangeCanvasWidth: onChangeCanvasWidth,
             onChangeCanvasHeight: onChangeCanvasHeight,
-            onChangeHeightModeIndex: onChangeHeightModeIndex))
+            onChangeHeightModeIndex: onChangeHeightModeIndex,
+            onChangeBackgroundColorId: onChangeBackgroundColorId))
     }
 
     public init() {

--- a/studio/LonaStudio/Generated/inspector/CanvasInspector.swift
+++ b/studio/LonaStudio/Generated/inspector/CanvasInspector.swift
@@ -1,0 +1,572 @@
+import AppKit
+import Foundation
+
+// MARK: - CanvasInspector
+
+public class CanvasInspector: NSBox {
+
+  // MARK: Lifecycle
+
+  public init(_ parameters: Parameters) {
+    self.parameters = parameters
+
+    super.init(frame: .zero)
+
+    setUpViews()
+    setUpConstraints()
+
+    update()
+  }
+
+  public convenience init() {
+    self.init(Parameters())
+  }
+
+  public required init?(coder aDecoder: NSCoder) {
+    self.parameters = Parameters()
+
+    super.init(coder: aDecoder)
+
+    setUpViews()
+    setUpConstraints()
+
+    update()
+  }
+
+  // MARK: Public
+
+  public var parameters: Parameters {
+    didSet {
+      if parameters != oldValue {
+        update()
+      }
+    }
+  }
+
+  // MARK: Private
+
+  private var presetRowView = NSBox()
+  private var presetLabelView = LNATextField(labelWithString: "")
+  private var presetDropdownView = ControlledDropdown()
+  private var deviceRowView = NSBox()
+  private var deviceLabelView = LNATextField(labelWithString: "")
+  private var deviceValueContainerView = NSBox()
+  private var deviceDropdownView = ControlledDropdown()
+  private var customDimensionsContainerView = NSBox()
+  private var widthContainerView = NSBox()
+  private var widthLabelView = LNATextField(labelWithString: "")
+  private var widthInputView = NumberInput()
+  private var hSpacerView = NSBox()
+  private var heightContainerView = NSBox()
+  private var heightLabelView = LNATextField(labelWithString: "")
+  private var heightInputView = NumberInput()
+  private var nameRowView = NSBox()
+  private var nameLabelView = LNATextField(labelWithString: "")
+  private var nameInputView = TextInput()
+  private var backgroundColorRowView = NSBox()
+  private var backgroundColorLabelView = LNATextField(labelWithString: "")
+  private var backgroundColorInputView = TextInput()
+
+  private var presetLabelViewTextStyle = TextStyles.regular
+  private var deviceLabelViewTextStyle = TextStyles.regular
+  private var widthLabelViewTextStyle = TextStyles.regular
+  private var heightLabelViewTextStyle = TextStyles.regular
+  private var nameLabelViewTextStyle = TextStyles.regular
+  private var backgroundColorLabelViewTextStyle = TextStyles.regular
+
+  private func setUpViews() {
+    boxType = .custom
+    borderType = .noBorder
+    contentViewMargins = .zero
+    presetRowView.boxType = .custom
+    presetRowView.borderType = .noBorder
+    presetRowView.contentViewMargins = .zero
+    deviceRowView.boxType = .custom
+    deviceRowView.borderType = .noBorder
+    deviceRowView.contentViewMargins = .zero
+    nameRowView.boxType = .custom
+    nameRowView.borderType = .noBorder
+    nameRowView.contentViewMargins = .zero
+    backgroundColorRowView.boxType = .custom
+    backgroundColorRowView.borderType = .noBorder
+    backgroundColorRowView.contentViewMargins = .zero
+    presetLabelView.lineBreakMode = .byWordWrapping
+    deviceLabelView.lineBreakMode = .byWordWrapping
+    deviceValueContainerView.boxType = .custom
+    deviceValueContainerView.borderType = .noBorder
+    deviceValueContainerView.contentViewMargins = .zero
+    customDimensionsContainerView.boxType = .custom
+    customDimensionsContainerView.borderType = .noBorder
+    customDimensionsContainerView.contentViewMargins = .zero
+    widthContainerView.boxType = .custom
+    widthContainerView.borderType = .noBorder
+    widthContainerView.contentViewMargins = .zero
+    hSpacerView.boxType = .custom
+    hSpacerView.borderType = .noBorder
+    hSpacerView.contentViewMargins = .zero
+    heightContainerView.boxType = .custom
+    heightContainerView.borderType = .noBorder
+    heightContainerView.contentViewMargins = .zero
+    widthLabelView.lineBreakMode = .byWordWrapping
+    heightLabelView.lineBreakMode = .byWordWrapping
+    nameLabelView.lineBreakMode = .byWordWrapping
+    backgroundColorLabelView.lineBreakMode = .byWordWrapping
+
+    addSubview(presetRowView)
+    addSubview(deviceRowView)
+    addSubview(nameRowView)
+    addSubview(backgroundColorRowView)
+    presetRowView.addSubview(presetLabelView)
+    presetRowView.addSubview(presetDropdownView)
+    deviceRowView.addSubview(deviceLabelView)
+    deviceRowView.addSubview(deviceValueContainerView)
+    deviceValueContainerView.addSubview(deviceDropdownView)
+    deviceValueContainerView.addSubview(customDimensionsContainerView)
+    customDimensionsContainerView.addSubview(widthContainerView)
+    customDimensionsContainerView.addSubview(hSpacerView)
+    customDimensionsContainerView.addSubview(heightContainerView)
+    widthContainerView.addSubview(widthLabelView)
+    widthContainerView.addSubview(widthInputView)
+    heightContainerView.addSubview(heightLabelView)
+    heightContainerView.addSubview(heightInputView)
+    nameRowView.addSubview(nameLabelView)
+    nameRowView.addSubview(nameInputView)
+    backgroundColorRowView.addSubview(backgroundColorLabelView)
+    backgroundColorRowView.addSubview(backgroundColorInputView)
+
+    presetLabelView.attributedStringValue = presetLabelViewTextStyle.apply(to: "Preset")
+    presetDropdownView.selectedIndex = 0
+    presetDropdownView.values = ["Component (Flexible-height)", "Screen (Fixed-height)"]
+    deviceLabelView.attributedStringValue = deviceLabelViewTextStyle.apply(to: "Device")
+    deviceDropdownView.selectedIndex = 0
+    deviceDropdownView.values = []
+    widthLabelView.attributedStringValue = widthLabelViewTextStyle.apply(to: "Width")
+    widthInputView.numberValue = 0
+    heightLabelView.attributedStringValue = heightLabelViewTextStyle.apply(to: "Height")
+    heightInputView.numberValue = 0
+    nameLabelView.attributedStringValue = nameLabelViewTextStyle.apply(to: "Name")
+    nameInputView.textValue = "Text"
+    backgroundColorLabelView.attributedStringValue = backgroundColorLabelViewTextStyle.apply(to: "Background")
+    backgroundColorInputView.textValue = "Text"
+  }
+
+  private func setUpConstraints() {
+    translatesAutoresizingMaskIntoConstraints = false
+    presetRowView.translatesAutoresizingMaskIntoConstraints = false
+    deviceRowView.translatesAutoresizingMaskIntoConstraints = false
+    nameRowView.translatesAutoresizingMaskIntoConstraints = false
+    backgroundColorRowView.translatesAutoresizingMaskIntoConstraints = false
+    presetLabelView.translatesAutoresizingMaskIntoConstraints = false
+    presetDropdownView.translatesAutoresizingMaskIntoConstraints = false
+    deviceLabelView.translatesAutoresizingMaskIntoConstraints = false
+    deviceValueContainerView.translatesAutoresizingMaskIntoConstraints = false
+    deviceDropdownView.translatesAutoresizingMaskIntoConstraints = false
+    customDimensionsContainerView.translatesAutoresizingMaskIntoConstraints = false
+    widthContainerView.translatesAutoresizingMaskIntoConstraints = false
+    hSpacerView.translatesAutoresizingMaskIntoConstraints = false
+    heightContainerView.translatesAutoresizingMaskIntoConstraints = false
+    widthLabelView.translatesAutoresizingMaskIntoConstraints = false
+    widthInputView.translatesAutoresizingMaskIntoConstraints = false
+    heightLabelView.translatesAutoresizingMaskIntoConstraints = false
+    heightInputView.translatesAutoresizingMaskIntoConstraints = false
+    nameLabelView.translatesAutoresizingMaskIntoConstraints = false
+    nameInputView.translatesAutoresizingMaskIntoConstraints = false
+    backgroundColorLabelView.translatesAutoresizingMaskIntoConstraints = false
+    backgroundColorInputView.translatesAutoresizingMaskIntoConstraints = false
+
+    let presetRowViewTopAnchorConstraint = presetRowView.topAnchor.constraint(equalTo: topAnchor, constant: 16)
+    let presetRowViewLeadingAnchorConstraint = presetRowView.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let presetRowViewTrailingAnchorConstraint = presetRowView.trailingAnchor.constraint(equalTo: trailingAnchor)
+    let deviceRowViewTopAnchorConstraint = deviceRowView
+      .topAnchor
+      .constraint(equalTo: presetRowView.bottomAnchor, constant: 16)
+    let deviceRowViewLeadingAnchorConstraint = deviceRowView.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let deviceRowViewTrailingAnchorConstraint = deviceRowView.trailingAnchor.constraint(equalTo: trailingAnchor)
+    let nameRowViewTopAnchorConstraint = nameRowView
+      .topAnchor
+      .constraint(equalTo: deviceRowView.bottomAnchor, constant: 16)
+    let nameRowViewLeadingAnchorConstraint = nameRowView.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let nameRowViewTrailingAnchorConstraint = nameRowView.trailingAnchor.constraint(equalTo: trailingAnchor)
+    let backgroundColorRowViewBottomAnchorConstraint = backgroundColorRowView
+      .bottomAnchor
+      .constraint(equalTo: bottomAnchor, constant: -16)
+    let backgroundColorRowViewTopAnchorConstraint = backgroundColorRowView
+      .topAnchor
+      .constraint(equalTo: nameRowView.bottomAnchor, constant: 16)
+    let backgroundColorRowViewLeadingAnchorConstraint = backgroundColorRowView
+      .leadingAnchor
+      .constraint(equalTo: leadingAnchor)
+    let backgroundColorRowViewTrailingAnchorConstraint = backgroundColorRowView
+      .trailingAnchor
+      .constraint(equalTo: trailingAnchor)
+    let presetLabelViewHeightAnchorParentConstraint = presetLabelView
+      .heightAnchor
+      .constraint(lessThanOrEqualTo: presetRowView.heightAnchor)
+    let presetDropdownViewHeightAnchorParentConstraint = presetDropdownView
+      .heightAnchor
+      .constraint(lessThanOrEqualTo: presetRowView.heightAnchor)
+    let presetLabelViewLeadingAnchorConstraint = presetLabelView
+      .leadingAnchor
+      .constraint(equalTo: presetRowView.leadingAnchor)
+    let presetLabelViewTopAnchorConstraint = presetLabelView.topAnchor.constraint(equalTo: presetRowView.topAnchor)
+    let presetLabelViewCenterYAnchorConstraint = presetLabelView
+      .centerYAnchor
+      .constraint(equalTo: presetRowView.centerYAnchor)
+    let presetLabelViewBottomAnchorConstraint = presetLabelView
+      .bottomAnchor
+      .constraint(equalTo: presetRowView.bottomAnchor)
+    let presetDropdownViewTrailingAnchorConstraint = presetDropdownView
+      .trailingAnchor
+      .constraint(equalTo: presetRowView.trailingAnchor)
+    let presetDropdownViewLeadingAnchorConstraint = presetDropdownView
+      .leadingAnchor
+      .constraint(equalTo: presetLabelView.trailingAnchor, constant: 20)
+    let presetDropdownViewTopAnchorConstraint = presetDropdownView
+      .topAnchor
+      .constraint(equalTo: presetRowView.topAnchor)
+    let presetDropdownViewCenterYAnchorConstraint = presetDropdownView
+      .centerYAnchor
+      .constraint(equalTo: presetRowView.centerYAnchor)
+    let presetDropdownViewBottomAnchorConstraint = presetDropdownView
+      .bottomAnchor
+      .constraint(equalTo: presetRowView.bottomAnchor)
+    let deviceLabelViewHeightAnchorParentConstraint = deviceLabelView
+      .heightAnchor
+      .constraint(lessThanOrEqualTo: deviceRowView.heightAnchor, constant: -4)
+    let deviceValueContainerViewHeightAnchorParentConstraint = deviceValueContainerView
+      .heightAnchor
+      .constraint(lessThanOrEqualTo: deviceRowView.heightAnchor)
+    let deviceLabelViewLeadingAnchorConstraint = deviceLabelView
+      .leadingAnchor
+      .constraint(equalTo: deviceRowView.leadingAnchor)
+    let deviceLabelViewTopAnchorConstraint = deviceLabelView
+      .topAnchor
+      .constraint(equalTo: deviceRowView.topAnchor, constant: 4)
+    let deviceLabelViewBottomAnchorConstraint = deviceLabelView
+      .bottomAnchor
+      .constraint(equalTo: deviceRowView.bottomAnchor)
+    let deviceValueContainerViewTrailingAnchorConstraint = deviceValueContainerView
+      .trailingAnchor
+      .constraint(equalTo: deviceRowView.trailingAnchor)
+    let deviceValueContainerViewLeadingAnchorConstraint = deviceValueContainerView
+      .leadingAnchor
+      .constraint(equalTo: deviceLabelView.trailingAnchor, constant: 20)
+    let deviceValueContainerViewTopAnchorConstraint = deviceValueContainerView
+      .topAnchor
+      .constraint(equalTo: deviceRowView.topAnchor)
+    let deviceValueContainerViewBottomAnchorConstraint = deviceValueContainerView
+      .bottomAnchor
+      .constraint(equalTo: deviceRowView.bottomAnchor)
+    let nameLabelViewHeightAnchorParentConstraint = nameLabelView
+      .heightAnchor
+      .constraint(lessThanOrEqualTo: nameRowView.heightAnchor)
+    let nameInputViewHeightAnchorParentConstraint = nameInputView
+      .heightAnchor
+      .constraint(lessThanOrEqualTo: nameRowView.heightAnchor)
+    let nameLabelViewLeadingAnchorConstraint = nameLabelView
+      .leadingAnchor
+      .constraint(equalTo: nameRowView.leadingAnchor)
+    let nameLabelViewTopAnchorConstraint = nameLabelView.topAnchor.constraint(equalTo: nameRowView.topAnchor)
+    let nameLabelViewCenterYAnchorConstraint = nameLabelView
+      .centerYAnchor
+      .constraint(equalTo: nameRowView.centerYAnchor)
+    let nameLabelViewBottomAnchorConstraint = nameLabelView.bottomAnchor.constraint(equalTo: nameRowView.bottomAnchor)
+    let nameInputViewTrailingAnchorConstraint = nameInputView
+      .trailingAnchor
+      .constraint(equalTo: nameRowView.trailingAnchor)
+    let nameInputViewLeadingAnchorConstraint = nameInputView
+      .leadingAnchor
+      .constraint(equalTo: nameLabelView.trailingAnchor, constant: 20)
+    let nameInputViewTopAnchorConstraint = nameInputView.topAnchor.constraint(equalTo: nameRowView.topAnchor)
+    let nameInputViewCenterYAnchorConstraint = nameInputView
+      .centerYAnchor
+      .constraint(equalTo: nameRowView.centerYAnchor)
+    let nameInputViewBottomAnchorConstraint = nameInputView.bottomAnchor.constraint(equalTo: nameRowView.bottomAnchor)
+    let backgroundColorLabelViewHeightAnchorParentConstraint = backgroundColorLabelView
+      .heightAnchor
+      .constraint(lessThanOrEqualTo: backgroundColorRowView.heightAnchor)
+    let backgroundColorInputViewHeightAnchorParentConstraint = backgroundColorInputView
+      .heightAnchor
+      .constraint(lessThanOrEqualTo: backgroundColorRowView.heightAnchor)
+    let backgroundColorLabelViewLeadingAnchorConstraint = backgroundColorLabelView
+      .leadingAnchor
+      .constraint(equalTo: backgroundColorRowView.leadingAnchor)
+    let backgroundColorLabelViewTopAnchorConstraint = backgroundColorLabelView
+      .topAnchor
+      .constraint(equalTo: backgroundColorRowView.topAnchor)
+    let backgroundColorLabelViewCenterYAnchorConstraint = backgroundColorLabelView
+      .centerYAnchor
+      .constraint(equalTo: backgroundColorRowView.centerYAnchor)
+    let backgroundColorLabelViewBottomAnchorConstraint = backgroundColorLabelView
+      .bottomAnchor
+      .constraint(equalTo: backgroundColorRowView.bottomAnchor)
+    let backgroundColorInputViewTrailingAnchorConstraint = backgroundColorInputView
+      .trailingAnchor
+      .constraint(equalTo: backgroundColorRowView.trailingAnchor)
+    let backgroundColorInputViewLeadingAnchorConstraint = backgroundColorInputView
+      .leadingAnchor
+      .constraint(equalTo: backgroundColorLabelView.trailingAnchor, constant: 20)
+    let backgroundColorInputViewTopAnchorConstraint = backgroundColorInputView
+      .topAnchor
+      .constraint(equalTo: backgroundColorRowView.topAnchor)
+    let backgroundColorInputViewCenterYAnchorConstraint = backgroundColorInputView
+      .centerYAnchor
+      .constraint(equalTo: backgroundColorRowView.centerYAnchor)
+    let backgroundColorInputViewBottomAnchorConstraint = backgroundColorInputView
+      .bottomAnchor
+      .constraint(equalTo: backgroundColorRowView.bottomAnchor)
+    let presetLabelViewWidthAnchorConstraint = presetLabelView.widthAnchor.constraint(equalToConstant: 80)
+    let deviceLabelViewWidthAnchorConstraint = deviceLabelView.widthAnchor.constraint(equalToConstant: 80)
+    let deviceDropdownViewTopAnchorConstraint = deviceDropdownView
+      .topAnchor
+      .constraint(equalTo: deviceValueContainerView.topAnchor)
+    let deviceDropdownViewLeadingAnchorConstraint = deviceDropdownView
+      .leadingAnchor
+      .constraint(equalTo: deviceValueContainerView.leadingAnchor)
+    let deviceDropdownViewTrailingAnchorConstraint = deviceDropdownView
+      .trailingAnchor
+      .constraint(equalTo: deviceValueContainerView.trailingAnchor)
+    let customDimensionsContainerViewBottomAnchorConstraint = customDimensionsContainerView
+      .bottomAnchor
+      .constraint(equalTo: deviceValueContainerView.bottomAnchor)
+    let customDimensionsContainerViewTopAnchorConstraint = customDimensionsContainerView
+      .topAnchor
+      .constraint(equalTo: deviceDropdownView.bottomAnchor, constant: 16)
+    let customDimensionsContainerViewLeadingAnchorConstraint = customDimensionsContainerView
+      .leadingAnchor
+      .constraint(equalTo: deviceValueContainerView.leadingAnchor)
+    let customDimensionsContainerViewTrailingAnchorConstraint = customDimensionsContainerView
+      .trailingAnchor
+      .constraint(equalTo: deviceValueContainerView.trailingAnchor)
+    let widthContainerViewHeightContainerViewWidthAnchorSiblingConstraint = widthContainerView
+      .widthAnchor
+      .constraint(equalTo: heightContainerView.widthAnchor)
+    let widthContainerViewHeightAnchorParentConstraint = widthContainerView
+      .heightAnchor
+      .constraint(lessThanOrEqualTo: customDimensionsContainerView.heightAnchor)
+    let hSpacerViewHeightAnchorParentConstraint = hSpacerView
+      .heightAnchor
+      .constraint(lessThanOrEqualTo: customDimensionsContainerView.heightAnchor)
+    let heightContainerViewHeightAnchorParentConstraint = heightContainerView
+      .heightAnchor
+      .constraint(lessThanOrEqualTo: customDimensionsContainerView.heightAnchor)
+    let widthContainerViewLeadingAnchorConstraint = widthContainerView
+      .leadingAnchor
+      .constraint(equalTo: customDimensionsContainerView.leadingAnchor)
+    let widthContainerViewTopAnchorConstraint = widthContainerView
+      .topAnchor
+      .constraint(equalTo: customDimensionsContainerView.topAnchor)
+    let widthContainerViewBottomAnchorConstraint = widthContainerView
+      .bottomAnchor
+      .constraint(equalTo: customDimensionsContainerView.bottomAnchor)
+    let hSpacerViewLeadingAnchorConstraint = hSpacerView
+      .leadingAnchor
+      .constraint(equalTo: widthContainerView.trailingAnchor)
+    let hSpacerViewTopAnchorConstraint = hSpacerView
+      .topAnchor
+      .constraint(equalTo: customDimensionsContainerView.topAnchor)
+    let heightContainerViewTrailingAnchorConstraint = heightContainerView
+      .trailingAnchor
+      .constraint(equalTo: customDimensionsContainerView.trailingAnchor)
+    let heightContainerViewLeadingAnchorConstraint = heightContainerView
+      .leadingAnchor
+      .constraint(equalTo: hSpacerView.trailingAnchor)
+    let heightContainerViewTopAnchorConstraint = heightContainerView
+      .topAnchor
+      .constraint(equalTo: customDimensionsContainerView.topAnchor)
+    let heightContainerViewBottomAnchorConstraint = heightContainerView
+      .bottomAnchor
+      .constraint(equalTo: customDimensionsContainerView.bottomAnchor)
+    let widthLabelViewTopAnchorConstraint = widthLabelView.topAnchor.constraint(equalTo: widthContainerView.topAnchor)
+    let widthLabelViewLeadingAnchorConstraint = widthLabelView
+      .leadingAnchor
+      .constraint(equalTo: widthContainerView.leadingAnchor)
+    let widthLabelViewTrailingAnchorConstraint = widthLabelView
+      .trailingAnchor
+      .constraint(equalTo: widthContainerView.trailingAnchor)
+    let widthInputViewBottomAnchorConstraint = widthInputView
+      .bottomAnchor
+      .constraint(equalTo: widthContainerView.bottomAnchor)
+    let widthInputViewTopAnchorConstraint = widthInputView
+      .topAnchor
+      .constraint(equalTo: widthLabelView.bottomAnchor, constant: 8)
+    let widthInputViewLeadingAnchorConstraint = widthInputView
+      .leadingAnchor
+      .constraint(equalTo: widthContainerView.leadingAnchor)
+    let widthInputViewTrailingAnchorConstraint = widthInputView
+      .trailingAnchor
+      .constraint(equalTo: widthContainerView.trailingAnchor)
+    let hSpacerViewHeightAnchorConstraint = hSpacerView.heightAnchor.constraint(equalToConstant: 0)
+    let hSpacerViewWidthAnchorConstraint = hSpacerView.widthAnchor.constraint(equalToConstant: 20)
+    let heightLabelViewTopAnchorConstraint = heightLabelView
+      .topAnchor
+      .constraint(equalTo: heightContainerView.topAnchor)
+    let heightLabelViewLeadingAnchorConstraint = heightLabelView
+      .leadingAnchor
+      .constraint(equalTo: heightContainerView.leadingAnchor)
+    let heightLabelViewTrailingAnchorConstraint = heightLabelView
+      .trailingAnchor
+      .constraint(equalTo: heightContainerView.trailingAnchor)
+    let heightInputViewBottomAnchorConstraint = heightInputView
+      .bottomAnchor
+      .constraint(equalTo: heightContainerView.bottomAnchor)
+    let heightInputViewTopAnchorConstraint = heightInputView
+      .topAnchor
+      .constraint(equalTo: heightLabelView.bottomAnchor, constant: 8)
+    let heightInputViewLeadingAnchorConstraint = heightInputView
+      .leadingAnchor
+      .constraint(equalTo: heightContainerView.leadingAnchor)
+    let heightInputViewTrailingAnchorConstraint = heightInputView
+      .trailingAnchor
+      .constraint(equalTo: heightContainerView.trailingAnchor)
+    let nameLabelViewWidthAnchorConstraint = nameLabelView.widthAnchor.constraint(equalToConstant: 80)
+    let backgroundColorLabelViewWidthAnchorConstraint = backgroundColorLabelView
+      .widthAnchor
+      .constraint(equalToConstant: 80)
+
+    presetLabelViewHeightAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
+    presetDropdownViewHeightAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
+    deviceLabelViewHeightAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
+    deviceValueContainerViewHeightAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
+    nameLabelViewHeightAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
+    nameInputViewHeightAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
+    backgroundColorLabelViewHeightAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
+    backgroundColorInputViewHeightAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
+    widthContainerViewHeightAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
+    hSpacerViewHeightAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
+    heightContainerViewHeightAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
+
+    NSLayoutConstraint.activate([
+      presetRowViewTopAnchorConstraint,
+      presetRowViewLeadingAnchorConstraint,
+      presetRowViewTrailingAnchorConstraint,
+      deviceRowViewTopAnchorConstraint,
+      deviceRowViewLeadingAnchorConstraint,
+      deviceRowViewTrailingAnchorConstraint,
+      nameRowViewTopAnchorConstraint,
+      nameRowViewLeadingAnchorConstraint,
+      nameRowViewTrailingAnchorConstraint,
+      backgroundColorRowViewBottomAnchorConstraint,
+      backgroundColorRowViewTopAnchorConstraint,
+      backgroundColorRowViewLeadingAnchorConstraint,
+      backgroundColorRowViewTrailingAnchorConstraint,
+      presetLabelViewHeightAnchorParentConstraint,
+      presetDropdownViewHeightAnchorParentConstraint,
+      presetLabelViewLeadingAnchorConstraint,
+      presetLabelViewTopAnchorConstraint,
+      presetLabelViewCenterYAnchorConstraint,
+      presetLabelViewBottomAnchorConstraint,
+      presetDropdownViewTrailingAnchorConstraint,
+      presetDropdownViewLeadingAnchorConstraint,
+      presetDropdownViewTopAnchorConstraint,
+      presetDropdownViewCenterYAnchorConstraint,
+      presetDropdownViewBottomAnchorConstraint,
+      deviceLabelViewHeightAnchorParentConstraint,
+      deviceValueContainerViewHeightAnchorParentConstraint,
+      deviceLabelViewLeadingAnchorConstraint,
+      deviceLabelViewTopAnchorConstraint,
+      deviceLabelViewBottomAnchorConstraint,
+      deviceValueContainerViewTrailingAnchorConstraint,
+      deviceValueContainerViewLeadingAnchorConstraint,
+      deviceValueContainerViewTopAnchorConstraint,
+      deviceValueContainerViewBottomAnchorConstraint,
+      nameLabelViewHeightAnchorParentConstraint,
+      nameInputViewHeightAnchorParentConstraint,
+      nameLabelViewLeadingAnchorConstraint,
+      nameLabelViewTopAnchorConstraint,
+      nameLabelViewCenterYAnchorConstraint,
+      nameLabelViewBottomAnchorConstraint,
+      nameInputViewTrailingAnchorConstraint,
+      nameInputViewLeadingAnchorConstraint,
+      nameInputViewTopAnchorConstraint,
+      nameInputViewCenterYAnchorConstraint,
+      nameInputViewBottomAnchorConstraint,
+      backgroundColorLabelViewHeightAnchorParentConstraint,
+      backgroundColorInputViewHeightAnchorParentConstraint,
+      backgroundColorLabelViewLeadingAnchorConstraint,
+      backgroundColorLabelViewTopAnchorConstraint,
+      backgroundColorLabelViewCenterYAnchorConstraint,
+      backgroundColorLabelViewBottomAnchorConstraint,
+      backgroundColorInputViewTrailingAnchorConstraint,
+      backgroundColorInputViewLeadingAnchorConstraint,
+      backgroundColorInputViewTopAnchorConstraint,
+      backgroundColorInputViewCenterYAnchorConstraint,
+      backgroundColorInputViewBottomAnchorConstraint,
+      presetLabelViewWidthAnchorConstraint,
+      deviceLabelViewWidthAnchorConstraint,
+      deviceDropdownViewTopAnchorConstraint,
+      deviceDropdownViewLeadingAnchorConstraint,
+      deviceDropdownViewTrailingAnchorConstraint,
+      customDimensionsContainerViewBottomAnchorConstraint,
+      customDimensionsContainerViewTopAnchorConstraint,
+      customDimensionsContainerViewLeadingAnchorConstraint,
+      customDimensionsContainerViewTrailingAnchorConstraint,
+      widthContainerViewHeightContainerViewWidthAnchorSiblingConstraint,
+      widthContainerViewHeightAnchorParentConstraint,
+      hSpacerViewHeightAnchorParentConstraint,
+      heightContainerViewHeightAnchorParentConstraint,
+      widthContainerViewLeadingAnchorConstraint,
+      widthContainerViewTopAnchorConstraint,
+      widthContainerViewBottomAnchorConstraint,
+      hSpacerViewLeadingAnchorConstraint,
+      hSpacerViewTopAnchorConstraint,
+      heightContainerViewTrailingAnchorConstraint,
+      heightContainerViewLeadingAnchorConstraint,
+      heightContainerViewTopAnchorConstraint,
+      heightContainerViewBottomAnchorConstraint,
+      widthLabelViewTopAnchorConstraint,
+      widthLabelViewLeadingAnchorConstraint,
+      widthLabelViewTrailingAnchorConstraint,
+      widthInputViewBottomAnchorConstraint,
+      widthInputViewTopAnchorConstraint,
+      widthInputViewLeadingAnchorConstraint,
+      widthInputViewTrailingAnchorConstraint,
+      hSpacerViewHeightAnchorConstraint,
+      hSpacerViewWidthAnchorConstraint,
+      heightLabelViewTopAnchorConstraint,
+      heightLabelViewLeadingAnchorConstraint,
+      heightLabelViewTrailingAnchorConstraint,
+      heightInputViewBottomAnchorConstraint,
+      heightInputViewTopAnchorConstraint,
+      heightInputViewLeadingAnchorConstraint,
+      heightInputViewTrailingAnchorConstraint,
+      nameLabelViewWidthAnchorConstraint,
+      backgroundColorLabelViewWidthAnchorConstraint
+    ])
+  }
+
+  private func update() {}
+}
+
+// MARK: - Parameters
+
+extension CanvasInspector {
+  public struct Parameters: Equatable {
+    public init() {}
+  }
+}
+
+// MARK: - Model
+
+extension CanvasInspector {
+  public struct Model: LonaViewModel, Equatable {
+    public var id: String?
+    public var parameters: Parameters
+    public var type: String {
+      return "CanvasInspector"
+    }
+
+    public init(id: String? = nil, parameters: Parameters) {
+      self.id = id
+      self.parameters = parameters
+    }
+
+    public init(_ parameters: Parameters) {
+      self.parameters = parameters
+    }
+
+    public init() {
+      self.init(Parameters())
+    }
+  }
+}

--- a/studio/LonaStudio/Generated/inspector/CanvasInspector.swift
+++ b/studio/LonaStudio/Generated/inspector/CanvasInspector.swift
@@ -18,6 +18,27 @@ public class CanvasInspector: NSBox {
     update()
   }
 
+  public convenience init(
+    showsDimensionInputs: Bool,
+    heightMode: CanvasHeight,
+    devicePreset: String,
+    canvasHeight: CGFloat,
+    canvasWidth: CGFloat,
+    canvasName: String?,
+    backgroundColorId: String)
+  {
+    self
+      .init(
+        Parameters(
+          showsDimensionInputs: showsDimensionInputs,
+          heightMode: heightMode,
+          devicePreset: devicePreset,
+          canvasHeight: canvasHeight,
+          canvasWidth: canvasWidth,
+          canvasName: canvasName,
+          backgroundColorId: backgroundColorId))
+  }
+
   public convenience init() {
     self.init(Parameters())
   }
@@ -35,6 +56,69 @@ public class CanvasInspector: NSBox {
 
   // MARK: Public
 
+  public var showsDimensionInputs: Bool {
+    get { return parameters.showsDimensionInputs }
+    set {
+      if parameters.showsDimensionInputs != newValue {
+        parameters.showsDimensionInputs = newValue
+      }
+    }
+  }
+
+  public var heightMode: CanvasHeight {
+    get { return parameters.heightMode }
+    set {
+      if parameters.heightMode != newValue {
+        parameters.heightMode = newValue
+      }
+    }
+  }
+
+  public var devicePreset: String {
+    get { return parameters.devicePreset }
+    set {
+      if parameters.devicePreset != newValue {
+        parameters.devicePreset = newValue
+      }
+    }
+  }
+
+  public var canvasHeight: CGFloat {
+    get { return parameters.canvasHeight }
+    set {
+      if parameters.canvasHeight != newValue {
+        parameters.canvasHeight = newValue
+      }
+    }
+  }
+
+  public var canvasWidth: CGFloat {
+    get { return parameters.canvasWidth }
+    set {
+      if parameters.canvasWidth != newValue {
+        parameters.canvasWidth = newValue
+      }
+    }
+  }
+
+  public var canvasName: String? {
+    get { return parameters.canvasName }
+    set {
+      if parameters.canvasName != newValue {
+        parameters.canvasName = newValue
+      }
+    }
+  }
+
+  public var backgroundColorId: String {
+    get { return parameters.backgroundColorId }
+    set {
+      if parameters.backgroundColorId != newValue {
+        parameters.backgroundColorId = newValue
+      }
+    }
+  }
+
   public var parameters: Parameters {
     didSet {
       if parameters != oldValue {
@@ -45,9 +129,9 @@ public class CanvasInspector: NSBox {
 
   // MARK: Private
 
-  private var presetRowView = NSBox()
-  private var presetLabelView = LNATextField(labelWithString: "")
-  private var presetDropdownView = ControlledDropdown()
+  private var layoutRowView = NSBox()
+  private var layoutLabelView = LNATextField(labelWithString: "")
+  private var layoutDropdownView = ControlledDropdown()
   private var deviceRowView = NSBox()
   private var deviceLabelView = LNATextField(labelWithString: "")
   private var deviceValueContainerView = NSBox()
@@ -67,20 +151,55 @@ public class CanvasInspector: NSBox {
   private var backgroundColorLabelView = LNATextField(labelWithString: "")
   private var backgroundColorInputView = TextInput()
 
-  private var presetLabelViewTextStyle = TextStyles.regular
+  private var layoutLabelViewTextStyle = TextStyles.regular
   private var deviceLabelViewTextStyle = TextStyles.regular
   private var widthLabelViewTextStyle = TextStyles.regular
   private var heightLabelViewTextStyle = TextStyles.regular
   private var nameLabelViewTextStyle = TextStyles.regular
   private var backgroundColorLabelViewTextStyle = TextStyles.regular
 
+  private var deviceDropdownViewBottomAnchorDeviceValueContainerViewBottomAnchorConstraint: NSLayoutConstraint?
+  private var customDimensionsContainerViewBottomAnchorDeviceValueContainerViewBottomAnchorConstraint: NSLayoutConstraint?
+  private var customDimensionsContainerViewTopAnchorDeviceDropdownViewBottomAnchorConstraint: NSLayoutConstraint?
+  private var customDimensionsContainerViewLeadingAnchorDeviceValueContainerViewLeadingAnchorConstraint: NSLayoutConstraint?
+  private var customDimensionsContainerViewTrailingAnchorDeviceValueContainerViewTrailingAnchorConstraint: NSLayoutConstraint?
+  private var widthContainerViewHeightContainerViewWidthAnchorSiblingConstraint: NSLayoutConstraint?
+  private var widthContainerViewHeightAnchorParentConstraint: NSLayoutConstraint?
+  private var hSpacerViewHeightAnchorParentConstraint: NSLayoutConstraint?
+  private var heightContainerViewHeightAnchorParentConstraint: NSLayoutConstraint?
+  private var widthContainerViewLeadingAnchorCustomDimensionsContainerViewLeadingAnchorConstraint: NSLayoutConstraint?
+  private var widthContainerViewTopAnchorCustomDimensionsContainerViewTopAnchorConstraint: NSLayoutConstraint?
+  private var widthContainerViewBottomAnchorCustomDimensionsContainerViewBottomAnchorConstraint: NSLayoutConstraint?
+  private var hSpacerViewLeadingAnchorWidthContainerViewTrailingAnchorConstraint: NSLayoutConstraint?
+  private var hSpacerViewTopAnchorCustomDimensionsContainerViewTopAnchorConstraint: NSLayoutConstraint?
+  private var heightContainerViewTrailingAnchorCustomDimensionsContainerViewTrailingAnchorConstraint: NSLayoutConstraint?
+  private var heightContainerViewLeadingAnchorHSpacerViewTrailingAnchorConstraint: NSLayoutConstraint?
+  private var heightContainerViewTopAnchorCustomDimensionsContainerViewTopAnchorConstraint: NSLayoutConstraint?
+  private var heightContainerViewBottomAnchorCustomDimensionsContainerViewBottomAnchorConstraint: NSLayoutConstraint?
+  private var widthLabelViewTopAnchorWidthContainerViewTopAnchorConstraint: NSLayoutConstraint?
+  private var widthLabelViewLeadingAnchorWidthContainerViewLeadingAnchorConstraint: NSLayoutConstraint?
+  private var widthLabelViewTrailingAnchorWidthContainerViewTrailingAnchorConstraint: NSLayoutConstraint?
+  private var widthInputViewBottomAnchorWidthContainerViewBottomAnchorConstraint: NSLayoutConstraint?
+  private var widthInputViewTopAnchorWidthLabelViewBottomAnchorConstraint: NSLayoutConstraint?
+  private var widthInputViewLeadingAnchorWidthContainerViewLeadingAnchorConstraint: NSLayoutConstraint?
+  private var widthInputViewTrailingAnchorWidthContainerViewTrailingAnchorConstraint: NSLayoutConstraint?
+  private var hSpacerViewHeightAnchorConstraint: NSLayoutConstraint?
+  private var hSpacerViewWidthAnchorConstraint: NSLayoutConstraint?
+  private var heightLabelViewTopAnchorHeightContainerViewTopAnchorConstraint: NSLayoutConstraint?
+  private var heightLabelViewLeadingAnchorHeightContainerViewLeadingAnchorConstraint: NSLayoutConstraint?
+  private var heightLabelViewTrailingAnchorHeightContainerViewTrailingAnchorConstraint: NSLayoutConstraint?
+  private var heightInputViewBottomAnchorHeightContainerViewBottomAnchorConstraint: NSLayoutConstraint?
+  private var heightInputViewTopAnchorHeightLabelViewBottomAnchorConstraint: NSLayoutConstraint?
+  private var heightInputViewLeadingAnchorHeightContainerViewLeadingAnchorConstraint: NSLayoutConstraint?
+  private var heightInputViewTrailingAnchorHeightContainerViewTrailingAnchorConstraint: NSLayoutConstraint?
+
   private func setUpViews() {
     boxType = .custom
     borderType = .noBorder
     contentViewMargins = .zero
-    presetRowView.boxType = .custom
-    presetRowView.borderType = .noBorder
-    presetRowView.contentViewMargins = .zero
+    layoutRowView.boxType = .custom
+    layoutRowView.borderType = .noBorder
+    layoutRowView.contentViewMargins = .zero
     deviceRowView.boxType = .custom
     deviceRowView.borderType = .noBorder
     deviceRowView.contentViewMargins = .zero
@@ -90,7 +209,7 @@ public class CanvasInspector: NSBox {
     backgroundColorRowView.boxType = .custom
     backgroundColorRowView.borderType = .noBorder
     backgroundColorRowView.contentViewMargins = .zero
-    presetLabelView.lineBreakMode = .byWordWrapping
+    layoutLabelView.lineBreakMode = .byWordWrapping
     deviceLabelView.lineBreakMode = .byWordWrapping
     deviceValueContainerView.boxType = .custom
     deviceValueContainerView.borderType = .noBorder
@@ -112,12 +231,12 @@ public class CanvasInspector: NSBox {
     nameLabelView.lineBreakMode = .byWordWrapping
     backgroundColorLabelView.lineBreakMode = .byWordWrapping
 
-    addSubview(presetRowView)
+    addSubview(layoutRowView)
     addSubview(deviceRowView)
     addSubview(nameRowView)
     addSubview(backgroundColorRowView)
-    presetRowView.addSubview(presetLabelView)
-    presetRowView.addSubview(presetDropdownView)
+    layoutRowView.addSubview(layoutLabelView)
+    layoutRowView.addSubview(layoutDropdownView)
     deviceRowView.addSubview(deviceLabelView)
     deviceRowView.addSubview(deviceValueContainerView)
     deviceValueContainerView.addSubview(deviceDropdownView)
@@ -134,30 +253,27 @@ public class CanvasInspector: NSBox {
     backgroundColorRowView.addSubview(backgroundColorLabelView)
     backgroundColorRowView.addSubview(backgroundColorInputView)
 
-    presetLabelView.attributedStringValue = presetLabelViewTextStyle.apply(to: "Preset")
-    presetDropdownView.selectedIndex = 0
-    presetDropdownView.values = ["Component (Flexible-height)", "Screen (Fixed-height)"]
+    layoutLabelView.attributedStringValue = layoutLabelViewTextStyle.apply(to: "Layout")
+    layoutDropdownView.selectedIndex = 0
+    layoutDropdownView.values = ["Component (Flexible-height)", "Screen (Fixed-height)"]
     deviceLabelView.attributedStringValue = deviceLabelViewTextStyle.apply(to: "Device")
     deviceDropdownView.selectedIndex = 0
-    deviceDropdownView.values = []
+    deviceDropdownView.values = ["iPhone SE"]
     widthLabelView.attributedStringValue = widthLabelViewTextStyle.apply(to: "Width")
-    widthInputView.numberValue = 0
     heightLabelView.attributedStringValue = heightLabelViewTextStyle.apply(to: "Height")
-    heightInputView.numberValue = 0
     nameLabelView.attributedStringValue = nameLabelViewTextStyle.apply(to: "Name")
     nameInputView.textValue = "Text"
     backgroundColorLabelView.attributedStringValue = backgroundColorLabelViewTextStyle.apply(to: "Background")
-    backgroundColorInputView.textValue = "Text"
   }
 
   private func setUpConstraints() {
     translatesAutoresizingMaskIntoConstraints = false
-    presetRowView.translatesAutoresizingMaskIntoConstraints = false
+    layoutRowView.translatesAutoresizingMaskIntoConstraints = false
     deviceRowView.translatesAutoresizingMaskIntoConstraints = false
     nameRowView.translatesAutoresizingMaskIntoConstraints = false
     backgroundColorRowView.translatesAutoresizingMaskIntoConstraints = false
-    presetLabelView.translatesAutoresizingMaskIntoConstraints = false
-    presetDropdownView.translatesAutoresizingMaskIntoConstraints = false
+    layoutLabelView.translatesAutoresizingMaskIntoConstraints = false
+    layoutDropdownView.translatesAutoresizingMaskIntoConstraints = false
     deviceLabelView.translatesAutoresizingMaskIntoConstraints = false
     deviceValueContainerView.translatesAutoresizingMaskIntoConstraints = false
     deviceDropdownView.translatesAutoresizingMaskIntoConstraints = false
@@ -174,12 +290,12 @@ public class CanvasInspector: NSBox {
     backgroundColorLabelView.translatesAutoresizingMaskIntoConstraints = false
     backgroundColorInputView.translatesAutoresizingMaskIntoConstraints = false
 
-    let presetRowViewTopAnchorConstraint = presetRowView.topAnchor.constraint(equalTo: topAnchor, constant: 16)
-    let presetRowViewLeadingAnchorConstraint = presetRowView.leadingAnchor.constraint(equalTo: leadingAnchor)
-    let presetRowViewTrailingAnchorConstraint = presetRowView.trailingAnchor.constraint(equalTo: trailingAnchor)
+    let layoutRowViewTopAnchorConstraint = layoutRowView.topAnchor.constraint(equalTo: topAnchor, constant: 16)
+    let layoutRowViewLeadingAnchorConstraint = layoutRowView.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let layoutRowViewTrailingAnchorConstraint = layoutRowView.trailingAnchor.constraint(equalTo: trailingAnchor)
     let deviceRowViewTopAnchorConstraint = deviceRowView
       .topAnchor
-      .constraint(equalTo: presetRowView.bottomAnchor, constant: 16)
+      .constraint(equalTo: layoutRowView.bottomAnchor, constant: 16)
     let deviceRowViewLeadingAnchorConstraint = deviceRowView.leadingAnchor.constraint(equalTo: leadingAnchor)
     let deviceRowViewTrailingAnchorConstraint = deviceRowView.trailingAnchor.constraint(equalTo: trailingAnchor)
     let nameRowViewTopAnchorConstraint = nameRowView
@@ -199,40 +315,40 @@ public class CanvasInspector: NSBox {
     let backgroundColorRowViewTrailingAnchorConstraint = backgroundColorRowView
       .trailingAnchor
       .constraint(equalTo: trailingAnchor)
-    let presetLabelViewHeightAnchorParentConstraint = presetLabelView
+    let layoutLabelViewHeightAnchorParentConstraint = layoutLabelView
       .heightAnchor
-      .constraint(lessThanOrEqualTo: presetRowView.heightAnchor)
-    let presetDropdownViewHeightAnchorParentConstraint = presetDropdownView
+      .constraint(lessThanOrEqualTo: layoutRowView.heightAnchor)
+    let layoutDropdownViewHeightAnchorParentConstraint = layoutDropdownView
       .heightAnchor
-      .constraint(lessThanOrEqualTo: presetRowView.heightAnchor)
-    let presetLabelViewLeadingAnchorConstraint = presetLabelView
+      .constraint(lessThanOrEqualTo: layoutRowView.heightAnchor)
+    let layoutLabelViewLeadingAnchorConstraint = layoutLabelView
       .leadingAnchor
-      .constraint(equalTo: presetRowView.leadingAnchor)
-    let presetLabelViewTopAnchorConstraint = presetLabelView.topAnchor.constraint(equalTo: presetRowView.topAnchor)
-    let presetLabelViewCenterYAnchorConstraint = presetLabelView
+      .constraint(equalTo: layoutRowView.leadingAnchor)
+    let layoutLabelViewTopAnchorConstraint = layoutLabelView.topAnchor.constraint(equalTo: layoutRowView.topAnchor)
+    let layoutLabelViewCenterYAnchorConstraint = layoutLabelView
       .centerYAnchor
-      .constraint(equalTo: presetRowView.centerYAnchor)
-    let presetLabelViewBottomAnchorConstraint = presetLabelView
+      .constraint(equalTo: layoutRowView.centerYAnchor)
+    let layoutLabelViewBottomAnchorConstraint = layoutLabelView
       .bottomAnchor
-      .constraint(equalTo: presetRowView.bottomAnchor)
-    let presetDropdownViewTrailingAnchorConstraint = presetDropdownView
+      .constraint(equalTo: layoutRowView.bottomAnchor)
+    let layoutDropdownViewTrailingAnchorConstraint = layoutDropdownView
       .trailingAnchor
-      .constraint(equalTo: presetRowView.trailingAnchor)
-    let presetDropdownViewLeadingAnchorConstraint = presetDropdownView
+      .constraint(equalTo: layoutRowView.trailingAnchor)
+    let layoutDropdownViewLeadingAnchorConstraint = layoutDropdownView
       .leadingAnchor
-      .constraint(equalTo: presetLabelView.trailingAnchor, constant: 20)
-    let presetDropdownViewTopAnchorConstraint = presetDropdownView
+      .constraint(equalTo: layoutLabelView.trailingAnchor, constant: 20)
+    let layoutDropdownViewTopAnchorConstraint = layoutDropdownView
       .topAnchor
-      .constraint(equalTo: presetRowView.topAnchor)
-    let presetDropdownViewCenterYAnchorConstraint = presetDropdownView
+      .constraint(equalTo: layoutRowView.topAnchor)
+    let layoutDropdownViewCenterYAnchorConstraint = layoutDropdownView
       .centerYAnchor
-      .constraint(equalTo: presetRowView.centerYAnchor)
-    let presetDropdownViewBottomAnchorConstraint = presetDropdownView
+      .constraint(equalTo: layoutRowView.centerYAnchor)
+    let layoutDropdownViewBottomAnchorConstraint = layoutDropdownView
       .bottomAnchor
-      .constraint(equalTo: presetRowView.bottomAnchor)
+      .constraint(equalTo: layoutRowView.bottomAnchor)
     let deviceLabelViewHeightAnchorParentConstraint = deviceLabelView
       .heightAnchor
-      .constraint(lessThanOrEqualTo: deviceRowView.heightAnchor, constant: -4)
+      .constraint(lessThanOrEqualTo: deviceRowView.heightAnchor, constant: -2)
     let deviceValueContainerViewHeightAnchorParentConstraint = deviceValueContainerView
       .heightAnchor
       .constraint(lessThanOrEqualTo: deviceRowView.heightAnchor)
@@ -241,7 +357,7 @@ public class CanvasInspector: NSBox {
       .constraint(equalTo: deviceRowView.leadingAnchor)
     let deviceLabelViewTopAnchorConstraint = deviceLabelView
       .topAnchor
-      .constraint(equalTo: deviceRowView.topAnchor, constant: 4)
+      .constraint(equalTo: deviceRowView.topAnchor, constant: 2)
     let deviceLabelViewBottomAnchorConstraint = deviceLabelView
       .bottomAnchor
       .constraint(equalTo: deviceRowView.bottomAnchor)
@@ -315,7 +431,7 @@ public class CanvasInspector: NSBox {
     let backgroundColorInputViewBottomAnchorConstraint = backgroundColorInputView
       .bottomAnchor
       .constraint(equalTo: backgroundColorRowView.bottomAnchor)
-    let presetLabelViewWidthAnchorConstraint = presetLabelView.widthAnchor.constraint(equalToConstant: 80)
+    let layoutLabelViewWidthAnchorConstraint = layoutLabelView.widthAnchor.constraint(equalToConstant: 80)
     let deviceLabelViewWidthAnchorConstraint = deviceLabelView.widthAnchor.constraint(equalToConstant: 80)
     let deviceDropdownViewTopAnchorConstraint = deviceDropdownView
       .topAnchor
@@ -326,16 +442,23 @@ public class CanvasInspector: NSBox {
     let deviceDropdownViewTrailingAnchorConstraint = deviceDropdownView
       .trailingAnchor
       .constraint(equalTo: deviceValueContainerView.trailingAnchor)
-    let customDimensionsContainerViewBottomAnchorConstraint = customDimensionsContainerView
+    let nameLabelViewWidthAnchorConstraint = nameLabelView.widthAnchor.constraint(equalToConstant: 80)
+    let backgroundColorLabelViewWidthAnchorConstraint = backgroundColorLabelView
+      .widthAnchor
+      .constraint(equalToConstant: 80)
+    let deviceDropdownViewBottomAnchorDeviceValueContainerViewBottomAnchorConstraint = deviceDropdownView
       .bottomAnchor
       .constraint(equalTo: deviceValueContainerView.bottomAnchor)
-    let customDimensionsContainerViewTopAnchorConstraint = customDimensionsContainerView
+    let customDimensionsContainerViewBottomAnchorDeviceValueContainerViewBottomAnchorConstraint = customDimensionsContainerView
+      .bottomAnchor
+      .constraint(equalTo: deviceValueContainerView.bottomAnchor)
+    let customDimensionsContainerViewTopAnchorDeviceDropdownViewBottomAnchorConstraint = customDimensionsContainerView
       .topAnchor
       .constraint(equalTo: deviceDropdownView.bottomAnchor, constant: 16)
-    let customDimensionsContainerViewLeadingAnchorConstraint = customDimensionsContainerView
+    let customDimensionsContainerViewLeadingAnchorDeviceValueContainerViewLeadingAnchorConstraint = customDimensionsContainerView
       .leadingAnchor
       .constraint(equalTo: deviceValueContainerView.leadingAnchor)
-    let customDimensionsContainerViewTrailingAnchorConstraint = customDimensionsContainerView
+    let customDimensionsContainerViewTrailingAnchorDeviceValueContainerViewTrailingAnchorConstraint = customDimensionsContainerView
       .trailingAnchor
       .constraint(equalTo: deviceValueContainerView.trailingAnchor)
     let widthContainerViewHeightContainerViewWidthAnchorSiblingConstraint = widthContainerView
@@ -350,82 +473,80 @@ public class CanvasInspector: NSBox {
     let heightContainerViewHeightAnchorParentConstraint = heightContainerView
       .heightAnchor
       .constraint(lessThanOrEqualTo: customDimensionsContainerView.heightAnchor)
-    let widthContainerViewLeadingAnchorConstraint = widthContainerView
+    let widthContainerViewLeadingAnchorCustomDimensionsContainerViewLeadingAnchorConstraint = widthContainerView
       .leadingAnchor
       .constraint(equalTo: customDimensionsContainerView.leadingAnchor)
-    let widthContainerViewTopAnchorConstraint = widthContainerView
+    let widthContainerViewTopAnchorCustomDimensionsContainerViewTopAnchorConstraint = widthContainerView
       .topAnchor
       .constraint(equalTo: customDimensionsContainerView.topAnchor)
-    let widthContainerViewBottomAnchorConstraint = widthContainerView
+    let widthContainerViewBottomAnchorCustomDimensionsContainerViewBottomAnchorConstraint = widthContainerView
       .bottomAnchor
       .constraint(equalTo: customDimensionsContainerView.bottomAnchor)
-    let hSpacerViewLeadingAnchorConstraint = hSpacerView
+    let hSpacerViewLeadingAnchorWidthContainerViewTrailingAnchorConstraint = hSpacerView
       .leadingAnchor
       .constraint(equalTo: widthContainerView.trailingAnchor)
-    let hSpacerViewTopAnchorConstraint = hSpacerView
+    let hSpacerViewTopAnchorCustomDimensionsContainerViewTopAnchorConstraint = hSpacerView
       .topAnchor
       .constraint(equalTo: customDimensionsContainerView.topAnchor)
-    let heightContainerViewTrailingAnchorConstraint = heightContainerView
+    let heightContainerViewTrailingAnchorCustomDimensionsContainerViewTrailingAnchorConstraint = heightContainerView
       .trailingAnchor
       .constraint(equalTo: customDimensionsContainerView.trailingAnchor)
-    let heightContainerViewLeadingAnchorConstraint = heightContainerView
+    let heightContainerViewLeadingAnchorHSpacerViewTrailingAnchorConstraint = heightContainerView
       .leadingAnchor
       .constraint(equalTo: hSpacerView.trailingAnchor)
-    let heightContainerViewTopAnchorConstraint = heightContainerView
+    let heightContainerViewTopAnchorCustomDimensionsContainerViewTopAnchorConstraint = heightContainerView
       .topAnchor
       .constraint(equalTo: customDimensionsContainerView.topAnchor)
-    let heightContainerViewBottomAnchorConstraint = heightContainerView
+    let heightContainerViewBottomAnchorCustomDimensionsContainerViewBottomAnchorConstraint = heightContainerView
       .bottomAnchor
       .constraint(equalTo: customDimensionsContainerView.bottomAnchor)
-    let widthLabelViewTopAnchorConstraint = widthLabelView.topAnchor.constraint(equalTo: widthContainerView.topAnchor)
-    let widthLabelViewLeadingAnchorConstraint = widthLabelView
+    let widthLabelViewTopAnchorWidthContainerViewTopAnchorConstraint = widthLabelView
+      .topAnchor
+      .constraint(equalTo: widthContainerView.topAnchor)
+    let widthLabelViewLeadingAnchorWidthContainerViewLeadingAnchorConstraint = widthLabelView
       .leadingAnchor
       .constraint(equalTo: widthContainerView.leadingAnchor)
-    let widthLabelViewTrailingAnchorConstraint = widthLabelView
+    let widthLabelViewTrailingAnchorWidthContainerViewTrailingAnchorConstraint = widthLabelView
       .trailingAnchor
       .constraint(equalTo: widthContainerView.trailingAnchor)
-    let widthInputViewBottomAnchorConstraint = widthInputView
+    let widthInputViewBottomAnchorWidthContainerViewBottomAnchorConstraint = widthInputView
       .bottomAnchor
       .constraint(equalTo: widthContainerView.bottomAnchor)
-    let widthInputViewTopAnchorConstraint = widthInputView
+    let widthInputViewTopAnchorWidthLabelViewBottomAnchorConstraint = widthInputView
       .topAnchor
       .constraint(equalTo: widthLabelView.bottomAnchor, constant: 8)
-    let widthInputViewLeadingAnchorConstraint = widthInputView
+    let widthInputViewLeadingAnchorWidthContainerViewLeadingAnchorConstraint = widthInputView
       .leadingAnchor
       .constraint(equalTo: widthContainerView.leadingAnchor)
-    let widthInputViewTrailingAnchorConstraint = widthInputView
+    let widthInputViewTrailingAnchorWidthContainerViewTrailingAnchorConstraint = widthInputView
       .trailingAnchor
       .constraint(equalTo: widthContainerView.trailingAnchor)
     let hSpacerViewHeightAnchorConstraint = hSpacerView.heightAnchor.constraint(equalToConstant: 0)
     let hSpacerViewWidthAnchorConstraint = hSpacerView.widthAnchor.constraint(equalToConstant: 20)
-    let heightLabelViewTopAnchorConstraint = heightLabelView
+    let heightLabelViewTopAnchorHeightContainerViewTopAnchorConstraint = heightLabelView
       .topAnchor
       .constraint(equalTo: heightContainerView.topAnchor)
-    let heightLabelViewLeadingAnchorConstraint = heightLabelView
+    let heightLabelViewLeadingAnchorHeightContainerViewLeadingAnchorConstraint = heightLabelView
       .leadingAnchor
       .constraint(equalTo: heightContainerView.leadingAnchor)
-    let heightLabelViewTrailingAnchorConstraint = heightLabelView
+    let heightLabelViewTrailingAnchorHeightContainerViewTrailingAnchorConstraint = heightLabelView
       .trailingAnchor
       .constraint(equalTo: heightContainerView.trailingAnchor)
-    let heightInputViewBottomAnchorConstraint = heightInputView
+    let heightInputViewBottomAnchorHeightContainerViewBottomAnchorConstraint = heightInputView
       .bottomAnchor
       .constraint(equalTo: heightContainerView.bottomAnchor)
-    let heightInputViewTopAnchorConstraint = heightInputView
+    let heightInputViewTopAnchorHeightLabelViewBottomAnchorConstraint = heightInputView
       .topAnchor
       .constraint(equalTo: heightLabelView.bottomAnchor, constant: 8)
-    let heightInputViewLeadingAnchorConstraint = heightInputView
+    let heightInputViewLeadingAnchorHeightContainerViewLeadingAnchorConstraint = heightInputView
       .leadingAnchor
       .constraint(equalTo: heightContainerView.leadingAnchor)
-    let heightInputViewTrailingAnchorConstraint = heightInputView
+    let heightInputViewTrailingAnchorHeightContainerViewTrailingAnchorConstraint = heightInputView
       .trailingAnchor
       .constraint(equalTo: heightContainerView.trailingAnchor)
-    let nameLabelViewWidthAnchorConstraint = nameLabelView.widthAnchor.constraint(equalToConstant: 80)
-    let backgroundColorLabelViewWidthAnchorConstraint = backgroundColorLabelView
-      .widthAnchor
-      .constraint(equalToConstant: 80)
 
-    presetLabelViewHeightAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
-    presetDropdownViewHeightAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
+    layoutLabelViewHeightAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
+    layoutDropdownViewHeightAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
     deviceLabelViewHeightAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
     deviceValueContainerViewHeightAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
     nameLabelViewHeightAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
@@ -436,113 +557,252 @@ public class CanvasInspector: NSBox {
     hSpacerViewHeightAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
     heightContainerViewHeightAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
 
-    NSLayoutConstraint.activate([
-      presetRowViewTopAnchorConstraint,
-      presetRowViewLeadingAnchorConstraint,
-      presetRowViewTrailingAnchorConstraint,
-      deviceRowViewTopAnchorConstraint,
-      deviceRowViewLeadingAnchorConstraint,
-      deviceRowViewTrailingAnchorConstraint,
-      nameRowViewTopAnchorConstraint,
-      nameRowViewLeadingAnchorConstraint,
-      nameRowViewTrailingAnchorConstraint,
-      backgroundColorRowViewBottomAnchorConstraint,
-      backgroundColorRowViewTopAnchorConstraint,
-      backgroundColorRowViewLeadingAnchorConstraint,
-      backgroundColorRowViewTrailingAnchorConstraint,
-      presetLabelViewHeightAnchorParentConstraint,
-      presetDropdownViewHeightAnchorParentConstraint,
-      presetLabelViewLeadingAnchorConstraint,
-      presetLabelViewTopAnchorConstraint,
-      presetLabelViewCenterYAnchorConstraint,
-      presetLabelViewBottomAnchorConstraint,
-      presetDropdownViewTrailingAnchorConstraint,
-      presetDropdownViewLeadingAnchorConstraint,
-      presetDropdownViewTopAnchorConstraint,
-      presetDropdownViewCenterYAnchorConstraint,
-      presetDropdownViewBottomAnchorConstraint,
-      deviceLabelViewHeightAnchorParentConstraint,
-      deviceValueContainerViewHeightAnchorParentConstraint,
-      deviceLabelViewLeadingAnchorConstraint,
-      deviceLabelViewTopAnchorConstraint,
-      deviceLabelViewBottomAnchorConstraint,
-      deviceValueContainerViewTrailingAnchorConstraint,
-      deviceValueContainerViewLeadingAnchorConstraint,
-      deviceValueContainerViewTopAnchorConstraint,
-      deviceValueContainerViewBottomAnchorConstraint,
-      nameLabelViewHeightAnchorParentConstraint,
-      nameInputViewHeightAnchorParentConstraint,
-      nameLabelViewLeadingAnchorConstraint,
-      nameLabelViewTopAnchorConstraint,
-      nameLabelViewCenterYAnchorConstraint,
-      nameLabelViewBottomAnchorConstraint,
-      nameInputViewTrailingAnchorConstraint,
-      nameInputViewLeadingAnchorConstraint,
-      nameInputViewTopAnchorConstraint,
-      nameInputViewCenterYAnchorConstraint,
-      nameInputViewBottomAnchorConstraint,
-      backgroundColorLabelViewHeightAnchorParentConstraint,
-      backgroundColorInputViewHeightAnchorParentConstraint,
-      backgroundColorLabelViewLeadingAnchorConstraint,
-      backgroundColorLabelViewTopAnchorConstraint,
-      backgroundColorLabelViewCenterYAnchorConstraint,
-      backgroundColorLabelViewBottomAnchorConstraint,
-      backgroundColorInputViewTrailingAnchorConstraint,
-      backgroundColorInputViewLeadingAnchorConstraint,
-      backgroundColorInputViewTopAnchorConstraint,
-      backgroundColorInputViewCenterYAnchorConstraint,
-      backgroundColorInputViewBottomAnchorConstraint,
-      presetLabelViewWidthAnchorConstraint,
-      deviceLabelViewWidthAnchorConstraint,
-      deviceDropdownViewTopAnchorConstraint,
-      deviceDropdownViewLeadingAnchorConstraint,
-      deviceDropdownViewTrailingAnchorConstraint,
-      customDimensionsContainerViewBottomAnchorConstraint,
-      customDimensionsContainerViewTopAnchorConstraint,
-      customDimensionsContainerViewLeadingAnchorConstraint,
-      customDimensionsContainerViewTrailingAnchorConstraint,
-      widthContainerViewHeightContainerViewWidthAnchorSiblingConstraint,
-      widthContainerViewHeightAnchorParentConstraint,
-      hSpacerViewHeightAnchorParentConstraint,
-      heightContainerViewHeightAnchorParentConstraint,
-      widthContainerViewLeadingAnchorConstraint,
-      widthContainerViewTopAnchorConstraint,
-      widthContainerViewBottomAnchorConstraint,
-      hSpacerViewLeadingAnchorConstraint,
-      hSpacerViewTopAnchorConstraint,
-      heightContainerViewTrailingAnchorConstraint,
-      heightContainerViewLeadingAnchorConstraint,
-      heightContainerViewTopAnchorConstraint,
-      heightContainerViewBottomAnchorConstraint,
-      widthLabelViewTopAnchorConstraint,
-      widthLabelViewLeadingAnchorConstraint,
-      widthLabelViewTrailingAnchorConstraint,
-      widthInputViewBottomAnchorConstraint,
-      widthInputViewTopAnchorConstraint,
-      widthInputViewLeadingAnchorConstraint,
-      widthInputViewTrailingAnchorConstraint,
-      hSpacerViewHeightAnchorConstraint,
-      hSpacerViewWidthAnchorConstraint,
-      heightLabelViewTopAnchorConstraint,
-      heightLabelViewLeadingAnchorConstraint,
-      heightLabelViewTrailingAnchorConstraint,
-      heightInputViewBottomAnchorConstraint,
-      heightInputViewTopAnchorConstraint,
-      heightInputViewLeadingAnchorConstraint,
-      heightInputViewTrailingAnchorConstraint,
-      nameLabelViewWidthAnchorConstraint,
-      backgroundColorLabelViewWidthAnchorConstraint
-    ])
+    self.deviceDropdownViewBottomAnchorDeviceValueContainerViewBottomAnchorConstraint =
+      deviceDropdownViewBottomAnchorDeviceValueContainerViewBottomAnchorConstraint
+    self.customDimensionsContainerViewBottomAnchorDeviceValueContainerViewBottomAnchorConstraint =
+      customDimensionsContainerViewBottomAnchorDeviceValueContainerViewBottomAnchorConstraint
+    self.customDimensionsContainerViewTopAnchorDeviceDropdownViewBottomAnchorConstraint =
+      customDimensionsContainerViewTopAnchorDeviceDropdownViewBottomAnchorConstraint
+    self.customDimensionsContainerViewLeadingAnchorDeviceValueContainerViewLeadingAnchorConstraint =
+      customDimensionsContainerViewLeadingAnchorDeviceValueContainerViewLeadingAnchorConstraint
+    self.customDimensionsContainerViewTrailingAnchorDeviceValueContainerViewTrailingAnchorConstraint =
+      customDimensionsContainerViewTrailingAnchorDeviceValueContainerViewTrailingAnchorConstraint
+    self.widthContainerViewHeightContainerViewWidthAnchorSiblingConstraint =
+      widthContainerViewHeightContainerViewWidthAnchorSiblingConstraint
+    self.widthContainerViewHeightAnchorParentConstraint = widthContainerViewHeightAnchorParentConstraint
+    self.hSpacerViewHeightAnchorParentConstraint = hSpacerViewHeightAnchorParentConstraint
+    self.heightContainerViewHeightAnchorParentConstraint = heightContainerViewHeightAnchorParentConstraint
+    self.widthContainerViewLeadingAnchorCustomDimensionsContainerViewLeadingAnchorConstraint =
+      widthContainerViewLeadingAnchorCustomDimensionsContainerViewLeadingAnchorConstraint
+    self.widthContainerViewTopAnchorCustomDimensionsContainerViewTopAnchorConstraint =
+      widthContainerViewTopAnchorCustomDimensionsContainerViewTopAnchorConstraint
+    self.widthContainerViewBottomAnchorCustomDimensionsContainerViewBottomAnchorConstraint =
+      widthContainerViewBottomAnchorCustomDimensionsContainerViewBottomAnchorConstraint
+    self.hSpacerViewLeadingAnchorWidthContainerViewTrailingAnchorConstraint =
+      hSpacerViewLeadingAnchorWidthContainerViewTrailingAnchorConstraint
+    self.hSpacerViewTopAnchorCustomDimensionsContainerViewTopAnchorConstraint =
+      hSpacerViewTopAnchorCustomDimensionsContainerViewTopAnchorConstraint
+    self.heightContainerViewTrailingAnchorCustomDimensionsContainerViewTrailingAnchorConstraint =
+      heightContainerViewTrailingAnchorCustomDimensionsContainerViewTrailingAnchorConstraint
+    self.heightContainerViewLeadingAnchorHSpacerViewTrailingAnchorConstraint =
+      heightContainerViewLeadingAnchorHSpacerViewTrailingAnchorConstraint
+    self.heightContainerViewTopAnchorCustomDimensionsContainerViewTopAnchorConstraint =
+      heightContainerViewTopAnchorCustomDimensionsContainerViewTopAnchorConstraint
+    self.heightContainerViewBottomAnchorCustomDimensionsContainerViewBottomAnchorConstraint =
+      heightContainerViewBottomAnchorCustomDimensionsContainerViewBottomAnchorConstraint
+    self.widthLabelViewTopAnchorWidthContainerViewTopAnchorConstraint =
+      widthLabelViewTopAnchorWidthContainerViewTopAnchorConstraint
+    self.widthLabelViewLeadingAnchorWidthContainerViewLeadingAnchorConstraint =
+      widthLabelViewLeadingAnchorWidthContainerViewLeadingAnchorConstraint
+    self.widthLabelViewTrailingAnchorWidthContainerViewTrailingAnchorConstraint =
+      widthLabelViewTrailingAnchorWidthContainerViewTrailingAnchorConstraint
+    self.widthInputViewBottomAnchorWidthContainerViewBottomAnchorConstraint =
+      widthInputViewBottomAnchorWidthContainerViewBottomAnchorConstraint
+    self.widthInputViewTopAnchorWidthLabelViewBottomAnchorConstraint =
+      widthInputViewTopAnchorWidthLabelViewBottomAnchorConstraint
+    self.widthInputViewLeadingAnchorWidthContainerViewLeadingAnchorConstraint =
+      widthInputViewLeadingAnchorWidthContainerViewLeadingAnchorConstraint
+    self.widthInputViewTrailingAnchorWidthContainerViewTrailingAnchorConstraint =
+      widthInputViewTrailingAnchorWidthContainerViewTrailingAnchorConstraint
+    self.hSpacerViewHeightAnchorConstraint = hSpacerViewHeightAnchorConstraint
+    self.hSpacerViewWidthAnchorConstraint = hSpacerViewWidthAnchorConstraint
+    self.heightLabelViewTopAnchorHeightContainerViewTopAnchorConstraint =
+      heightLabelViewTopAnchorHeightContainerViewTopAnchorConstraint
+    self.heightLabelViewLeadingAnchorHeightContainerViewLeadingAnchorConstraint =
+      heightLabelViewLeadingAnchorHeightContainerViewLeadingAnchorConstraint
+    self.heightLabelViewTrailingAnchorHeightContainerViewTrailingAnchorConstraint =
+      heightLabelViewTrailingAnchorHeightContainerViewTrailingAnchorConstraint
+    self.heightInputViewBottomAnchorHeightContainerViewBottomAnchorConstraint =
+      heightInputViewBottomAnchorHeightContainerViewBottomAnchorConstraint
+    self.heightInputViewTopAnchorHeightLabelViewBottomAnchorConstraint =
+      heightInputViewTopAnchorHeightLabelViewBottomAnchorConstraint
+    self.heightInputViewLeadingAnchorHeightContainerViewLeadingAnchorConstraint =
+      heightInputViewLeadingAnchorHeightContainerViewLeadingAnchorConstraint
+    self.heightInputViewTrailingAnchorHeightContainerViewTrailingAnchorConstraint =
+      heightInputViewTrailingAnchorHeightContainerViewTrailingAnchorConstraint
+
+    NSLayoutConstraint.activate(
+      [
+        layoutRowViewTopAnchorConstraint,
+        layoutRowViewLeadingAnchorConstraint,
+        layoutRowViewTrailingAnchorConstraint,
+        deviceRowViewTopAnchorConstraint,
+        deviceRowViewLeadingAnchorConstraint,
+        deviceRowViewTrailingAnchorConstraint,
+        nameRowViewTopAnchorConstraint,
+        nameRowViewLeadingAnchorConstraint,
+        nameRowViewTrailingAnchorConstraint,
+        backgroundColorRowViewBottomAnchorConstraint,
+        backgroundColorRowViewTopAnchorConstraint,
+        backgroundColorRowViewLeadingAnchorConstraint,
+        backgroundColorRowViewTrailingAnchorConstraint,
+        layoutLabelViewHeightAnchorParentConstraint,
+        layoutDropdownViewHeightAnchorParentConstraint,
+        layoutLabelViewLeadingAnchorConstraint,
+        layoutLabelViewTopAnchorConstraint,
+        layoutLabelViewCenterYAnchorConstraint,
+        layoutLabelViewBottomAnchorConstraint,
+        layoutDropdownViewTrailingAnchorConstraint,
+        layoutDropdownViewLeadingAnchorConstraint,
+        layoutDropdownViewTopAnchorConstraint,
+        layoutDropdownViewCenterYAnchorConstraint,
+        layoutDropdownViewBottomAnchorConstraint,
+        deviceLabelViewHeightAnchorParentConstraint,
+        deviceValueContainerViewHeightAnchorParentConstraint,
+        deviceLabelViewLeadingAnchorConstraint,
+        deviceLabelViewTopAnchorConstraint,
+        deviceLabelViewBottomAnchorConstraint,
+        deviceValueContainerViewTrailingAnchorConstraint,
+        deviceValueContainerViewLeadingAnchorConstraint,
+        deviceValueContainerViewTopAnchorConstraint,
+        deviceValueContainerViewBottomAnchorConstraint,
+        nameLabelViewHeightAnchorParentConstraint,
+        nameInputViewHeightAnchorParentConstraint,
+        nameLabelViewLeadingAnchorConstraint,
+        nameLabelViewTopAnchorConstraint,
+        nameLabelViewCenterYAnchorConstraint,
+        nameLabelViewBottomAnchorConstraint,
+        nameInputViewTrailingAnchorConstraint,
+        nameInputViewLeadingAnchorConstraint,
+        nameInputViewTopAnchorConstraint,
+        nameInputViewCenterYAnchorConstraint,
+        nameInputViewBottomAnchorConstraint,
+        backgroundColorLabelViewHeightAnchorParentConstraint,
+        backgroundColorInputViewHeightAnchorParentConstraint,
+        backgroundColorLabelViewLeadingAnchorConstraint,
+        backgroundColorLabelViewTopAnchorConstraint,
+        backgroundColorLabelViewCenterYAnchorConstraint,
+        backgroundColorLabelViewBottomAnchorConstraint,
+        backgroundColorInputViewTrailingAnchorConstraint,
+        backgroundColorInputViewLeadingAnchorConstraint,
+        backgroundColorInputViewTopAnchorConstraint,
+        backgroundColorInputViewCenterYAnchorConstraint,
+        backgroundColorInputViewBottomAnchorConstraint,
+        layoutLabelViewWidthAnchorConstraint,
+        deviceLabelViewWidthAnchorConstraint,
+        deviceDropdownViewTopAnchorConstraint,
+        deviceDropdownViewLeadingAnchorConstraint,
+        deviceDropdownViewTrailingAnchorConstraint,
+        nameLabelViewWidthAnchorConstraint,
+        backgroundColorLabelViewWidthAnchorConstraint
+      ] +
+        conditionalConstraints(customDimensionsContainerViewIsHidden: customDimensionsContainerView.isHidden))
   }
 
-  private func update() {}
+  private func conditionalConstraints(customDimensionsContainerViewIsHidden: Bool) -> [NSLayoutConstraint] {
+    var constraints: [NSLayoutConstraint?]
+
+    switch (customDimensionsContainerViewIsHidden) {
+      case (true):
+        constraints = [deviceDropdownViewBottomAnchorDeviceValueContainerViewBottomAnchorConstraint]
+      case (false):
+        constraints = [
+          customDimensionsContainerViewBottomAnchorDeviceValueContainerViewBottomAnchorConstraint,
+          customDimensionsContainerViewTopAnchorDeviceDropdownViewBottomAnchorConstraint,
+          customDimensionsContainerViewLeadingAnchorDeviceValueContainerViewLeadingAnchorConstraint,
+          customDimensionsContainerViewTrailingAnchorDeviceValueContainerViewTrailingAnchorConstraint,
+          widthContainerViewHeightContainerViewWidthAnchorSiblingConstraint,
+          widthContainerViewHeightAnchorParentConstraint,
+          hSpacerViewHeightAnchorParentConstraint,
+          heightContainerViewHeightAnchorParentConstraint,
+          widthContainerViewLeadingAnchorCustomDimensionsContainerViewLeadingAnchorConstraint,
+          widthContainerViewTopAnchorCustomDimensionsContainerViewTopAnchorConstraint,
+          widthContainerViewBottomAnchorCustomDimensionsContainerViewBottomAnchorConstraint,
+          hSpacerViewLeadingAnchorWidthContainerViewTrailingAnchorConstraint,
+          hSpacerViewTopAnchorCustomDimensionsContainerViewTopAnchorConstraint,
+          heightContainerViewTrailingAnchorCustomDimensionsContainerViewTrailingAnchorConstraint,
+          heightContainerViewLeadingAnchorHSpacerViewTrailingAnchorConstraint,
+          heightContainerViewTopAnchorCustomDimensionsContainerViewTopAnchorConstraint,
+          heightContainerViewBottomAnchorCustomDimensionsContainerViewBottomAnchorConstraint,
+          widthLabelViewTopAnchorWidthContainerViewTopAnchorConstraint,
+          widthLabelViewLeadingAnchorWidthContainerViewLeadingAnchorConstraint,
+          widthLabelViewTrailingAnchorWidthContainerViewTrailingAnchorConstraint,
+          widthInputViewBottomAnchorWidthContainerViewBottomAnchorConstraint,
+          widthInputViewTopAnchorWidthLabelViewBottomAnchorConstraint,
+          widthInputViewLeadingAnchorWidthContainerViewLeadingAnchorConstraint,
+          widthInputViewTrailingAnchorWidthContainerViewTrailingAnchorConstraint,
+          hSpacerViewHeightAnchorConstraint,
+          hSpacerViewWidthAnchorConstraint,
+          heightLabelViewTopAnchorHeightContainerViewTopAnchorConstraint,
+          heightLabelViewLeadingAnchorHeightContainerViewLeadingAnchorConstraint,
+          heightLabelViewTrailingAnchorHeightContainerViewTrailingAnchorConstraint,
+          heightInputViewBottomAnchorHeightContainerViewBottomAnchorConstraint,
+          heightInputViewTopAnchorHeightLabelViewBottomAnchorConstraint,
+          heightInputViewLeadingAnchorHeightContainerViewLeadingAnchorConstraint,
+          heightInputViewTrailingAnchorHeightContainerViewTrailingAnchorConstraint
+        ]
+    }
+
+    return constraints.compactMap({ $0 })
+  }
+
+  private func update() {
+    let customDimensionsContainerViewIsHidden = customDimensionsContainerView.isHidden
+
+    customDimensionsContainerView.isHidden = !showsDimensionInputs
+    widthInputView.numberValue = canvasWidth
+    heightInputView.numberValue = canvasHeight
+    backgroundColorInputView.textValue = backgroundColorId
+
+    if customDimensionsContainerView.isHidden != customDimensionsContainerViewIsHidden {
+      NSLayoutConstraint.deactivate(
+        conditionalConstraints(customDimensionsContainerViewIsHidden: customDimensionsContainerViewIsHidden))
+      NSLayoutConstraint.activate(
+        conditionalConstraints(customDimensionsContainerViewIsHidden: customDimensionsContainerView.isHidden))
+    }
+  }
 }
 
 // MARK: - Parameters
 
 extension CanvasInspector {
   public struct Parameters: Equatable {
-    public init() {}
+    public var showsDimensionInputs: Bool
+    public var heightMode: CanvasHeight
+    public var devicePreset: String
+    public var canvasHeight: CGFloat
+    public var canvasWidth: CGFloat
+    public var canvasName: String?
+    public var backgroundColorId: String
+
+    public init(
+      showsDimensionInputs: Bool,
+      heightMode: CanvasHeight,
+      devicePreset: String,
+      canvasHeight: CGFloat,
+      canvasWidth: CGFloat,
+      canvasName: String? = nil,
+      backgroundColorId: String)
+    {
+      self.showsDimensionInputs = showsDimensionInputs
+      self.heightMode = heightMode
+      self.devicePreset = devicePreset
+      self.canvasHeight = canvasHeight
+      self.canvasWidth = canvasWidth
+      self.canvasName = canvasName
+      self.backgroundColorId = backgroundColorId
+    }
+
+    public init() {
+      self
+        .init(
+          showsDimensionInputs: false,
+          heightMode: .flexibleHeight,
+          devicePreset: "",
+          canvasHeight: 0,
+          canvasWidth: 0,
+          canvasName: nil,
+          backgroundColorId: "")
+    }
+
+    public static func ==(lhs: Parameters, rhs: Parameters) -> Bool {
+      return lhs.showsDimensionInputs == rhs.showsDimensionInputs &&
+        lhs.heightMode == rhs.heightMode &&
+          lhs.devicePreset == rhs.devicePreset &&
+            lhs.canvasHeight == rhs.canvasHeight &&
+              lhs.canvasWidth == rhs.canvasWidth &&
+                lhs.canvasName == rhs.canvasName && lhs.backgroundColorId == rhs.backgroundColorId
+    }
   }
 }
 
@@ -565,8 +825,71 @@ extension CanvasInspector {
       self.parameters = parameters
     }
 
+    public init(
+      showsDimensionInputs: Bool,
+      heightMode: CanvasHeight,
+      devicePreset: String,
+      canvasHeight: CGFloat,
+      canvasWidth: CGFloat,
+      canvasName: String? = nil,
+      backgroundColorId: String)
+    {
+      self
+        .init(
+          Parameters(
+            showsDimensionInputs: showsDimensionInputs,
+            heightMode: heightMode,
+            devicePreset: devicePreset,
+            canvasHeight: canvasHeight,
+            canvasWidth: canvasWidth,
+            canvasName: canvasName,
+            backgroundColorId: backgroundColorId))
+    }
+
     public init() {
-      self.init(Parameters())
+      self
+        .init(
+          showsDimensionInputs: false,
+          heightMode: .flexibleHeight,
+          devicePreset: "",
+          canvasHeight: 0,
+          canvasWidth: 0,
+          canvasName: nil,
+          backgroundColorId: "")
+    }
+  }
+}
+
+// MARK: - CanvasHeight
+
+extension CanvasInspector {
+  public enum CanvasHeight: Codable, Equatable {
+    case flexibleHeight
+    case fixedHeight
+
+    // MARK: Codable
+
+    public init(from decoder: Decoder) throws {
+      let container = try decoder.singleValueContainer()
+      let type = try container.decode(Bool.self)
+
+      switch type {
+        case false:
+          self = .flexibleHeight
+        case true:
+          self = .fixedHeight
+      }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+      var container = encoder.singleValueContainer()
+
+      switch self {
+        case .flexibleHeight:
+          try container.encode(false)
+        case .fixedHeight:
+          try container.encode(true)
+      }
     }
   }
 }

--- a/studio/LonaStudio/Generated/inspector/CanvasInspector.swift
+++ b/studio/LonaStudio/Generated/inspector/CanvasInspector.swift
@@ -172,6 +172,11 @@ public class CanvasInspector: NSBox {
     set { parameters.onChangeCanvasHeight = newValue }
   }
 
+  public var onChangeHeightModeIndex: ((Int) -> Void)? {
+    get { return parameters.onChangeHeightModeIndex }
+    set { parameters.onChangeHeightModeIndex = newValue }
+  }
+
   public var parameters: Parameters {
     didSet {
       if parameters != oldValue {
@@ -210,41 +215,6 @@ public class CanvasInspector: NSBox {
   private var heightLabelViewTextStyle = TextStyles.regular
   private var nameLabelViewTextStyle = TextStyles.regular
   private var backgroundColorLabelViewTextStyle = TextStyles.regular
-
-  private var deviceDropdownViewBottomAnchorDeviceValueContainerViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var customDimensionsContainerViewBottomAnchorDeviceValueContainerViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var customDimensionsContainerViewTopAnchorDeviceDropdownViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var customDimensionsContainerViewLeadingAnchorDeviceValueContainerViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var customDimensionsContainerViewTrailingAnchorDeviceValueContainerViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var widthContainerViewHeightContainerViewWidthAnchorSiblingConstraint: NSLayoutConstraint?
-  private var widthContainerViewHeightAnchorParentConstraint: NSLayoutConstraint?
-  private var hSpacerViewHeightAnchorParentConstraint: NSLayoutConstraint?
-  private var heightContainerViewHeightAnchorParentConstraint: NSLayoutConstraint?
-  private var widthContainerViewLeadingAnchorCustomDimensionsContainerViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var widthContainerViewTopAnchorCustomDimensionsContainerViewTopAnchorConstraint: NSLayoutConstraint?
-  private var widthContainerViewBottomAnchorCustomDimensionsContainerViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var hSpacerViewLeadingAnchorWidthContainerViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var hSpacerViewTopAnchorCustomDimensionsContainerViewTopAnchorConstraint: NSLayoutConstraint?
-  private var heightContainerViewTrailingAnchorCustomDimensionsContainerViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var heightContainerViewLeadingAnchorHSpacerViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var heightContainerViewTopAnchorCustomDimensionsContainerViewTopAnchorConstraint: NSLayoutConstraint?
-  private var heightContainerViewBottomAnchorCustomDimensionsContainerViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var widthLabelViewTopAnchorWidthContainerViewTopAnchorConstraint: NSLayoutConstraint?
-  private var widthLabelViewLeadingAnchorWidthContainerViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var widthLabelViewTrailingAnchorWidthContainerViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var widthInputViewBottomAnchorWidthContainerViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var widthInputViewTopAnchorWidthLabelViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var widthInputViewLeadingAnchorWidthContainerViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var widthInputViewTrailingAnchorWidthContainerViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var hSpacerViewHeightAnchorConstraint: NSLayoutConstraint?
-  private var hSpacerViewWidthAnchorConstraint: NSLayoutConstraint?
-  private var heightLabelViewTopAnchorHeightContainerViewTopAnchorConstraint: NSLayoutConstraint?
-  private var heightLabelViewLeadingAnchorHeightContainerViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var heightLabelViewTrailingAnchorHeightContainerViewTrailingAnchorConstraint: NSLayoutConstraint?
-  private var heightInputViewBottomAnchorHeightContainerViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var heightInputViewTopAnchorHeightLabelViewBottomAnchorConstraint: NSLayoutConstraint?
-  private var heightInputViewLeadingAnchorHeightContainerViewLeadingAnchorConstraint: NSLayoutConstraint?
-  private var heightInputViewTrailingAnchorHeightContainerViewTrailingAnchorConstraint: NSLayoutConstraint?
 
   private func setUpViews() {
     boxType = .custom
@@ -310,7 +280,6 @@ public class CanvasInspector: NSBox {
     layoutDropdownView.values = ["Flexible-height", "Fixed-height"]
     deviceLabelView.attributedStringValue = deviceLabelViewTextStyle.apply(to: "Device")
     widthLabelView.attributedStringValue = widthLabelViewTextStyle.apply(to: "Width")
-    heightLabelView.attributedStringValue = heightLabelViewTextStyle.apply(to: "Height")
     nameLabelView.attributedStringValue = nameLabelViewTextStyle.apply(to: "Name")
     backgroundColorLabelView.attributedStringValue = backgroundColorLabelViewTextStyle.apply(to: "Background")
   }
@@ -491,23 +460,16 @@ public class CanvasInspector: NSBox {
     let deviceDropdownViewTrailingAnchorConstraint = deviceDropdownView
       .trailingAnchor
       .constraint(equalTo: deviceValueContainerView.trailingAnchor)
-    let nameLabelViewWidthAnchorConstraint = nameLabelView.widthAnchor.constraint(equalToConstant: 80)
-    let backgroundColorLabelViewWidthAnchorConstraint = backgroundColorLabelView
-      .widthAnchor
-      .constraint(equalToConstant: 80)
-    let deviceDropdownViewBottomAnchorDeviceValueContainerViewBottomAnchorConstraint = deviceDropdownView
+    let customDimensionsContainerViewBottomAnchorConstraint = customDimensionsContainerView
       .bottomAnchor
       .constraint(equalTo: deviceValueContainerView.bottomAnchor)
-    let customDimensionsContainerViewBottomAnchorDeviceValueContainerViewBottomAnchorConstraint = customDimensionsContainerView
-      .bottomAnchor
-      .constraint(equalTo: deviceValueContainerView.bottomAnchor)
-    let customDimensionsContainerViewTopAnchorDeviceDropdownViewBottomAnchorConstraint = customDimensionsContainerView
+    let customDimensionsContainerViewTopAnchorConstraint = customDimensionsContainerView
       .topAnchor
       .constraint(equalTo: deviceDropdownView.bottomAnchor, constant: 16)
-    let customDimensionsContainerViewLeadingAnchorDeviceValueContainerViewLeadingAnchorConstraint = customDimensionsContainerView
+    let customDimensionsContainerViewLeadingAnchorConstraint = customDimensionsContainerView
       .leadingAnchor
       .constraint(equalTo: deviceValueContainerView.leadingAnchor)
-    let customDimensionsContainerViewTrailingAnchorDeviceValueContainerViewTrailingAnchorConstraint = customDimensionsContainerView
+    let customDimensionsContainerViewTrailingAnchorConstraint = customDimensionsContainerView
       .trailingAnchor
       .constraint(equalTo: deviceValueContainerView.trailingAnchor)
     let widthContainerViewHeightContainerViewWidthAnchorSiblingConstraint = widthContainerView
@@ -522,77 +484,79 @@ public class CanvasInspector: NSBox {
     let heightContainerViewHeightAnchorParentConstraint = heightContainerView
       .heightAnchor
       .constraint(lessThanOrEqualTo: customDimensionsContainerView.heightAnchor)
-    let widthContainerViewLeadingAnchorCustomDimensionsContainerViewLeadingAnchorConstraint = widthContainerView
+    let widthContainerViewLeadingAnchorConstraint = widthContainerView
       .leadingAnchor
       .constraint(equalTo: customDimensionsContainerView.leadingAnchor)
-    let widthContainerViewTopAnchorCustomDimensionsContainerViewTopAnchorConstraint = widthContainerView
+    let widthContainerViewTopAnchorConstraint = widthContainerView
       .topAnchor
       .constraint(equalTo: customDimensionsContainerView.topAnchor)
-    let widthContainerViewBottomAnchorCustomDimensionsContainerViewBottomAnchorConstraint = widthContainerView
+    let widthContainerViewBottomAnchorConstraint = widthContainerView
       .bottomAnchor
       .constraint(equalTo: customDimensionsContainerView.bottomAnchor)
-    let hSpacerViewLeadingAnchorWidthContainerViewTrailingAnchorConstraint = hSpacerView
+    let hSpacerViewLeadingAnchorConstraint = hSpacerView
       .leadingAnchor
       .constraint(equalTo: widthContainerView.trailingAnchor)
-    let hSpacerViewTopAnchorCustomDimensionsContainerViewTopAnchorConstraint = hSpacerView
+    let hSpacerViewTopAnchorConstraint = hSpacerView
       .topAnchor
       .constraint(equalTo: customDimensionsContainerView.topAnchor)
-    let heightContainerViewTrailingAnchorCustomDimensionsContainerViewTrailingAnchorConstraint = heightContainerView
+    let heightContainerViewTrailingAnchorConstraint = heightContainerView
       .trailingAnchor
       .constraint(equalTo: customDimensionsContainerView.trailingAnchor)
-    let heightContainerViewLeadingAnchorHSpacerViewTrailingAnchorConstraint = heightContainerView
+    let heightContainerViewLeadingAnchorConstraint = heightContainerView
       .leadingAnchor
       .constraint(equalTo: hSpacerView.trailingAnchor)
-    let heightContainerViewTopAnchorCustomDimensionsContainerViewTopAnchorConstraint = heightContainerView
+    let heightContainerViewTopAnchorConstraint = heightContainerView
       .topAnchor
       .constraint(equalTo: customDimensionsContainerView.topAnchor)
-    let heightContainerViewBottomAnchorCustomDimensionsContainerViewBottomAnchorConstraint = heightContainerView
+    let heightContainerViewBottomAnchorConstraint = heightContainerView
       .bottomAnchor
       .constraint(equalTo: customDimensionsContainerView.bottomAnchor)
-    let widthLabelViewTopAnchorWidthContainerViewTopAnchorConstraint = widthLabelView
-      .topAnchor
-      .constraint(equalTo: widthContainerView.topAnchor)
-    let widthLabelViewLeadingAnchorWidthContainerViewLeadingAnchorConstraint = widthLabelView
+    let widthLabelViewTopAnchorConstraint = widthLabelView.topAnchor.constraint(equalTo: widthContainerView.topAnchor)
+    let widthLabelViewLeadingAnchorConstraint = widthLabelView
       .leadingAnchor
       .constraint(equalTo: widthContainerView.leadingAnchor)
-    let widthLabelViewTrailingAnchorWidthContainerViewTrailingAnchorConstraint = widthLabelView
+    let widthLabelViewTrailingAnchorConstraint = widthLabelView
       .trailingAnchor
       .constraint(equalTo: widthContainerView.trailingAnchor)
-    let widthInputViewBottomAnchorWidthContainerViewBottomAnchorConstraint = widthInputView
+    let widthInputViewBottomAnchorConstraint = widthInputView
       .bottomAnchor
       .constraint(equalTo: widthContainerView.bottomAnchor)
-    let widthInputViewTopAnchorWidthLabelViewBottomAnchorConstraint = widthInputView
+    let widthInputViewTopAnchorConstraint = widthInputView
       .topAnchor
       .constraint(equalTo: widthLabelView.bottomAnchor, constant: 8)
-    let widthInputViewLeadingAnchorWidthContainerViewLeadingAnchorConstraint = widthInputView
+    let widthInputViewLeadingAnchorConstraint = widthInputView
       .leadingAnchor
       .constraint(equalTo: widthContainerView.leadingAnchor)
-    let widthInputViewTrailingAnchorWidthContainerViewTrailingAnchorConstraint = widthInputView
+    let widthInputViewTrailingAnchorConstraint = widthInputView
       .trailingAnchor
       .constraint(equalTo: widthContainerView.trailingAnchor)
     let hSpacerViewHeightAnchorConstraint = hSpacerView.heightAnchor.constraint(equalToConstant: 0)
-    let hSpacerViewWidthAnchorConstraint = hSpacerView.widthAnchor.constraint(equalToConstant: 20)
-    let heightLabelViewTopAnchorHeightContainerViewTopAnchorConstraint = heightLabelView
+    let hSpacerViewWidthAnchorConstraint = hSpacerView.widthAnchor.constraint(equalToConstant: 8)
+    let heightLabelViewTopAnchorConstraint = heightLabelView
       .topAnchor
       .constraint(equalTo: heightContainerView.topAnchor)
-    let heightLabelViewLeadingAnchorHeightContainerViewLeadingAnchorConstraint = heightLabelView
+    let heightLabelViewLeadingAnchorConstraint = heightLabelView
       .leadingAnchor
       .constraint(equalTo: heightContainerView.leadingAnchor)
-    let heightLabelViewTrailingAnchorHeightContainerViewTrailingAnchorConstraint = heightLabelView
+    let heightLabelViewTrailingAnchorConstraint = heightLabelView
       .trailingAnchor
       .constraint(equalTo: heightContainerView.trailingAnchor)
-    let heightInputViewBottomAnchorHeightContainerViewBottomAnchorConstraint = heightInputView
+    let heightInputViewBottomAnchorConstraint = heightInputView
       .bottomAnchor
       .constraint(equalTo: heightContainerView.bottomAnchor)
-    let heightInputViewTopAnchorHeightLabelViewBottomAnchorConstraint = heightInputView
+    let heightInputViewTopAnchorConstraint = heightInputView
       .topAnchor
       .constraint(equalTo: heightLabelView.bottomAnchor, constant: 8)
-    let heightInputViewLeadingAnchorHeightContainerViewLeadingAnchorConstraint = heightInputView
+    let heightInputViewLeadingAnchorConstraint = heightInputView
       .leadingAnchor
       .constraint(equalTo: heightContainerView.leadingAnchor)
-    let heightInputViewTrailingAnchorHeightContainerViewTrailingAnchorConstraint = heightInputView
+    let heightInputViewTrailingAnchorConstraint = heightInputView
       .trailingAnchor
       .constraint(equalTo: heightContainerView.trailingAnchor)
+    let nameLabelViewWidthAnchorConstraint = nameLabelView.widthAnchor.constraint(equalToConstant: 80)
+    let backgroundColorLabelViewWidthAnchorConstraint = backgroundColorLabelView
+      .widthAnchor
+      .constraint(equalToConstant: 80)
 
     layoutLabelViewHeightAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
     layoutDropdownViewHeightAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
@@ -606,199 +570,121 @@ public class CanvasInspector: NSBox {
     hSpacerViewHeightAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
     heightContainerViewHeightAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
 
-    self.deviceDropdownViewBottomAnchorDeviceValueContainerViewBottomAnchorConstraint =
-      deviceDropdownViewBottomAnchorDeviceValueContainerViewBottomAnchorConstraint
-    self.customDimensionsContainerViewBottomAnchorDeviceValueContainerViewBottomAnchorConstraint =
-      customDimensionsContainerViewBottomAnchorDeviceValueContainerViewBottomAnchorConstraint
-    self.customDimensionsContainerViewTopAnchorDeviceDropdownViewBottomAnchorConstraint =
-      customDimensionsContainerViewTopAnchorDeviceDropdownViewBottomAnchorConstraint
-    self.customDimensionsContainerViewLeadingAnchorDeviceValueContainerViewLeadingAnchorConstraint =
-      customDimensionsContainerViewLeadingAnchorDeviceValueContainerViewLeadingAnchorConstraint
-    self.customDimensionsContainerViewTrailingAnchorDeviceValueContainerViewTrailingAnchorConstraint =
-      customDimensionsContainerViewTrailingAnchorDeviceValueContainerViewTrailingAnchorConstraint
-    self.widthContainerViewHeightContainerViewWidthAnchorSiblingConstraint =
-      widthContainerViewHeightContainerViewWidthAnchorSiblingConstraint
-    self.widthContainerViewHeightAnchorParentConstraint = widthContainerViewHeightAnchorParentConstraint
-    self.hSpacerViewHeightAnchorParentConstraint = hSpacerViewHeightAnchorParentConstraint
-    self.heightContainerViewHeightAnchorParentConstraint = heightContainerViewHeightAnchorParentConstraint
-    self.widthContainerViewLeadingAnchorCustomDimensionsContainerViewLeadingAnchorConstraint =
-      widthContainerViewLeadingAnchorCustomDimensionsContainerViewLeadingAnchorConstraint
-    self.widthContainerViewTopAnchorCustomDimensionsContainerViewTopAnchorConstraint =
-      widthContainerViewTopAnchorCustomDimensionsContainerViewTopAnchorConstraint
-    self.widthContainerViewBottomAnchorCustomDimensionsContainerViewBottomAnchorConstraint =
-      widthContainerViewBottomAnchorCustomDimensionsContainerViewBottomAnchorConstraint
-    self.hSpacerViewLeadingAnchorWidthContainerViewTrailingAnchorConstraint =
-      hSpacerViewLeadingAnchorWidthContainerViewTrailingAnchorConstraint
-    self.hSpacerViewTopAnchorCustomDimensionsContainerViewTopAnchorConstraint =
-      hSpacerViewTopAnchorCustomDimensionsContainerViewTopAnchorConstraint
-    self.heightContainerViewTrailingAnchorCustomDimensionsContainerViewTrailingAnchorConstraint =
-      heightContainerViewTrailingAnchorCustomDimensionsContainerViewTrailingAnchorConstraint
-    self.heightContainerViewLeadingAnchorHSpacerViewTrailingAnchorConstraint =
-      heightContainerViewLeadingAnchorHSpacerViewTrailingAnchorConstraint
-    self.heightContainerViewTopAnchorCustomDimensionsContainerViewTopAnchorConstraint =
-      heightContainerViewTopAnchorCustomDimensionsContainerViewTopAnchorConstraint
-    self.heightContainerViewBottomAnchorCustomDimensionsContainerViewBottomAnchorConstraint =
-      heightContainerViewBottomAnchorCustomDimensionsContainerViewBottomAnchorConstraint
-    self.widthLabelViewTopAnchorWidthContainerViewTopAnchorConstraint =
-      widthLabelViewTopAnchorWidthContainerViewTopAnchorConstraint
-    self.widthLabelViewLeadingAnchorWidthContainerViewLeadingAnchorConstraint =
-      widthLabelViewLeadingAnchorWidthContainerViewLeadingAnchorConstraint
-    self.widthLabelViewTrailingAnchorWidthContainerViewTrailingAnchorConstraint =
-      widthLabelViewTrailingAnchorWidthContainerViewTrailingAnchorConstraint
-    self.widthInputViewBottomAnchorWidthContainerViewBottomAnchorConstraint =
-      widthInputViewBottomAnchorWidthContainerViewBottomAnchorConstraint
-    self.widthInputViewTopAnchorWidthLabelViewBottomAnchorConstraint =
-      widthInputViewTopAnchorWidthLabelViewBottomAnchorConstraint
-    self.widthInputViewLeadingAnchorWidthContainerViewLeadingAnchorConstraint =
-      widthInputViewLeadingAnchorWidthContainerViewLeadingAnchorConstraint
-    self.widthInputViewTrailingAnchorWidthContainerViewTrailingAnchorConstraint =
-      widthInputViewTrailingAnchorWidthContainerViewTrailingAnchorConstraint
-    self.hSpacerViewHeightAnchorConstraint = hSpacerViewHeightAnchorConstraint
-    self.hSpacerViewWidthAnchorConstraint = hSpacerViewWidthAnchorConstraint
-    self.heightLabelViewTopAnchorHeightContainerViewTopAnchorConstraint =
-      heightLabelViewTopAnchorHeightContainerViewTopAnchorConstraint
-    self.heightLabelViewLeadingAnchorHeightContainerViewLeadingAnchorConstraint =
-      heightLabelViewLeadingAnchorHeightContainerViewLeadingAnchorConstraint
-    self.heightLabelViewTrailingAnchorHeightContainerViewTrailingAnchorConstraint =
-      heightLabelViewTrailingAnchorHeightContainerViewTrailingAnchorConstraint
-    self.heightInputViewBottomAnchorHeightContainerViewBottomAnchorConstraint =
-      heightInputViewBottomAnchorHeightContainerViewBottomAnchorConstraint
-    self.heightInputViewTopAnchorHeightLabelViewBottomAnchorConstraint =
-      heightInputViewTopAnchorHeightLabelViewBottomAnchorConstraint
-    self.heightInputViewLeadingAnchorHeightContainerViewLeadingAnchorConstraint =
-      heightInputViewLeadingAnchorHeightContainerViewLeadingAnchorConstraint
-    self.heightInputViewTrailingAnchorHeightContainerViewTrailingAnchorConstraint =
-      heightInputViewTrailingAnchorHeightContainerViewTrailingAnchorConstraint
-
-    NSLayoutConstraint.activate(
-      [
-        layoutRowViewTopAnchorConstraint,
-        layoutRowViewLeadingAnchorConstraint,
-        layoutRowViewTrailingAnchorConstraint,
-        deviceRowViewTopAnchorConstraint,
-        deviceRowViewLeadingAnchorConstraint,
-        deviceRowViewTrailingAnchorConstraint,
-        nameRowViewTopAnchorConstraint,
-        nameRowViewLeadingAnchorConstraint,
-        nameRowViewTrailingAnchorConstraint,
-        backgroundColorRowViewBottomAnchorConstraint,
-        backgroundColorRowViewTopAnchorConstraint,
-        backgroundColorRowViewLeadingAnchorConstraint,
-        backgroundColorRowViewTrailingAnchorConstraint,
-        layoutLabelViewHeightAnchorParentConstraint,
-        layoutDropdownViewHeightAnchorParentConstraint,
-        layoutLabelViewLeadingAnchorConstraint,
-        layoutLabelViewTopAnchorConstraint,
-        layoutLabelViewCenterYAnchorConstraint,
-        layoutLabelViewBottomAnchorConstraint,
-        layoutDropdownViewTrailingAnchorConstraint,
-        layoutDropdownViewLeadingAnchorConstraint,
-        layoutDropdownViewTopAnchorConstraint,
-        layoutDropdownViewCenterYAnchorConstraint,
-        layoutDropdownViewBottomAnchorConstraint,
-        deviceLabelViewHeightAnchorParentConstraint,
-        deviceValueContainerViewHeightAnchorParentConstraint,
-        deviceLabelViewLeadingAnchorConstraint,
-        deviceLabelViewTopAnchorConstraint,
-        deviceLabelViewBottomAnchorConstraint,
-        deviceValueContainerViewTrailingAnchorConstraint,
-        deviceValueContainerViewLeadingAnchorConstraint,
-        deviceValueContainerViewTopAnchorConstraint,
-        deviceValueContainerViewBottomAnchorConstraint,
-        nameLabelViewHeightAnchorParentConstraint,
-        nameInputViewHeightAnchorParentConstraint,
-        nameLabelViewLeadingAnchorConstraint,
-        nameLabelViewTopAnchorConstraint,
-        nameLabelViewCenterYAnchorConstraint,
-        nameLabelViewBottomAnchorConstraint,
-        nameInputViewTrailingAnchorConstraint,
-        nameInputViewLeadingAnchorConstraint,
-        nameInputViewTopAnchorConstraint,
-        nameInputViewCenterYAnchorConstraint,
-        nameInputViewBottomAnchorConstraint,
-        backgroundColorLabelViewHeightAnchorParentConstraint,
-        backgroundColorInputViewHeightAnchorParentConstraint,
-        backgroundColorLabelViewLeadingAnchorConstraint,
-        backgroundColorLabelViewTopAnchorConstraint,
-        backgroundColorLabelViewCenterYAnchorConstraint,
-        backgroundColorLabelViewBottomAnchorConstraint,
-        backgroundColorInputViewTrailingAnchorConstraint,
-        backgroundColorInputViewLeadingAnchorConstraint,
-        backgroundColorInputViewTopAnchorConstraint,
-        backgroundColorInputViewCenterYAnchorConstraint,
-        backgroundColorInputViewBottomAnchorConstraint,
-        layoutLabelViewWidthAnchorConstraint,
-        deviceLabelViewWidthAnchorConstraint,
-        deviceDropdownViewTopAnchorConstraint,
-        deviceDropdownViewLeadingAnchorConstraint,
-        deviceDropdownViewTrailingAnchorConstraint,
-        nameLabelViewWidthAnchorConstraint,
-        backgroundColorLabelViewWidthAnchorConstraint
-      ] +
-        conditionalConstraints(customDimensionsContainerViewIsHidden: customDimensionsContainerView.isHidden))
-  }
-
-  private func conditionalConstraints(customDimensionsContainerViewIsHidden: Bool) -> [NSLayoutConstraint] {
-    var constraints: [NSLayoutConstraint?]
-
-    switch (customDimensionsContainerViewIsHidden) {
-      case (true):
-        constraints = [deviceDropdownViewBottomAnchorDeviceValueContainerViewBottomAnchorConstraint]
-      case (false):
-        constraints = [
-          customDimensionsContainerViewBottomAnchorDeviceValueContainerViewBottomAnchorConstraint,
-          customDimensionsContainerViewTopAnchorDeviceDropdownViewBottomAnchorConstraint,
-          customDimensionsContainerViewLeadingAnchorDeviceValueContainerViewLeadingAnchorConstraint,
-          customDimensionsContainerViewTrailingAnchorDeviceValueContainerViewTrailingAnchorConstraint,
-          widthContainerViewHeightContainerViewWidthAnchorSiblingConstraint,
-          widthContainerViewHeightAnchorParentConstraint,
-          hSpacerViewHeightAnchorParentConstraint,
-          heightContainerViewHeightAnchorParentConstraint,
-          widthContainerViewLeadingAnchorCustomDimensionsContainerViewLeadingAnchorConstraint,
-          widthContainerViewTopAnchorCustomDimensionsContainerViewTopAnchorConstraint,
-          widthContainerViewBottomAnchorCustomDimensionsContainerViewBottomAnchorConstraint,
-          hSpacerViewLeadingAnchorWidthContainerViewTrailingAnchorConstraint,
-          hSpacerViewTopAnchorCustomDimensionsContainerViewTopAnchorConstraint,
-          heightContainerViewTrailingAnchorCustomDimensionsContainerViewTrailingAnchorConstraint,
-          heightContainerViewLeadingAnchorHSpacerViewTrailingAnchorConstraint,
-          heightContainerViewTopAnchorCustomDimensionsContainerViewTopAnchorConstraint,
-          heightContainerViewBottomAnchorCustomDimensionsContainerViewBottomAnchorConstraint,
-          widthLabelViewTopAnchorWidthContainerViewTopAnchorConstraint,
-          widthLabelViewLeadingAnchorWidthContainerViewLeadingAnchorConstraint,
-          widthLabelViewTrailingAnchorWidthContainerViewTrailingAnchorConstraint,
-          widthInputViewBottomAnchorWidthContainerViewBottomAnchorConstraint,
-          widthInputViewTopAnchorWidthLabelViewBottomAnchorConstraint,
-          widthInputViewLeadingAnchorWidthContainerViewLeadingAnchorConstraint,
-          widthInputViewTrailingAnchorWidthContainerViewTrailingAnchorConstraint,
-          hSpacerViewHeightAnchorConstraint,
-          hSpacerViewWidthAnchorConstraint,
-          heightLabelViewTopAnchorHeightContainerViewTopAnchorConstraint,
-          heightLabelViewLeadingAnchorHeightContainerViewLeadingAnchorConstraint,
-          heightLabelViewTrailingAnchorHeightContainerViewTrailingAnchorConstraint,
-          heightInputViewBottomAnchorHeightContainerViewBottomAnchorConstraint,
-          heightInputViewTopAnchorHeightLabelViewBottomAnchorConstraint,
-          heightInputViewLeadingAnchorHeightContainerViewLeadingAnchorConstraint,
-          heightInputViewTrailingAnchorHeightContainerViewTrailingAnchorConstraint
-        ]
-    }
-
-    return constraints.compactMap({ $0 })
+    NSLayoutConstraint.activate([
+      layoutRowViewTopAnchorConstraint,
+      layoutRowViewLeadingAnchorConstraint,
+      layoutRowViewTrailingAnchorConstraint,
+      deviceRowViewTopAnchorConstraint,
+      deviceRowViewLeadingAnchorConstraint,
+      deviceRowViewTrailingAnchorConstraint,
+      nameRowViewTopAnchorConstraint,
+      nameRowViewLeadingAnchorConstraint,
+      nameRowViewTrailingAnchorConstraint,
+      backgroundColorRowViewBottomAnchorConstraint,
+      backgroundColorRowViewTopAnchorConstraint,
+      backgroundColorRowViewLeadingAnchorConstraint,
+      backgroundColorRowViewTrailingAnchorConstraint,
+      layoutLabelViewHeightAnchorParentConstraint,
+      layoutDropdownViewHeightAnchorParentConstraint,
+      layoutLabelViewLeadingAnchorConstraint,
+      layoutLabelViewTopAnchorConstraint,
+      layoutLabelViewCenterYAnchorConstraint,
+      layoutLabelViewBottomAnchorConstraint,
+      layoutDropdownViewTrailingAnchorConstraint,
+      layoutDropdownViewLeadingAnchorConstraint,
+      layoutDropdownViewTopAnchorConstraint,
+      layoutDropdownViewCenterYAnchorConstraint,
+      layoutDropdownViewBottomAnchorConstraint,
+      deviceLabelViewHeightAnchorParentConstraint,
+      deviceValueContainerViewHeightAnchorParentConstraint,
+      deviceLabelViewLeadingAnchorConstraint,
+      deviceLabelViewTopAnchorConstraint,
+      deviceLabelViewBottomAnchorConstraint,
+      deviceValueContainerViewTrailingAnchorConstraint,
+      deviceValueContainerViewLeadingAnchorConstraint,
+      deviceValueContainerViewTopAnchorConstraint,
+      deviceValueContainerViewBottomAnchorConstraint,
+      nameLabelViewHeightAnchorParentConstraint,
+      nameInputViewHeightAnchorParentConstraint,
+      nameLabelViewLeadingAnchorConstraint,
+      nameLabelViewTopAnchorConstraint,
+      nameLabelViewCenterYAnchorConstraint,
+      nameLabelViewBottomAnchorConstraint,
+      nameInputViewTrailingAnchorConstraint,
+      nameInputViewLeadingAnchorConstraint,
+      nameInputViewTopAnchorConstraint,
+      nameInputViewCenterYAnchorConstraint,
+      nameInputViewBottomAnchorConstraint,
+      backgroundColorLabelViewHeightAnchorParentConstraint,
+      backgroundColorInputViewHeightAnchorParentConstraint,
+      backgroundColorLabelViewLeadingAnchorConstraint,
+      backgroundColorLabelViewTopAnchorConstraint,
+      backgroundColorLabelViewCenterYAnchorConstraint,
+      backgroundColorLabelViewBottomAnchorConstraint,
+      backgroundColorInputViewTrailingAnchorConstraint,
+      backgroundColorInputViewLeadingAnchorConstraint,
+      backgroundColorInputViewTopAnchorConstraint,
+      backgroundColorInputViewCenterYAnchorConstraint,
+      backgroundColorInputViewBottomAnchorConstraint,
+      layoutLabelViewWidthAnchorConstraint,
+      deviceLabelViewWidthAnchorConstraint,
+      deviceDropdownViewTopAnchorConstraint,
+      deviceDropdownViewLeadingAnchorConstraint,
+      deviceDropdownViewTrailingAnchorConstraint,
+      customDimensionsContainerViewBottomAnchorConstraint,
+      customDimensionsContainerViewTopAnchorConstraint,
+      customDimensionsContainerViewLeadingAnchorConstraint,
+      customDimensionsContainerViewTrailingAnchorConstraint,
+      widthContainerViewHeightContainerViewWidthAnchorSiblingConstraint,
+      widthContainerViewHeightAnchorParentConstraint,
+      hSpacerViewHeightAnchorParentConstraint,
+      heightContainerViewHeightAnchorParentConstraint,
+      widthContainerViewLeadingAnchorConstraint,
+      widthContainerViewTopAnchorConstraint,
+      widthContainerViewBottomAnchorConstraint,
+      hSpacerViewLeadingAnchorConstraint,
+      hSpacerViewTopAnchorConstraint,
+      heightContainerViewTrailingAnchorConstraint,
+      heightContainerViewLeadingAnchorConstraint,
+      heightContainerViewTopAnchorConstraint,
+      heightContainerViewBottomAnchorConstraint,
+      widthLabelViewTopAnchorConstraint,
+      widthLabelViewLeadingAnchorConstraint,
+      widthLabelViewTrailingAnchorConstraint,
+      widthInputViewBottomAnchorConstraint,
+      widthInputViewTopAnchorConstraint,
+      widthInputViewLeadingAnchorConstraint,
+      widthInputViewTrailingAnchorConstraint,
+      hSpacerViewHeightAnchorConstraint,
+      hSpacerViewWidthAnchorConstraint,
+      heightLabelViewTopAnchorConstraint,
+      heightLabelViewLeadingAnchorConstraint,
+      heightLabelViewTrailingAnchorConstraint,
+      heightInputViewBottomAnchorConstraint,
+      heightInputViewTopAnchorConstraint,
+      heightInputViewLeadingAnchorConstraint,
+      heightInputViewTrailingAnchorConstraint,
+      nameLabelViewWidthAnchorConstraint,
+      backgroundColorLabelViewWidthAnchorConstraint
+    ])
   }
 
   private func update() {
-    let customDimensionsContainerViewIsHidden = customDimensionsContainerView.isHidden
-
+    heightLabelView.attributedStringValue = heightLabelViewTextStyle.apply(to: "Height")
     layoutDropdownView.selectedIndex = 0
-    customDimensionsContainerView.isHidden = !showsDimensionInputs
+    heightInputView.disabled = showsDimensionInputs
+    widthInputView.disabled = showsDimensionInputs
     deviceDropdownView.values = availableDevices
     deviceDropdownView.selectedIndex = deviceIndex
     deviceDropdownView.onChangeIndex = handleOnChangeDeviceIndex
+    layoutDropdownView.onChangeIndex = handleOnChangeHeightModeIndex
     widthInputView.numberValue = canvasWidth
     heightInputView.numberValue = canvasHeight
     backgroundColorInputView.textValue = backgroundColorId
     nameInputView.placeholderString = canvasNamePlaceholder
     if heightMode == .flexibleHeight {
       layoutDropdownView.selectedIndex = 0
+      heightLabelView.attributedStringValue = heightLabelViewTextStyle.apply(to: "Min Height")
     }
     if heightMode == .fixedHeight {
       layoutDropdownView.selectedIndex = 1
@@ -811,13 +697,6 @@ public class CanvasInspector: NSBox {
     nameInputView.onChangeTextValue = handleOnChangeCanvasName
     heightInputView.onChangeNumberValue = handleOnChangeCanvasHeight
     widthInputView.onChangeNumberValue = handleOnChangeCanvasWidth
-
-    if customDimensionsContainerView.isHidden != customDimensionsContainerViewIsHidden {
-      NSLayoutConstraint.deactivate(
-        conditionalConstraints(customDimensionsContainerViewIsHidden: customDimensionsContainerViewIsHidden))
-      NSLayoutConstraint.activate(
-        conditionalConstraints(customDimensionsContainerViewIsHidden: customDimensionsContainerView.isHidden))
-    }
   }
 
   private func handleOnChangeDeviceIndex(_ arg0: Int) {
@@ -834,6 +713,10 @@ public class CanvasInspector: NSBox {
 
   private func handleOnChangeCanvasHeight(_ arg0: CGFloat) {
     onChangeCanvasHeight?(arg0)
+  }
+
+  private func handleOnChangeHeightModeIndex(_ arg0: Int) {
+    onChangeHeightModeIndex?(arg0)
   }
 }
 
@@ -855,6 +738,7 @@ extension CanvasInspector {
     public var onChangeCanvasName: StringHandler
     public var onChangeCanvasWidth: ((CGFloat) -> Void)?
     public var onChangeCanvasHeight: ((CGFloat) -> Void)?
+    public var onChangeHeightModeIndex: ((Int) -> Void)?
 
     public init(
       showsDimensionInputs: Bool,
@@ -870,7 +754,8 @@ extension CanvasInspector {
       onChangeDeviceIndex: ((Int) -> Void)? = nil,
       onChangeCanvasName: StringHandler = nil,
       onChangeCanvasWidth: ((CGFloat) -> Void)? = nil,
-      onChangeCanvasHeight: ((CGFloat) -> Void)? = nil)
+      onChangeCanvasHeight: ((CGFloat) -> Void)? = nil,
+      onChangeHeightModeIndex: ((Int) -> Void)? = nil)
     {
       self.showsDimensionInputs = showsDimensionInputs
       self.availableDevices = availableDevices
@@ -886,6 +771,7 @@ extension CanvasInspector {
       self.onChangeCanvasName = onChangeCanvasName
       self.onChangeCanvasWidth = onChangeCanvasWidth
       self.onChangeCanvasHeight = onChangeCanvasHeight
+      self.onChangeHeightModeIndex = onChangeHeightModeIndex
     }
 
     public init() {
@@ -951,7 +837,8 @@ extension CanvasInspector {
       onChangeDeviceIndex: ((Int) -> Void)? = nil,
       onChangeCanvasName: StringHandler = nil,
       onChangeCanvasWidth: ((CGFloat) -> Void)? = nil,
-      onChangeCanvasHeight: ((CGFloat) -> Void)? = nil)
+      onChangeCanvasHeight: ((CGFloat) -> Void)? = nil,
+      onChangeHeightModeIndex: ((Int) -> Void)? = nil)
     {
       self
         .init(
@@ -969,7 +856,8 @@ extension CanvasInspector {
             onChangeDeviceIndex: onChangeDeviceIndex,
             onChangeCanvasName: onChangeCanvasName,
             onChangeCanvasWidth: onChangeCanvasWidth,
-            onChangeCanvasHeight: onChangeCanvasHeight))
+            onChangeCanvasHeight: onChangeCanvasHeight,
+            onChangeHeightModeIndex: onChangeHeightModeIndex))
     }
 
     public init() {

--- a/studio/LonaStudio/Generated/inspector/CanvasInspector.swift
+++ b/studio/LonaStudio/Generated/inspector/CanvasInspector.swift
@@ -282,7 +282,7 @@ public class CanvasInspector: NSBox {
     backgroundColorRowView.addSubview(backgroundColorInputView)
 
     layoutLabelView.attributedStringValue = layoutLabelViewTextStyle.apply(to: "Layout")
-    layoutDropdownView.values = ["Flexible-height", "Fixed-height"]
+    layoutDropdownView.values = ["Flexible-height", "Fixed-size"]
     deviceLabelView.attributedStringValue = deviceLabelViewTextStyle.apply(to: "Device")
     widthLabelView.attributedStringValue = widthLabelViewTextStyle.apply(to: "Width")
     nameLabelView.attributedStringValue = nameLabelViewTextStyle.apply(to: "Name")

--- a/studio/LonaStudio/Models/CSComponent.swift
+++ b/studio/LonaStudio/Models/CSComponent.swift
@@ -230,11 +230,7 @@ class CSComponent: DataNode, NSCopying {
     static func makeDefaultComponent() -> CSComponent {
         return CSComponent(
             name: "Component",
-            canvas: [
-                Canvas(visible: true, name: "iPhone SE", width: 320, height: 100, heightMode: "At Least", exportScale: 1, backgroundColor: "white"),
-                Canvas(visible: true, name: "iPhone 7", width: 375, height: 100, heightMode: "At Least", exportScale: 1, backgroundColor: "white"),
-                Canvas(visible: true, name: "iPhone 7+", width: 414, height: 100, heightMode: "At Least", exportScale: 1, backgroundColor: "white")
-                ],
+            canvas: Canvas.createDefaultCanvasList(),
             rootLayer: CSLayer(name: "View", type: .view, parameters: [
                 "alignSelf": "stretch".toData()
                 ]),

--- a/studio/LonaStudio/Models/Canvas.swift
+++ b/studio/LonaStudio/Models/Canvas.swift
@@ -33,18 +33,42 @@ class Canvas: CSDataSerializable, CSDataDeserializable, NSCopying {
     var backgroundColor: String = "white"
     var exportScale: Double = 1
     var parameters: CSData = CSData.Object([:])
+    var device: Device = .custom
+
+    var computedHeight: CGFloat {
+        switch device {
+        case .custom:
+            return CGFloat(height)
+        case .preset(let devicePreset):
+            switch heightMode {
+            case "At Least":
+                return 1
+            default:
+                return devicePreset.height
+            }
+        }
+    }
+
+    var computedWidth: CGFloat {
+        switch device {
+        case .custom:
+            return CGFloat(width)
+        case .preset(let devicePreset):
+            return devicePreset.width
+        }
+    }
 
     var label: String {
         return name
     }
 
-    var aspectRatio: Double {
-        return width / height
-    }
+//    var aspectRatio: Double {
+//        return width / height
+//    }
 
     func value() -> CSValue {
         var data = toData()
-        data.set(keyPath: ["aspectRatio"], to: aspectRatio.toData())
+//        data.set(keyPath: ["aspectRatio"], to: aspectRatio.toData())
         return CSValue(type: CSCanvasType, data: data)
     }
 
@@ -59,8 +83,20 @@ class Canvas: CSDataSerializable, CSDataDeserializable, NSCopying {
     required init(_ data: CSData) {
         visible = data.get(key: "visible").bool ?? true
         name = data.get(key: "name").stringValue
-        width = data.get(key: "width").numberValue
-        height = data.get(key: "height").numberValue
+
+        if let deviceId = data.get(key: "deviceId").string,
+            let devicePreset = Canvas.devicePresets.first(where: { $0.name == deviceId }) {
+            device = .preset(devicePreset)
+
+            width = Double(devicePreset.width)
+            height = Double(devicePreset.height)
+        } else {
+            device = .custom
+
+            width = data.get(key: "width").numberValue
+            height = data.get(key: "height").numberValue
+        }
+
         heightMode = data.get(key: "heightMode").stringValue
         exportScale = data.get(key: "exportScale").number ?? 1
         backgroundColor = data.get(key: "backgroundColor").string ?? "white"
@@ -80,9 +116,6 @@ class Canvas: CSDataSerializable, CSDataDeserializable, NSCopying {
 
     func toData() -> CSData {
         var data = CSData.Object([
-            "name": name.toData(),
-            "width": width.toData(),
-            "height": height.toData(),
             "heightMode": heightMode.toData()
         ])
 
@@ -100,6 +133,19 @@ class Canvas: CSDataSerializable, CSDataDeserializable, NSCopying {
 
         if !parameters.objectValue.isEmpty {
             data["params"] = parameters
+        }
+
+        switch device {
+        case .preset(let devicePreset):
+            data["deviceId"] = devicePreset.name.toData()
+
+            if name != devicePreset.name {
+                data["name"] = name.toData()
+            }
+        case .custom:
+            data["width"] = width.toData()
+            data["height"] = height.toData()
+            data["name"] = name.toData()
         }
 
         return data
@@ -121,6 +167,41 @@ extension Canvas: Equatable {
             lhs.heightMode == rhs.heightMode &&
             lhs.backgroundColor == rhs.backgroundColor &&
             lhs.exportScale == rhs.exportScale &&
-            lhs.parameters == rhs.parameters)
+            lhs.parameters == rhs.parameters &&
+            lhs.device == rhs.device)
     }
+}
+
+extension Canvas {
+    enum Device: Equatable {
+        case custom
+        case preset(DevicePreset)
+    }
+
+    struct DevicePreset: Equatable {
+        let name: String
+        let width: CGFloat
+        let height: CGFloat
+    }
+
+    static let devicePresets: [DevicePreset] = [
+        DevicePreset(name: "iPhone 8", width: 375, height: 667),
+        DevicePreset(name: "iPhone 8 Plus", width: 414, height: 736),
+        DevicePreset(name: "iPhone SE", width: 320, height: 568),
+        DevicePreset(name: "iPhone XS", width: 375, height: 812),
+        DevicePreset(name: "iPhone XR", width: 414, height: 896),
+        DevicePreset(name: "iPhone XS Max", width: 414, height: 896),
+        DevicePreset(name: "iPad", width: 768, height: 1024),
+        DevicePreset(name: "iPad Pro 10.5\"", width: 834, height: 1112),
+        DevicePreset(name: "iPad Pro 11\"", width: 834, height: 1194),
+        DevicePreset(name: "iPad Pro 12.9\"", width: 1024, height: 1366),
+        DevicePreset(name: "Pixel 2", width: 412, height: 732),
+        DevicePreset(name: "Pixel 2 XL", width: 360, height: 720),
+        DevicePreset(name: "Galaxy S8", width: 360, height: 740),
+        DevicePreset(name: "Nexus 7", width: 600, height: 960),
+        DevicePreset(name: "Nexus 9", width: 768, height: 1024),
+        DevicePreset(name: "Nexus 10", width: 800, height: 1280),
+        DevicePreset(name: "Desktop", width: 1024, height: 1024),
+        DevicePreset(name: "Desktop HD", width: 1440, height: 1024)
+    ]
 }

--- a/studio/LonaStudio/Models/Canvas.swift
+++ b/studio/LonaStudio/Models/Canvas.swift
@@ -124,6 +124,45 @@ class Canvas: CSDataSerializable, CSDataDeserializable, NSCopying {
         self.parameters = parameters
     }
 
+    required init(
+        device: Device,
+        name: String = "",
+        heightMode: String = "At Least",
+        exportScale: Double = 1,
+        backgroundColor: String = "white") {
+        self.device = device
+        self.name = name
+        self.heightMode = heightMode
+        self.exportScale = exportScale
+        self.backgroundColor = backgroundColor
+
+        switch device {
+        case .custom:
+            break
+        case .preset(let preset):
+            width = Double(preset.width)
+
+            if heightMode == "At Least" {
+                height = 1
+            } else {
+                height = Double(preset.height)
+            }
+        }
+    }
+
+    static func createDefaultCanvas() -> Canvas {
+        return Canvas(device: .preset(Canvas.devicePresets[0]))
+    }
+
+    static func createDefaultCanvasList() -> [Canvas] {
+        let ios = Canvas.devicePresets.first(where: { $0.name == "iPhone SE" })!
+        let android = Canvas.devicePresets.first(where: { $0.name == "Pixel 2" })!
+        return [
+            Canvas(device: .preset(ios)),
+            Canvas(device: .preset(android))
+        ]
+    }
+
     func toData() -> CSData {
         var data = CSData.Object([
             "heightMode": heightMode.toData()
@@ -195,9 +234,9 @@ extension Canvas {
     }
 
     static let devicePresets: [DevicePreset] = [
+        DevicePreset(name: "iPhone SE", width: 320, height: 568),
         DevicePreset(name: "iPhone 8", width: 375, height: 667),
         DevicePreset(name: "iPhone 8 Plus", width: 414, height: 736),
-        DevicePreset(name: "iPhone SE", width: 320, height: 568),
         DevicePreset(name: "iPhone XS", width: 375, height: 812),
         DevicePreset(name: "iPhone XR", width: 414, height: 896),
         DevicePreset(name: "iPhone XS Max", width: 414, height: 896),

--- a/studio/LonaStudio/Models/Canvas.swift
+++ b/studio/LonaStudio/Models/Canvas.swift
@@ -11,7 +11,6 @@ import Foundation
 let CSCanvasType = CSType.dictionary([
     "height": (type: CSType.number, access: .read),
     "width": (type: CSType.number, access: .read),
-    "aspectRatio": (type: CSType.number, access: .read),
     "index": (type: CSType.number, access: .read),
     "name": (type: CSType.number, access: .read)
 ])
@@ -19,7 +18,6 @@ let CSCanvasType = CSType.dictionary([
 let CSEmptyCanvasValue = CSValue(type: CSCanvasType, data: .Object([
     "height": CSData.Null,
     "width": CSData.Null,
-    "aspectRatio": CSData.Null,
     "index": CSData.Null,
     "name": CSData.Null
 ]))
@@ -34,6 +32,19 @@ class Canvas: CSDataSerializable, CSDataDeserializable, NSCopying {
     var exportScale: Double = 1
     var parameters: CSData = CSData.Object([:])
     var device: Device = .custom
+
+    var computedName: String {
+        switch device {
+        case .preset(let devicePreset):
+            if !name.isEmpty && name != devicePreset.name {
+                return name
+            } else {
+                return devicePreset.name
+            }
+        case .custom:
+            return name
+        }
+    }
 
     var computedHeight: CGFloat {
         switch device {
@@ -62,14 +73,8 @@ class Canvas: CSDataSerializable, CSDataDeserializable, NSCopying {
         return name
     }
 
-//    var aspectRatio: Double {
-//        return width / height
-//    }
-
     func value() -> CSValue {
-        var data = toData()
-//        data.set(keyPath: ["aspectRatio"], to: aspectRatio.toData())
-        return CSValue(type: CSCanvasType, data: data)
+        return CSValue(type: CSCanvasType, data: toData())
     }
 
     func dimensionsString() -> String {
@@ -139,7 +144,7 @@ class Canvas: CSDataSerializable, CSDataDeserializable, NSCopying {
         case .preset(let devicePreset):
             data["deviceId"] = devicePreset.name.toData()
 
-            if name != devicePreset.name {
+            if !name.isEmpty && name != devicePreset.name {
                 data["name"] = name.toData()
             }
         case .custom:

--- a/studio/LonaStudio/Models/Canvas.swift
+++ b/studio/LonaStudio/Models/Canvas.swift
@@ -69,10 +69,6 @@ class Canvas: CSDataSerializable, CSDataDeserializable, NSCopying {
         }
     }
 
-    var label: String {
-        return name
-    }
-
     func value() -> CSValue {
         return CSValue(type: CSCanvasType, data: toData())
     }

--- a/studio/LonaStudio/Models/Canvas.swift
+++ b/studio/LonaStudio/Models/Canvas.swift
@@ -88,13 +88,19 @@ class Canvas: CSDataSerializable, CSDataDeserializable, NSCopying {
     required init(_ data: CSData) {
         visible = data.get(key: "visible").bool ?? true
         name = data.get(key: "name").stringValue
+        heightMode = data.get(key: "heightMode").stringValue
 
         if let deviceId = data.get(key: "deviceId").string,
             let devicePreset = Canvas.devicePresets.first(where: { $0.name == deviceId }) {
             device = .preset(devicePreset)
 
             width = Double(devicePreset.width)
-            height = Double(devicePreset.height)
+
+            if heightMode == "At Least" {
+                height = 1
+            } else {
+                height = Double(devicePreset.height)
+            }
         } else {
             device = .custom
 
@@ -102,7 +108,6 @@ class Canvas: CSDataSerializable, CSDataDeserializable, NSCopying {
             height = data.get(key: "height").numberValue
         }
 
-        heightMode = data.get(key: "heightMode").stringValue
         exportScale = data.get(key: "exportScale").number ?? 1
         backgroundColor = data.get(key: "backgroundColor").string ?? "white"
         parameters = data["params"] ?? data["parameters"] ?? CSData.Object([:])

--- a/studio/LonaStudio/Models/LogicNode.swift
+++ b/studio/LonaStudio/Models/LogicNode.swift
@@ -84,7 +84,7 @@ class LogicNode: DataNodeParent, DataNodeCopying {
             if let arg = argument(from: decl.content) {
                 invocation.arguments["value"] = arg
             }
-            invocation.name = "if let(variable, equal value)"
+            invocation.name = "let(variable, equal value)"
 
             node.invocation = invocation
         case .ifExpression(let content):

--- a/studio/LonaStudio/Models/LogicNode.swift
+++ b/studio/LonaStudio/Models/LogicNode.swift
@@ -71,6 +71,22 @@ class LogicNode: DataNodeParent, DataNodeCopying {
                 invocation.name = "assign(lhs, to rhs)"
             }
             node.invocation = invocation
+        case .variableDeclarationExpression(let decl):
+            var invocation = CSFunction.Invocation()
+
+            switch decl.identifier {
+            case .identifierExpression(let op):
+                invocation.arguments["variable"] = CSFunction.Argument.value(
+                    CSValue(type: CSType.string, data: op.toData()))
+            default:
+                break
+            }
+            if let arg = argument(from: decl.content) {
+                invocation.arguments["value"] = arg
+            }
+            invocation.name = "if let(variable, equal value)"
+
+            node.invocation = invocation
         case .ifExpression(let content):
             var invocation = CSFunction.Invocation()
 
@@ -175,6 +191,18 @@ class LogicNode: DataNodeParent, DataNodeCopying {
                 condition: .variableDeclarationExpression(decl),
                 body: nodes.map({ logicNode in logicNode.expression() }))
             return .ifExpression(content)
+        case "let(variable, equal value)":
+            let id: LonaExpression
+            switch optionalExpression(from: invocation.arguments["variable"]) {
+            case .literalExpression(let value):
+                id = .identifierExpression(value.data.stringValue)
+            default:
+                id = .placeholderExpression
+            }
+            let decl = VariableDeclarationNode(
+                identifier: id,
+                content: optionalExpression(from: invocation.arguments["value"]))
+            return .variableDeclarationExpression(decl)
         default:
             return .placeholderExpression
         }

--- a/studio/LonaStudio/Workspace/ComponentEditorViewController.swift
+++ b/studio/LonaStudio/Workspace/ComponentEditorViewController.swift
@@ -44,6 +44,7 @@ class ComponentEditorViewController: NSSplitViewController {
     public var onChangeInspectedCanvas: ((Int) -> Void)?
     public var onDeleteCanvas: ((Int) -> Void)?
     public var onAddCanvas: (() -> Void)?
+    public var onMoveCanvas: ((Int, Int) -> Void)?
 
     public func updateCanvas() {
         updateCanvasCollectionView()
@@ -123,6 +124,10 @@ class ComponentEditorViewController: NSSplitViewController {
 
         canvasAreaView.onAddCanvas = { [unowned self] in
             self.onAddCanvas?()
+        }
+
+        canvasAreaView.onMoveCanvasHeaderItem = { [unowned self] index, newIndex in
+            self.onMoveCanvas?(index, newIndex)
         }
 
         let tabs = SegmentedControlField(

--- a/studio/LonaStudio/Workspace/ComponentEditorViewController.swift
+++ b/studio/LonaStudio/Workspace/ComponentEditorViewController.swift
@@ -37,6 +37,7 @@ class ComponentEditorViewController: NSSplitViewController {
 
     public var onInspectLayer: ((CSLayer?) -> Void)?
     public var onChangeInspectedLayer: (() -> Void)?
+    public var onChangeInspectedCanvas: ((Int) -> Void)?
 
     public func updateCanvas() {
         updateCanvasCollectionView()
@@ -105,6 +106,10 @@ class ComponentEditorViewController: NSSplitViewController {
         setUpUtilities()
 
         layerList.fillColor = .white
+
+        canvasAreaView.onSelectCanvasHeaderItem = { [unowned self] index in
+            self.onChangeInspectedCanvas?(index)
+        }
 
         let tabs = SegmentedControlField(
             frame: NSRect(x: 0, y: 0, width: 500, height: 24),

--- a/studio/LonaStudio/Workspace/ComponentEditorViewController.swift
+++ b/studio/LonaStudio/Workspace/ComponentEditorViewController.swift
@@ -42,6 +42,7 @@ class ComponentEditorViewController: NSSplitViewController {
     public var onInspectLayer: ((CSLayer?) -> Void)?
     public var onChangeInspectedLayer: (() -> Void)?
     public var onChangeInspectedCanvas: ((Int) -> Void)?
+    public var onDeleteCanvas: ((Int) -> Void)?
 
     public func updateCanvas() {
         updateCanvasCollectionView()
@@ -113,6 +114,10 @@ class ComponentEditorViewController: NSSplitViewController {
 
         canvasAreaView.onSelectCanvasHeaderItem = { [unowned self] index in
             self.onChangeInspectedCanvas?(index)
+        }
+
+        canvasAreaView.onDeleteCanvasHeaderItem = { [unowned self] index in
+            self.onDeleteCanvas?(index)
         }
 
         let tabs = SegmentedControlField(

--- a/studio/LonaStudio/Workspace/ComponentEditorViewController.swift
+++ b/studio/LonaStudio/Workspace/ComponentEditorViewController.swift
@@ -131,9 +131,8 @@ class ComponentEditorViewController: NSSplitViewController {
         }
 
         let tabs = SegmentedControlField(
-            frame: NSRect(x: 0, y: 0, width: 500, height: 24),
+            frame: NSRect(x: 0, y: 0, width: 400, height: 24),
             values: [
-                UtilitiesView.Tab.devices.rawValue,
                 UtilitiesView.Tab.parameters.rawValue,
                 UtilitiesView.Tab.logic.rawValue,
                 UtilitiesView.Tab.examples.rawValue,
@@ -146,7 +145,7 @@ class ComponentEditorViewController: NSSplitViewController {
             guard let tab = UtilitiesView.Tab(rawValue: value) else { return }
             self.utilitiesView.currentTab = tab
         }
-        tabs.value = UtilitiesView.Tab.devices.rawValue
+        tabs.value = UtilitiesView.Tab.parameters.rawValue
 
         let splitView = SectionSplitter()
         splitView.addSubviewToDivider(tabs)

--- a/studio/LonaStudio/Workspace/ComponentEditorViewController.swift
+++ b/studio/LonaStudio/Workspace/ComponentEditorViewController.swift
@@ -43,6 +43,7 @@ class ComponentEditorViewController: NSSplitViewController {
     public var onChangeInspectedLayer: (() -> Void)?
     public var onChangeInspectedCanvas: ((Int) -> Void)?
     public var onDeleteCanvas: ((Int) -> Void)?
+    public var onAddCanvas: (() -> Void)?
 
     public func updateCanvas() {
         updateCanvasCollectionView()
@@ -118,6 +119,10 @@ class ComponentEditorViewController: NSSplitViewController {
 
         canvasAreaView.onDeleteCanvasHeaderItem = { [unowned self] index in
             self.onDeleteCanvas?(index)
+        }
+
+        canvasAreaView.onAddCanvas = { [unowned self] in
+            self.onAddCanvas?()
         }
 
         let tabs = SegmentedControlField(

--- a/studio/LonaStudio/Workspace/ComponentEditorViewController.swift
+++ b/studio/LonaStudio/Workspace/ComponentEditorViewController.swift
@@ -29,6 +29,10 @@ class ComponentEditorViewController: NSSplitViewController {
 
     public var component: CSComponent? = nil { didSet { update(withoutModifyingSelection: false) } }
     public var selectedLayerName: String? = nil { didSet { update(withoutModifyingSelection: true) } }
+    public var selectedCanvasHeaderItem: Int? {
+        get { return canvasAreaView.selectedHeaderItem }
+        set { canvasAreaView.selectedHeaderItem = newValue }
+    }
 
     public var canvasPanningEnabled: Bool {
         get { return canvasAreaView.panningEnabled }

--- a/studio/LonaStudio/Workspace/Inspector View/InspectorView.swift
+++ b/studio/LonaStudio/Workspace/Inspector View/InspectorView.swift
@@ -270,6 +270,12 @@ final class InspectorView: NSBox {
                 self.onChangeContent?(.canvas(newCanvas), .canvas)
             }
 
+            canvasInspector.onChangeBackgroundColorId = { value in
+                let newCanvas = canvas.copy() as! Canvas
+                newCanvas.backgroundColor = value
+                self.onChangeContent?(.canvas(newCanvas), .canvas)
+            }
+
             canvasInspector.onChangeHeightModeIndex = { index in
                 let newCanvas = canvas.copy() as! Canvas
 

--- a/studio/LonaStudio/Workspace/Inspector View/InspectorView.swift
+++ b/studio/LonaStudio/Workspace/Inspector View/InspectorView.swift
@@ -21,6 +21,7 @@ final class InspectorView: NSBox {
         case layer(CSLayer)
         case color(CSColor)
         case textStyle(CSTextStyle)
+        case canvas(Canvas)
 
         init?(_ color: CSColor?) {
             guard let color = color else { return nil }
@@ -32,6 +33,10 @@ final class InspectorView: NSBox {
             guard let textStyle = textStyle else { return nil }
 
             self = .textStyle(textStyle)
+        }
+
+        init?(_ canvas: Canvas) {
+            self = .canvas(canvas)
         }
     }
 
@@ -211,6 +216,17 @@ final class InspectorView: NSBox {
 
         case .textStyle:
             inspectorView.removeFromSuperview()
+        case .canvas:
+            inspectorView.removeFromSuperview()
+
+            inspectorView = CanvasInspector()
+
+            flippedView.addSubview(inspectorView)
+
+            inspectorView.widthAnchor.constraint(equalTo: flippedView.widthAnchor).isActive = true
+            inspectorView.heightAnchor.constraint(equalTo: flippedView.heightAnchor).isActive = true
+            inspectorView.topAnchor.constraint(equalTo: flippedView.topAnchor).isActive = true
+            inspectorView.bottomAnchor.constraint(equalTo: flippedView.bottomAnchor).isActive = true
         }
     }
 }

--- a/studio/LonaStudio/Workspace/Inspector View/InspectorView.swift
+++ b/studio/LonaStudio/Workspace/Inspector View/InspectorView.swift
@@ -270,17 +270,61 @@ final class InspectorView: NSBox {
                 self.onChangeContent?(.canvas(newCanvas), .canvas)
             }
 
+            canvasInspector.onChangeHeightModeIndex = { index in
+                let newCanvas = canvas.copy() as! Canvas
+
+                if index == 0 {
+                    newCanvas.heightMode = "At Least"
+
+                    switch canvas.device {
+                    case .custom:
+                        break
+                    case .preset:
+                        newCanvas.height = 1
+                    }
+                } else {
+                    newCanvas.heightMode = "Exactly"
+
+                    switch canvas.device {
+                    case .custom:
+                        break
+                    case .preset(let device):
+                        newCanvas.height = Double(device.height)
+                    }
+                }
+
+                self.onChangeContent?(.canvas(newCanvas), .canvas)
+            }
+
             canvasInspector.onChangeDeviceIndex = { index in
                 let newCanvas = canvas.copy() as! Canvas
 
                 if index == 0 {
                     newCanvas.device = .custom
+
+                    switch canvas.device {
+                    case .custom:
+                        break
+                    case .preset(let device):
+                        newCanvas.width = Double(device.width)
+
+                        if canvas.heightMode == "At Least" {
+                            newCanvas.height = 1
+                        } else {
+                            newCanvas.height = Double(device.height)
+                        }
+                    }
                 } else {
                     // Subtract one from the index, since we added "Custom" to the array of names
                     let preset = Canvas.devicePresets[index - 1]
                     newCanvas.device = .preset(preset)
                     newCanvas.width = Double(preset.width)
-                    newCanvas.height = Double(preset.height)
+
+                    if canvas.heightMode == "At Least" {
+                        newCanvas.height = 1
+                    } else {
+                        newCanvas.height = Double(preset.height)
+                    }
                 }
 
                 self.onChangeContent?(.canvas(newCanvas), .canvas)

--- a/studio/LonaStudio/Workspace/Inspector View/InspectorView.swift
+++ b/studio/LonaStudio/Workspace/Inspector View/InspectorView.swift
@@ -237,14 +237,13 @@ final class InspectorView: NSBox {
             switch canvas.device {
             case .custom:
                 canvasInspector.deviceIndex = 0
+                canvasInspector.canvasNamePlaceholder = "Custom name"
                 canvasInspector.canvasName = canvas.name
             case .preset(let device):
                 canvasInspector.deviceIndex = devicePresets.firstIndex(of: device.name) ?? 0
                 canvasInspector.canvasNamePlaceholder = device.name
                 canvasInspector.canvasName = canvas.name == device.name ? nil : canvas.name
             }
-
-            Swift.print("Set canvasInspector name", canvasInspector.canvasName)
 
             canvasInspector.onChangeCanvasName = { name in
                 let newCanvas = canvas.copy() as! Canvas

--- a/studio/LonaStudio/Workspace/Inspector View/InspectorView.swift
+++ b/studio/LonaStudio/Workspace/Inspector View/InspectorView.swift
@@ -216,17 +216,27 @@ final class InspectorView: NSBox {
 
         case .textStyle:
             inspectorView.removeFromSuperview()
-        case .canvas:
+        case .canvas(let canvas):
             inspectorView.removeFromSuperview()
 
-            inspectorView = CanvasInspector()
+            let canvasInspector = CanvasInspector()
+
+            canvasInspector.showsDimensionInputs = true
+            canvasInspector.canvasHeight = CGFloat(canvas.height)
+            canvasInspector.canvasWidth = CGFloat(canvas.width)
+            canvasInspector.heightMode = canvas.heightMode == "At Least" ? .flexibleHeight : .fixedHeight
+            canvasInspector.canvasName = canvas.name
+
+            inspectorView = canvasInspector
 
             flippedView.addSubview(inspectorView)
 
-            inspectorView.widthAnchor.constraint(equalTo: flippedView.widthAnchor).isActive = true
-            inspectorView.heightAnchor.constraint(equalTo: flippedView.heightAnchor).isActive = true
+            inspectorView.leadingAnchor.constraint(equalTo: flippedView.leadingAnchor).isActive = true
+            inspectorView.trailingAnchor.constraint(equalTo: flippedView.trailingAnchor).isActive = true
             inspectorView.topAnchor.constraint(equalTo: flippedView.topAnchor).isActive = true
             inspectorView.bottomAnchor.constraint(equalTo: flippedView.bottomAnchor).isActive = true
+
+
         }
     }
 }

--- a/studio/LonaStudio/Workspace/UtilitiesView.swift
+++ b/studio/LonaStudio/Workspace/UtilitiesView.swift
@@ -12,16 +12,15 @@ import AppKit
 class UtilitiesView: NSBox {
 
     enum Tab: String {
-        case details = "Details"
-        case devices = "Devices"
         case parameters = "Parameters"
-        case examples = "Examples"
         case logic = "Logic"
+        case examples = "Examples"
+        case details = "Details"
     }
 
     // MARK: Lifecycle
 
-    public init(currentTab: Tab = .devices) {
+    public init(currentTab: Tab = .parameters) {
         self.currentTab = currentTab
 
         super.init(frame: .zero)
@@ -115,15 +114,6 @@ class UtilitiesView: NSBox {
             caseListView?.component = component
             caseListView?.list = component?.cases ?? []
             caseListView?.editor?.reloadData()
-        case .devices:
-            if canvasListView == nil {
-                canvasListView = CanvasListView(frame: .zero)
-                canvasListView?.onChange = { [unowned self] list in self.onChangeCanvasList?(list) }
-            }
-
-            canvasListView?.editorView.component = component
-            canvasListView?.canvasList = component?.canvas ?? []
-            canvasListView?.canvasLayout = component?.canvasLayoutAxis ?? StaticCanvasRenderer.Layout.canvasXcaseY
         case .parameters:
             if parameterListEditorView == nil {
                 parameterListEditorView = ParameterListEditorView(frame: .zero)
@@ -142,7 +132,6 @@ class UtilitiesView: NSBox {
 
         let tabMap: [Tab: NSView?] = [
             .details: metadataEditorView,
-            .devices: canvasListView,
             .parameters: parameterListEditorView,
             .examples: caseListView?.editor,
             .logic: logicListView?.editor

--- a/studio/LonaStudio/Workspace/WorkspaceViewController.swift
+++ b/studio/LonaStudio/Workspace/WorkspaceViewController.swift
@@ -132,8 +132,10 @@ class WorkspaceViewController: NSSplitViewController {
 
             let canvas = component.canvas[index]
 
+            controller.selectedLayerName = nil
+            controller.selectedCanvasHeaderItem = index
             self.inspectedContent = .canvas(canvas)
-            self.update()
+            self.inspectorView.content = .canvas(canvas)
         }
 
         return controller
@@ -470,6 +472,7 @@ class WorkspaceViewController: NSSplitViewController {
                 }
                 self.inspectedContent = .layer(layer)
                 self.inspectorView.content = .layer(layer)
+                self.componentEditorViewController.selectedCanvasHeaderItem = nil
                 self.componentEditorViewController.selectedLayerName = layer.name
             }
 

--- a/studio/LonaStudio/Workspace/WorkspaceViewController.swift
+++ b/studio/LonaStudio/Workspace/WorkspaceViewController.swift
@@ -480,7 +480,16 @@ class WorkspaceViewController: NSSplitViewController {
                 self.inspectorView.content = self.inspectedContent
             }
 
-            inspectorView.onChangeContent = { content, changeType in
+            inspectorView.onChangeContent = { [unowned self] content, changeType in
+                switch content {
+                case .canvas(let canvas):
+                    guard let index = self.componentEditorViewController.selectedCanvasHeaderItem else { break }
+                    self.component?.canvas[index] = canvas
+                    self.componentEditorViewController.updateCanvas()
+                default:
+                    break
+                }
+
                 switch changeType {
                 case .canvas:
                     self.componentEditorViewController.updateCanvas()

--- a/studio/LonaStudio/Workspace/WorkspaceViewController.swift
+++ b/studio/LonaStudio/Workspace/WorkspaceViewController.swift
@@ -168,6 +168,23 @@ class WorkspaceViewController: NSSplitViewController {
             self.inspectorView.content = .canvas(canvas)
         }
 
+        controller.onMoveCanvas = { [unowned self] index, newIndex in
+            guard let component = self.component else { return }
+
+            component.canvas.swapAt(index, newIndex)
+
+            controller.selectedLayerName = nil
+
+            // If there was a canvas selected previous, re-select it at its new index
+            if controller.selectedCanvasHeaderItem == index {
+                let canvas = component.canvas[newIndex]
+
+                controller.selectedCanvasHeaderItem = newIndex
+                self.inspectedContent = .canvas(canvas)
+                self.inspectorView.content = .canvas(canvas)
+            }
+        }
+
         return controller
     }()
 

--- a/studio/LonaStudio/Workspace/WorkspaceViewController.swift
+++ b/studio/LonaStudio/Workspace/WorkspaceViewController.swift
@@ -138,6 +138,17 @@ class WorkspaceViewController: NSSplitViewController {
             self.inspectorView.content = .canvas(canvas)
         }
 
+        controller.onDeleteCanvas = { [unowned self] index in
+            guard let component = self.component else { return }
+
+            component.canvas.remove(at: index)
+
+            controller.selectedLayerName = nil
+            controller.selectedCanvasHeaderItem = nil
+            self.inspectedContent = nil
+            self.inspectorView.content = nil
+        }
+
         return controller
     }()
 

--- a/studio/LonaStudio/Workspace/WorkspaceViewController.swift
+++ b/studio/LonaStudio/Workspace/WorkspaceViewController.swift
@@ -149,6 +149,25 @@ class WorkspaceViewController: NSSplitViewController {
             self.inspectorView.content = nil
         }
 
+        controller.onAddCanvas = { [unowned self] in
+            guard let component = self.component else { return }
+
+            let canvas: Canvas
+
+            if let last = component.canvas.last {
+                canvas = last.copy() as! Canvas
+            } else {
+                canvas = Canvas.createDefaultCanvas()
+            }
+
+            component.canvas.append(canvas)
+
+            controller.selectedLayerName = nil
+            controller.selectedCanvasHeaderItem = component.canvas.count - 1
+            self.inspectedContent = .canvas(canvas)
+            self.inspectorView.content = .canvas(canvas)
+        }
+
         return controller
     }()
 

--- a/studio/LonaStudio/Workspace/WorkspaceViewController.swift
+++ b/studio/LonaStudio/Workspace/WorkspaceViewController.swift
@@ -124,7 +124,21 @@ class WorkspaceViewController: NSSplitViewController {
     }()
 
     private lazy var editorViewController = EditorViewController()
-    private lazy var componentEditorViewController = ComponentEditorViewController()
+    private lazy var componentEditorViewController: ComponentEditorViewController = {
+        let controller = ComponentEditorViewController()
+
+        controller.onChangeInspectedCanvas = { [unowned self] index in
+            guard let component = self.component else { return }
+
+            let canvas = component.canvas[index]
+
+            self.inspectedContent = .canvas(canvas)
+            self.update()
+        }
+
+        return controller
+    }()
+
     private lazy var codeEditorViewController = CodeEditorViewController()
 
     private lazy var colorEditorViewController: ColorEditorViewController = {

--- a/workspace/colors.json
+++ b/workspace/colors.json
@@ -43,6 +43,12 @@
       "value" : "rgba(0,0,0,0.0)"
     },
     {
+      "comment" : "MacOS system selection color",
+      "id" : "systemSelection",
+      "name" : "SystemSelection",
+      "value" : "rgb(4,99,225)"
+    },
+    {
       "comment" : "",
       "id" : "red50",
       "name" : "Red 50",

--- a/workspace/components/CanvasTableHeaderExtra.component
+++ b/workspace/components/CanvasTableHeaderExtra.component
@@ -1,0 +1,145 @@
+{
+  "devices" : [
+    {
+      "height" : 0,
+      "heightMode" : "At Least",
+      "name" : "Header Column",
+      "width" : 42
+    }
+  ],
+  "examples" : [
+    {
+      "id" : "Default",
+      "name" : "Default",
+      "params" : {
+
+      }
+    },
+    {
+      "id" : "Selected",
+      "name" : "Selected",
+      "params" : {
+        "selected" : true
+      }
+    }
+  ],
+  "logic" : [
+    {
+      "assignee" : [
+        "layers",
+        "HDivider",
+        "backgroundColor"
+      ],
+      "content" : [
+        "parameters",
+        "dividerColor"
+      ],
+      "type" : "AssignExpr"
+    },
+    {
+      "assignee" : [
+        "layers",
+        "Button",
+        "onPress"
+      ],
+      "content" : [
+        "parameters",
+        "onClickPlus"
+      ],
+      "type" : "AssignExpr"
+    },
+    {
+      "body" : [
+        {
+          "assignee" : [
+            "layers",
+            "Button",
+            "backgroundColor"
+          ],
+          "content" : {
+            "type" : "LitExpr",
+            "value" : {
+              "data" : "headerBackground",
+              "type" : "Color"
+            }
+          },
+          "type" : "AssignExpr"
+        }
+      ],
+      "condition" : {
+        "left" : [
+          "layers",
+          "Button",
+          "pressed"
+        ],
+        "op" : "==",
+        "right" : {
+          "type" : "LitExpr",
+          "value" : {
+            "data" : true,
+            "type" : "Boolean"
+          }
+        },
+        "type" : "BinExpr"
+      },
+      "type" : "IfExpr"
+    }
+  ],
+  "params" : [
+    {
+      "name" : "dividerColor",
+      "type" : "Color"
+    },
+    {
+      "name" : "onClickPlus",
+      "type" : {
+        "name" : "Function"
+      }
+    }
+  ],
+  "root" : {
+    "children" : [
+      {
+        "children" : [
+          {
+            "id" : "Title",
+            "params" : {
+              "font" : "large",
+              "text" : "+",
+              "textAlign" : "center"
+            },
+            "type" : "Lona:Text"
+          }
+        ],
+        "id" : "Button",
+        "params" : {
+          "alignItems" : "center",
+          "backgroundColor" : "grey200",
+          "borderRadius" : 11,
+          "height" : 22,
+          "marginBottom" : 8,
+          "marginTop" : 7,
+          "width" : 22
+        },
+        "type" : "Lona:View"
+      },
+      {
+        "id" : "HDivider",
+        "params" : {
+          "alignSelf" : "stretch",
+          "backgroundColor" : "#D8D8D8",
+          "height" : 1
+        },
+        "type" : "Lona:View"
+      }
+    ],
+    "id" : "Container",
+    "params" : {
+      "alignItems" : "center",
+      "alignSelf" : "stretch",
+      "backgroundColor" : "white",
+      "height" : 38
+    },
+    "type" : "Lona:View"
+  }
+}

--- a/workspace/components/CanvasTableHeaderItem.component
+++ b/workspace/components/CanvasTableHeaderItem.component
@@ -119,7 +119,37 @@
           "content" : {
             "type" : "LitExpr",
             "value" : {
-              "data" : "blue600",
+              "data" : "systemSelection",
+              "type" : "Color"
+            }
+          },
+          "type" : "AssignExpr"
+        },
+        {
+          "assignee" : [
+            "layers",
+            "HDivider",
+            "backgroundColor"
+          ],
+          "content" : {
+            "type" : "LitExpr",
+            "value" : {
+              "data" : "systemSelection",
+              "type" : "Color"
+            }
+          },
+          "type" : "AssignExpr"
+        },
+        {
+          "assignee" : [
+            "layers",
+            "VDivider",
+            "backgroundColor"
+          ],
+          "content" : {
+            "type" : "LitExpr",
+            "value" : {
+              "data" : "systemSelection",
               "type" : "Color"
             }
           },

--- a/workspace/components/CanvasTableHeaderItem.component
+++ b/workspace/components/CanvasTableHeaderItem.component
@@ -14,6 +14,13 @@
       "params" : {
 
       }
+    },
+    {
+      "id" : "Selected",
+      "name" : "Selected",
+      "params" : {
+        "selected" : true
+      }
     }
   ],
   "logic" : [
@@ -52,6 +59,104 @@
         "titleText"
       ],
       "type" : "AssignExpr"
+    },
+    {
+      "assignee" : [
+        "layers",
+        "Container",
+        "onPress"
+      ],
+      "content" : [
+        "parameters",
+        "onClick"
+      ],
+      "type" : "AssignExpr"
+    },
+    {
+      "body" : [
+        {
+          "assignee" : [
+            "layers",
+            "Container",
+            "backgroundColor"
+          ],
+          "content" : {
+            "type" : "LitExpr",
+            "value" : {
+              "data" : "headerBackground",
+              "type" : "Color"
+            }
+          },
+          "type" : "AssignExpr"
+        }
+      ],
+      "condition" : {
+        "left" : [
+          "layers",
+          "Container",
+          "pressed"
+        ],
+        "op" : "==",
+        "right" : {
+          "type" : "LitExpr",
+          "value" : {
+            "data" : true,
+            "type" : "Boolean"
+          }
+        },
+        "type" : "BinExpr"
+      },
+      "type" : "IfExpr"
+    },
+    {
+      "body" : [
+        {
+          "assignee" : [
+            "layers",
+            "Container",
+            "backgroundColor"
+          ],
+          "content" : {
+            "type" : "LitExpr",
+            "value" : {
+              "data" : "blue600",
+              "type" : "Color"
+            }
+          },
+          "type" : "AssignExpr"
+        },
+        {
+          "assignee" : [
+            "layers",
+            "Title",
+            "textStyle"
+          ],
+          "content" : {
+            "type" : "LitExpr",
+            "value" : {
+              "data" : "sectionTitleInverse",
+              "type" : "TextStyle"
+            }
+          },
+          "type" : "AssignExpr"
+        }
+      ],
+      "condition" : {
+        "left" : [
+          "parameters",
+          "selected"
+        ],
+        "op" : "==",
+        "right" : {
+          "type" : "LitExpr",
+          "value" : {
+            "data" : true,
+            "type" : "Boolean"
+          }
+        },
+        "type" : "BinExpr"
+      },
+      "type" : "IfExpr"
     }
   ],
   "params" : [
@@ -62,6 +167,16 @@
     {
       "name" : "dividerColor",
       "type" : "Color"
+    },
+    {
+      "name" : "onClick",
+      "type" : {
+        "name" : "Function"
+      }
+    },
+    {
+      "name" : "selected",
+      "type" : "Boolean"
     }
   ],
   "root" : {

--- a/workspace/components/CanvasTableHeaderItem.component
+++ b/workspace/components/CanvasTableHeaderItem.component
@@ -3,7 +3,7 @@
     {
       "height" : 0,
       "heightMode" : "At Least",
-      "name" : "iPhone SE",
+      "name" : "Header Column",
       "width" : 320
     }
   ],
@@ -88,6 +88,21 @@
             }
           },
           "type" : "AssignExpr"
+        },
+        {
+          "assignee" : [
+            "layers",
+            "VDividerLeft",
+            "backgroundColor"
+          ],
+          "content" : {
+            "type" : "LitExpr",
+            "value" : {
+              "data" : "headerBackground",
+              "type" : "Color"
+            }
+          },
+          "type" : "AssignExpr"
         }
       ],
       "condition" : {
@@ -158,6 +173,21 @@
         {
           "assignee" : [
             "layers",
+            "VDividerLeft",
+            "backgroundColor"
+          ],
+          "content" : {
+            "type" : "LitExpr",
+            "value" : {
+              "data" : "systemSelection",
+              "type" : "Color"
+            }
+          },
+          "type" : "AssignExpr"
+        },
+        {
+          "assignee" : [
+            "layers",
             "Title",
             "textStyle"
           ],
@@ -187,6 +217,98 @@
         "type" : "BinExpr"
       },
       "type" : "IfExpr"
+    },
+    {
+      "body" : [
+        {
+          "assignee" : [
+            "layers",
+            "VDividerLeft",
+            "backgroundColor"
+          ],
+          "content" : {
+            "type" : "LitExpr",
+            "value" : {
+              "data" : "blue400",
+              "type" : "Color"
+            }
+          },
+          "type" : "AssignExpr"
+        }
+      ],
+      "condition" : {
+        "left" : [
+          "parameters",
+          "dropTargetIndicator"
+        ],
+        "op" : "==",
+        "right" : {
+          "type" : "LitExpr",
+          "value" : {
+            "data" : "left",
+            "type" : {
+              "alias" : "DropTargetIndicator",
+              "name" : "Named",
+              "of" : {
+                "cases" : [
+                  "none",
+                  "left",
+                  "right"
+                ],
+                "name" : "Enum"
+              }
+            }
+          }
+        },
+        "type" : "BinExpr"
+      },
+      "type" : "IfExpr"
+    },
+    {
+      "body" : [
+        {
+          "assignee" : [
+            "layers",
+            "VDivider",
+            "backgroundColor"
+          ],
+          "content" : {
+            "type" : "LitExpr",
+            "value" : {
+              "data" : "blue400",
+              "type" : "Color"
+            }
+          },
+          "type" : "AssignExpr"
+        }
+      ],
+      "condition" : {
+        "left" : [
+          "parameters",
+          "dropTargetIndicator"
+        ],
+        "op" : "==",
+        "right" : {
+          "type" : "LitExpr",
+          "value" : {
+            "data" : "right",
+            "type" : {
+              "alias" : "DropTargetIndicator",
+              "name" : "Named",
+              "of" : {
+                "cases" : [
+                  "none",
+                  "left",
+                  "right"
+                ],
+                "name" : "Enum"
+              }
+            }
+          }
+        },
+        "type" : "BinExpr"
+      },
+      "type" : "IfExpr"
     }
   ],
   "params" : [
@@ -207,12 +329,36 @@
     {
       "name" : "selected",
       "type" : "Boolean"
+    },
+    {
+      "name" : "dropTargetIndicator",
+      "type" : {
+        "alias" : "DropTargetIndicator",
+        "name" : "Named",
+        "of" : {
+          "cases" : [
+            "none",
+            "left",
+            "right"
+          ],
+          "name" : "Enum"
+        }
+      }
     }
   ],
   "root" : {
     "children" : [
       {
         "children" : [
+          {
+            "id" : "VDividerLeft",
+            "params" : {
+              "alignSelf" : "stretch",
+              "backgroundColor" : "white",
+              "width" : 1
+            },
+            "type" : "Lona:View"
+          },
           {
             "id" : "Title",
             "params" : {

--- a/workspace/components/TextInput.component
+++ b/workspace/components/TextInput.component
@@ -27,6 +27,10 @@
     {
       "name" : "onChangeTextValue",
       "type" : "StringHandler"
+    },
+    {
+      "name" : "placeholderString",
+      "type" : "String?"
     }
   ],
   "root" : {

--- a/workspace/ghosts/NumberInput.component
+++ b/workspace/ghosts/NumberInput.component
@@ -35,6 +35,10 @@
           }
         ]
       }
+    },
+    {
+      "name" : "disabled",
+      "type" : "Boolean"
     }
   ],
   "root" : {

--- a/workspace/inspector/CanvasInspector.component
+++ b/workspace/inspector/CanvasInspector.component
@@ -2,24 +2,18 @@
   "devices" : [
     {
       "backgroundColor" : "grey200",
-      "height" : 0,
-      "heightMode" : "At Least",
-      "name" : "iPhone SE",
-      "width" : 320
+      "deviceId" : "iPhone SE",
+      "heightMode" : "At Least"
     },
     {
       "backgroundColor" : "grey200",
-      "height" : 0,
-      "heightMode" : "At Least",
-      "name" : "iPhone 7",
-      "width" : 375
+      "deviceId" : "iPhone 8",
+      "heightMode" : "At Least"
     },
     {
       "backgroundColor" : "grey200",
-      "height" : 0,
-      "heightMode" : "At Least",
-      "name" : "iPhone 7+",
-      "width" : 414
+      "deviceId" : "iPhone XS",
+      "heightMode" : "At Least"
     }
   ],
   "examples" : [
@@ -41,6 +35,42 @@
       "content" : [
         "parameters",
         "showsDimensionInputs"
+      ],
+      "type" : "AssignExpr"
+    },
+    {
+      "assignee" : [
+        "layers",
+        "DeviceDropdown",
+        "values"
+      ],
+      "content" : [
+        "parameters",
+        "availableDevices"
+      ],
+      "type" : "AssignExpr"
+    },
+    {
+      "assignee" : [
+        "layers",
+        "DeviceDropdown",
+        "selectedIndex"
+      ],
+      "content" : [
+        "parameters",
+        "deviceIndex"
+      ],
+      "type" : "AssignExpr"
+    },
+    {
+      "assignee" : [
+        "layers",
+        "DeviceDropdown",
+        "onChangeIndex"
+      ],
+      "content" : [
+        "parameters",
+        "onChangeDeviceIndex"
       ],
       "type" : "AssignExpr"
     },
@@ -81,6 +111,18 @@
       "type" : "AssignExpr"
     },
     {
+      "assignee" : [
+        "layers",
+        "NameInput",
+        "placeholderString"
+      ],
+      "content" : [
+        "parameters",
+        "canvasNamePlaceholder"
+      ],
+      "type" : "AssignExpr"
+    },
+    {
       "body" : [
         {
           "assignee" : [
@@ -107,8 +149,18 @@
         "right" : {
           "type" : "LitExpr",
           "value" : {
-            "data" : 20,
-            "type" : "Number"
+            "data" : "flexibleHeight",
+            "type" : {
+              "alias" : "CanvasHeight",
+              "name" : "Named",
+              "of" : {
+                "cases" : [
+                  "flexibleHeight",
+                  "fixedHeight"
+                ],
+                "name" : "Enum"
+              }
+            }
           }
         },
         "type" : "BinExpr"
@@ -159,12 +211,95 @@
         "type" : "BinExpr"
       },
       "type" : "IfExpr"
+    },
+    {
+      "body" : [
+        {
+          "assignee" : [
+            "layers",
+            "NameInput",
+            "textValue"
+          ],
+          "content" : [
+            "canvasName"
+          ],
+          "type" : "AssignExpr"
+        }
+      ],
+      "condition" : {
+        "content" : [
+          "parameters",
+          "canvasName"
+        ],
+        "id" : "canvasName",
+        "type" : "VarDeclExpr"
+      },
+      "type" : "IfExpr"
+    },
+    {
+      "assignee" : [
+        "layers",
+        "NameInput",
+        "onChangeTextValue"
+      ],
+      "content" : [
+        "parameters",
+        "onChangeCanvasName"
+      ],
+      "type" : "AssignExpr"
+    },
+    {
+      "assignee" : [
+        "layers",
+        "HeightInput",
+        "onChangeNumberValue"
+      ],
+      "content" : [
+        "parameters",
+        "onChangeCanvasHeight"
+      ],
+      "type" : "AssignExpr"
+    },
+    {
+      "assignee" : [
+        "layers",
+        "WidthInput",
+        "onChangeNumberValue"
+      ],
+      "content" : [
+        "parameters",
+        "onChangeCanvasWidth"
+      ],
+      "type" : "AssignExpr"
     }
   ],
   "params" : [
     {
       "name" : "showsDimensionInputs",
       "type" : "Boolean"
+    },
+    {
+      "name" : "availableDevices",
+      "type" : {
+        "name" : "Array",
+        "of" : "String"
+      }
+    },
+    {
+      "name" : "deviceIndex",
+      "type" : "WholeNumber"
+    },
+    {
+      "name" : "onChangeDeviceIndex",
+      "type" : {
+        "name" : "Function",
+        "parameters" : [
+          {
+            "label" : "_",
+            "type" : "WholeNumber"
+          }
+        ]
+      }
     },
     {
       "name" : "heightMode",
@@ -197,8 +332,40 @@
       "type" : "String?"
     },
     {
+      "name" : "canvasNamePlaceholder",
+      "type" : "String"
+    },
+    {
       "name" : "backgroundColorId",
       "type" : "String"
+    },
+    {
+      "name" : "onChangeCanvasName",
+      "type" : "StringHandler"
+    },
+    {
+      "name" : "onChangeCanvasWidth",
+      "type" : {
+        "name" : "Function",
+        "parameters" : [
+          {
+            "label" : "_",
+            "type" : "Number"
+          }
+        ]
+      }
+    },
+    {
+      "name" : "onChangeCanvasHeight",
+      "type" : {
+        "name" : "Function",
+        "parameters" : [
+          {
+            "label" : "_",
+            "type" : "Number"
+          }
+        ]
+      }
     }
   ],
   "root" : {
@@ -219,8 +386,8 @@
             "params" : {
               "selectedIndex" : 0,
               "values" : [
-                "Component (Flexible-height)",
-                "Screen (Fixed-height)"
+                "Flexible-height",
+                "Fixed-height"
               ]
             },
             "type" : "ControlledDropdown"
@@ -254,7 +421,25 @@
                 "params" : {
                   "selectedIndex" : 0,
                   "values" : [
-                    "iPhone SE"
+                    "Custom",
+                    "iPhone 8",
+                    "iPhone 8 Plus",
+                    "iPhone SE",
+                    "iPhone XS",
+                    "iPhone XR",
+                    "iPhone XS Max",
+                    "iPad",
+                    "iPad Pro 10.5\"",
+                    "iPad Pro 11\"",
+                    "iPad Pro 12.9\"",
+                    "Pixel 2",
+                    "Pixel 2 XL",
+                    "Galaxy S8",
+                    "Nexus 7",
+                    "Nexus 9",
+                    "Nexus 10",
+                    "Desktop",
+                    "Desktop HD"
                   ]
                 },
                 "type" : "ControlledDropdown"
@@ -358,7 +543,8 @@
           {
             "id" : "NameInput",
             "params" : {
-              "textValue" : "Text"
+              "placeholderString" : "Custom name",
+              "textValue" : ""
             },
             "type" : "TextInput"
           }

--- a/workspace/inspector/CanvasInspector.component
+++ b/workspace/inspector/CanvasInspector.component
@@ -2,18 +2,10 @@
   "devices" : [
     {
       "backgroundColor" : "grey200",
-      "deviceId" : "iPhone SE",
-      "heightMode" : "At Least"
-    },
-    {
-      "backgroundColor" : "grey200",
-      "deviceId" : "iPhone 8",
-      "heightMode" : "At Least"
-    },
-    {
-      "backgroundColor" : "grey200",
-      "deviceId" : "iPhone XS",
-      "heightMode" : "At Least"
+      "height" : 1,
+      "heightMode" : "At Least",
+      "name" : "Inspector",
+      "width" : 320
     }
   ],
   "examples" : [
@@ -131,6 +123,18 @@
       "content" : [
         "parameters",
         "backgroundColorId"
+      ],
+      "type" : "AssignExpr"
+    },
+    {
+      "assignee" : [
+        "layers",
+        "BackgroundColorInput",
+        "onChangeTextValue"
+      ],
+      "content" : [
+        "parameters",
+        "onChangeBackgroundColorId"
       ],
       "type" : "AssignExpr"
     },
@@ -437,6 +441,10 @@
           }
         ]
       }
+    },
+    {
+      "name" : "onChangeBackgroundColorId",
+      "type" : "StringHandler"
     }
   ],
   "root" : {

--- a/workspace/inspector/CanvasInspector.component
+++ b/workspace/inspector/CanvasInspector.component
@@ -1,0 +1,244 @@
+{
+  "devices" : [
+    {
+      "height" : 0,
+      "heightMode" : "At Least",
+      "name" : "iPhone SE",
+      "width" : 320
+    },
+    {
+      "height" : 0,
+      "heightMode" : "At Least",
+      "name" : "iPhone 7",
+      "width" : 375
+    },
+    {
+      "height" : 0,
+      "heightMode" : "At Least",
+      "name" : "iPhone 7+",
+      "width" : 414
+    }
+  ],
+  "examples" : [
+    {
+      "id" : "Default",
+      "name" : "Default",
+      "params" : {
+
+      }
+    }
+  ],
+  "logic" : [
+
+  ],
+  "params" : [
+
+  ],
+  "root" : {
+    "children" : [
+      {
+        "children" : [
+          {
+            "id" : "PresetLabel",
+            "params" : {
+              "marginRight" : 20,
+              "text" : "Preset",
+              "width" : 80
+            },
+            "type" : "Lona:Text"
+          },
+          {
+            "id" : "PresetDropdown",
+            "params" : {
+              "selectedIndex" : 0,
+              "values" : [
+                "Component (Flexible-height)",
+                "Screen (Fixed-height)"
+              ]
+            },
+            "type" : "ControlledDropdown"
+          }
+        ],
+        "id" : "PresetRow",
+        "params" : {
+          "alignItems" : "center",
+          "alignSelf" : "stretch",
+          "flexDirection" : "row",
+          "marginTop" : 16
+        },
+        "type" : "Lona:View"
+      },
+      {
+        "children" : [
+          {
+            "id" : "DeviceLabel",
+            "params" : {
+              "marginRight" : 20,
+              "marginTop" : 4,
+              "text" : "Device",
+              "width" : 80
+            },
+            "type" : "Lona:Text"
+          },
+          {
+            "children" : [
+              {
+                "id" : "DeviceDropdown",
+                "params" : {
+                  "selectedIndex" : 0,
+                  "values" : [
+
+                  ]
+                },
+                "type" : "ControlledDropdown"
+              },
+              {
+                "children" : [
+                  {
+                    "children" : [
+                      {
+                        "id" : "WidthLabel",
+                        "params" : {
+                          "alignSelf" : "stretch",
+                          "marginBottom" : 8,
+                          "text" : "Width"
+                        },
+                        "type" : "Lona:Text"
+                      },
+                      {
+                        "id" : "WidthInput",
+                        "params" : {
+                          "numberValue" : 0
+                        },
+                        "type" : "NumberInput"
+                      }
+                    ],
+                    "id" : "WidthContainer",
+                    "params" : {
+                      "flex" : 1
+                    },
+                    "type" : "Lona:View"
+                  },
+                  {
+                    "id" : "HSpacer",
+                    "params" : {
+                      "height" : 0,
+                      "width" : 20
+                    },
+                    "type" : "Lona:View"
+                  },
+                  {
+                    "children" : [
+                      {
+                        "id" : "HeightLabel",
+                        "params" : {
+                          "alignSelf" : "stretch",
+                          "marginBottom" : 8,
+                          "text" : "Height"
+                        },
+                        "type" : "Lona:Text"
+                      },
+                      {
+                        "id" : "HeightInput",
+                        "params" : {
+                          "numberValue" : 0
+                        },
+                        "type" : "NumberInput"
+                      }
+                    ],
+                    "id" : "HeightContainer",
+                    "params" : {
+                      "flex" : 1
+                    },
+                    "type" : "Lona:View"
+                  }
+                ],
+                "id" : "CustomDimensionsContainer",
+                "params" : {
+                  "alignSelf" : "stretch",
+                  "flexDirection" : "row",
+                  "marginTop" : 16
+                },
+                "type" : "Lona:View"
+              }
+            ],
+            "id" : "DeviceValueContainer",
+            "params" : {
+              "flex" : 1
+            },
+            "type" : "Lona:View"
+          }
+        ],
+        "id" : "DeviceRow",
+        "params" : {
+          "alignSelf" : "stretch",
+          "flexDirection" : "row",
+          "marginTop" : 16
+        },
+        "type" : "Lona:View"
+      },
+      {
+        "children" : [
+          {
+            "id" : "NameLabel",
+            "params" : {
+              "marginRight" : 20,
+              "text" : "Name",
+              "width" : 80
+            },
+            "type" : "Lona:Text"
+          },
+          {
+            "id" : "NameInput",
+            "params" : {
+              "textValue" : "Text"
+            },
+            "type" : "TextInput"
+          }
+        ],
+        "id" : "NameRow",
+        "params" : {
+          "alignItems" : "center",
+          "alignSelf" : "stretch",
+          "flexDirection" : "row",
+          "marginTop" : 16
+        },
+        "type" : "Lona:View"
+      },
+      {
+        "children" : [
+          {
+            "id" : "BackgroundColorLabel",
+            "params" : {
+              "marginRight" : 20,
+              "text" : "Background",
+              "width" : 80
+            },
+            "type" : "Lona:Text"
+          },
+          {
+            "id" : "BackgroundColorInput",
+            "params" : {
+              "textValue" : "Text"
+            },
+            "type" : "TextInput"
+          }
+        ],
+        "id" : "BackgroundColorRow",
+        "params" : {
+          "alignItems" : "center",
+          "alignSelf" : "stretch",
+          "flexDirection" : "row",
+          "marginBottom" : 16,
+          "marginTop" : 16
+        },
+        "type" : "Lona:View"
+      }
+    ],
+    "id" : "Container",
+    "params" : {
+      "alignSelf" : "stretch"
+    },
+    "type" : "Lona:View"
+  }
+}

--- a/workspace/inspector/CanvasInspector.component
+++ b/workspace/inspector/CanvasInspector.component
@@ -466,7 +466,7 @@
               "selectedIndex" : 0,
               "values" : [
                 "Flexible-height",
-                "Fixed-height"
+                "Fixed-size"
               ]
             },
             "type" : "ControlledDropdown"

--- a/workspace/inspector/CanvasInspector.component
+++ b/workspace/inspector/CanvasInspector.component
@@ -1,18 +1,21 @@
 {
   "devices" : [
     {
+      "backgroundColor" : "grey200",
       "height" : 0,
       "heightMode" : "At Least",
       "name" : "iPhone SE",
       "width" : 320
     },
     {
+      "backgroundColor" : "grey200",
       "height" : 0,
       "heightMode" : "At Least",
       "name" : "iPhone 7",
       "width" : 375
     },
     {
+      "backgroundColor" : "grey200",
       "height" : 0,
       "heightMode" : "At Least",
       "name" : "iPhone 7+",
@@ -29,26 +32,190 @@
     }
   ],
   "logic" : [
-
+    {
+      "assignee" : [
+        "layers",
+        "CustomDimensionsContainer",
+        "visible"
+      ],
+      "content" : [
+        "parameters",
+        "showsDimensionInputs"
+      ],
+      "type" : "AssignExpr"
+    },
+    {
+      "assignee" : [
+        "layers",
+        "WidthInput",
+        "numberValue"
+      ],
+      "content" : [
+        "parameters",
+        "canvasWidth"
+      ],
+      "type" : "AssignExpr"
+    },
+    {
+      "assignee" : [
+        "layers",
+        "HeightInput",
+        "numberValue"
+      ],
+      "content" : [
+        "parameters",
+        "canvasHeight"
+      ],
+      "type" : "AssignExpr"
+    },
+    {
+      "assignee" : [
+        "layers",
+        "BackgroundColorInput",
+        "textValue"
+      ],
+      "content" : [
+        "parameters",
+        "backgroundColorId"
+      ],
+      "type" : "AssignExpr"
+    },
+    {
+      "body" : [
+        {
+          "assignee" : [
+            "layers",
+            "LayoutDropdown",
+            "selectedIndex"
+          ],
+          "content" : {
+            "type" : "LitExpr",
+            "value" : {
+              "data" : 0,
+              "type" : "WholeNumber"
+            }
+          },
+          "type" : "AssignExpr"
+        }
+      ],
+      "condition" : {
+        "left" : [
+          "parameters",
+          "heightMode"
+        ],
+        "op" : "==",
+        "right" : {
+          "type" : "LitExpr",
+          "value" : {
+            "data" : 20,
+            "type" : "Number"
+          }
+        },
+        "type" : "BinExpr"
+      },
+      "type" : "IfExpr"
+    },
+    {
+      "body" : [
+        {
+          "assignee" : [
+            "layers",
+            "LayoutDropdown",
+            "selectedIndex"
+          ],
+          "content" : {
+            "type" : "LitExpr",
+            "value" : {
+              "data" : 1,
+              "type" : "WholeNumber"
+            }
+          },
+          "type" : "AssignExpr"
+        }
+      ],
+      "condition" : {
+        "left" : [
+          "parameters",
+          "heightMode"
+        ],
+        "op" : "==",
+        "right" : {
+          "type" : "LitExpr",
+          "value" : {
+            "data" : "fixedHeight",
+            "type" : {
+              "alias" : "CanvasHeight",
+              "name" : "Named",
+              "of" : {
+                "cases" : [
+                  "flexibleHeight",
+                  "fixedHeight"
+                ],
+                "name" : "Enum"
+              }
+            }
+          }
+        },
+        "type" : "BinExpr"
+      },
+      "type" : "IfExpr"
+    }
   ],
   "params" : [
-
+    {
+      "name" : "showsDimensionInputs",
+      "type" : "Boolean"
+    },
+    {
+      "name" : "heightMode",
+      "type" : {
+        "alias" : "CanvasHeight",
+        "name" : "Named",
+        "of" : {
+          "cases" : [
+            "flexibleHeight",
+            "fixedHeight"
+          ],
+          "name" : "Enum"
+        }
+      }
+    },
+    {
+      "name" : "devicePreset",
+      "type" : "String"
+    },
+    {
+      "name" : "canvasHeight",
+      "type" : "Number"
+    },
+    {
+      "name" : "canvasWidth",
+      "type" : "Number"
+    },
+    {
+      "name" : "canvasName",
+      "type" : "String?"
+    },
+    {
+      "name" : "backgroundColorId",
+      "type" : "String"
+    }
   ],
   "root" : {
     "children" : [
       {
         "children" : [
           {
-            "id" : "PresetLabel",
+            "id" : "LayoutLabel",
             "params" : {
               "marginRight" : 20,
-              "text" : "Preset",
+              "text" : "Layout",
               "width" : 80
             },
             "type" : "Lona:Text"
           },
           {
-            "id" : "PresetDropdown",
+            "id" : "LayoutDropdown",
             "params" : {
               "selectedIndex" : 0,
               "values" : [
@@ -59,7 +226,7 @@
             "type" : "ControlledDropdown"
           }
         ],
-        "id" : "PresetRow",
+        "id" : "LayoutRow",
         "params" : {
           "alignItems" : "center",
           "alignSelf" : "stretch",
@@ -74,7 +241,7 @@
             "id" : "DeviceLabel",
             "params" : {
               "marginRight" : 20,
-              "marginTop" : 4,
+              "marginTop" : 2,
               "text" : "Device",
               "width" : 80
             },
@@ -87,7 +254,7 @@
                 "params" : {
                   "selectedIndex" : 0,
                   "values" : [
-
+                    "iPhone SE"
                   ]
                 },
                 "type" : "ControlledDropdown"

--- a/workspace/inspector/CanvasInspector.component
+++ b/workspace/inspector/CanvasInspector.component
@@ -213,12 +213,21 @@
       "type" : "IfExpr"
     },
     {
+      "content" : {
+        "type" : "LitExpr",
+        "value" : {
+          "data" : "",
+          "type" : "String"
+        }
+      },
+      "id" : "intermediateCanvasName",
+      "type" : "VarDeclExpr"
+    },
+    {
       "body" : [
         {
           "assignee" : [
-            "layers",
-            "NameInput",
-            "textValue"
+            "intermediateCanvasName"
           ],
           "content" : [
             "canvasName"
@@ -235,6 +244,17 @@
         "type" : "VarDeclExpr"
       },
       "type" : "IfExpr"
+    },
+    {
+      "assignee" : [
+        "layers",
+        "NameInput",
+        "textValue"
+      ],
+      "content" : [
+        "intermediateCanvasName"
+      ],
+      "type" : "AssignExpr"
     },
     {
       "assignee" : [

--- a/workspace/inspector/CanvasInspector.component
+++ b/workspace/inspector/CanvasInspector.component
@@ -29,8 +29,20 @@
     {
       "assignee" : [
         "layers",
-        "CustomDimensionsContainer",
-        "visible"
+        "HeightInput",
+        "disabled"
+      ],
+      "content" : [
+        "parameters",
+        "showsDimensionInputs"
+      ],
+      "type" : "AssignExpr"
+    },
+    {
+      "assignee" : [
+        "layers",
+        "WidthInput",
+        "disabled"
       ],
       "content" : [
         "parameters",
@@ -71,6 +83,18 @@
       "content" : [
         "parameters",
         "onChangeDeviceIndex"
+      ],
+      "type" : "AssignExpr"
+    },
+    {
+      "assignee" : [
+        "layers",
+        "LayoutDropdown",
+        "onChangeIndex"
+      ],
+      "content" : [
+        "parameters",
+        "onChangeHeightModeIndex"
       ],
       "type" : "AssignExpr"
     },
@@ -135,6 +159,21 @@
             "value" : {
               "data" : 0,
               "type" : "WholeNumber"
+            }
+          },
+          "type" : "AssignExpr"
+        },
+        {
+          "assignee" : [
+            "layers",
+            "HeightLabel",
+            "text"
+          ],
+          "content" : {
+            "type" : "LitExpr",
+            "value" : {
+              "data" : "Min Height",
+              "type" : "String"
             }
           },
           "type" : "AssignExpr"
@@ -386,6 +425,18 @@
           }
         ]
       }
+    },
+    {
+      "name" : "onChangeHeightModeIndex",
+      "type" : {
+        "name" : "Function",
+        "parameters" : [
+          {
+            "label" : "_",
+            "type" : "WholeNumber"
+          }
+        ]
+      }
     }
   ],
   "root" : {
@@ -495,7 +546,7 @@
                     "id" : "HSpacer",
                     "params" : {
                       "height" : 0,
-                      "width" : 20
+                      "width" : 8
                     },
                     "type" : "Lona:View"
                   },

--- a/workspace/screens/Welcome.component
+++ b/workspace/screens/Welcome.component
@@ -3,7 +3,7 @@
     {
       "height" : 0,
       "heightMode" : "At Least",
-      "name" : "iPhone SE",
+      "name" : "Launch Screen",
       "width" : 720
     }
   ],

--- a/workspace/textStyles.json
+++ b/workspace/textStyles.json
@@ -103,6 +103,13 @@
       "fontSize": 12,
       "fontWeight": "500",
       "color": "#545454"
+    },
+    {
+      "id": "sectionTitleInverse",
+      "name": "Section Title Inverse",
+      "fontSize": 12,
+      "fontWeight": "600",
+      "color": "white"
     }
   ]
 }


### PR DESCRIPTION
## What

Click the header above each column to configure a canvas:
- Canvases can be configured in the inspector
- Lona now has a list of built-in device presets
- Clarified the UI for picking height modes

Also:
- Removed the canvas list utility view
- This hides a few uncommon canvas features I don't think anybody is currently using.

## Testing Plan

- [X] Tested this change locally
- [X] Checked that existing features work
