### PR TITLE
Fix issue where utility tabs don't show/hide correctly

### DIFF
--- a/studio/LonaStudio/Workspace/UtilitiesView.swift
+++ b/studio/LonaStudio/Workspace/UtilitiesView.swift
@@ -141,9 +141,7 @@ class UtilitiesView: NSBox {
             guard let view = view else { continue }
 
             if tab == currentTab {
-                if view.superview != self {
-                    self.addSubviewStretched(subview: view)
-                }
+                self.addSubviewStretched(subview: view)
             } else {
                 view.removeFromSuperview()
             }

--- a/studio/LonaStudio/Workspace/UtilitiesView.swift
+++ b/studio/LonaStudio/Workspace/UtilitiesView.swift
@@ -145,9 +145,7 @@ class UtilitiesView: NSBox {
                     self.addSubviewStretched(subview: view)
                 }
             } else {
-                if view.superview == self {
-                    view.removeFromSuperview()
-                }
+                view.removeFromSuperview()
             }
         }
     }


### PR DESCRIPTION
## What

I'm not sure why yet but `view.superview` isn't `self`. In any case, the check is extraneous, so I'm removing it.

## Testing Plan

- [X] Tested this change locally
- [X] Checked that existing features work

cc @outdooricon 