### PR TITLE
Allow workspace name customization

### DIFF
--- a/studio/LonaStudio/AppDelegate.swift
+++ b/studio/LonaStudio/AppDelegate.swift
@@ -64,6 +64,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     var preferencesWindow: MASPreferencesWindowController?
 
+    private func reloadPreferencesWindow() {
+        preferencesWindow?.viewControllers.forEach { viewController in
+            if let workspacePreferences = viewController as? WorkspacePreferencesViewController {
+                workspacePreferences.render()
+            }
+        }
+    }
+
     @IBAction func showPreferences(_ sender: AnyObject) {
         if preferencesWindow == nil {
             let workspace = WorkspacePreferencesViewController()
@@ -71,6 +79,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
             preferencesWindow = MASPreferencesWindowController(viewControllers: [workspace], title: "Preferences")
         }
+
+        reloadPreferencesWindow()
 
         preferencesWindow?.showWindow(sender)
     }
@@ -225,6 +235,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         NSDocumentController.shared.noteNewRecentDocumentURL(url)
 
         CSWorkspacePreferences.reloadAllConfigurationFiles(closeDocuments: true)
+
+        reloadPreferencesWindow()
 
         return true
     }

--- a/studio/LonaStudio/Preferences/CSWorkspacePreferences.swift
+++ b/studio/LonaStudio/Preferences/CSWorkspacePreferences.swift
@@ -20,6 +20,7 @@ class CSWorkspacePreferences: CSPreferencesFile {
         case colorsPath
         case textStylesPath
         case workspaceIcon
+        case workspaceName
     }
 
     static var url: URL {
@@ -89,10 +90,26 @@ class CSWorkspacePreferences: CSPreferencesFile {
             }
         }
         set {
-            CSWorkspacePreferences.data[Keys.workspaceIcon.rawValue] = newValue == CSUnitValue
+            CSWorkspacePreferences.data[Keys.workspaceIcon.rawValue] = newValue.tag() == "None"
                 ? nil
                 : CSValue.compact(type: optionalURLType, data: newValue.data)
         }
+    }
+
+    static var workspaceNameValue: CSValue {
+        get {
+            return CSValue(type: CSType.string, data: CSWorkspacePreferences.data[Keys.workspaceName.rawValue] ?? "".toData())
+        }
+        set {
+            CSWorkspacePreferences.data[Keys.workspaceName.rawValue] = newValue.data.stringValue == ""
+                ? nil
+                : newValue.data
+        }
+    }
+
+    static var workspaceName: String {
+        let customName = workspaceNameValue.data.stringValue
+        return customName.isEmpty ? LonaModule.current.url.lastPathComponent : customName
     }
 
     static var data: CSData = load()

--- a/studio/LonaStudio/Preferences/WorkspacePreferencesViewController.swift
+++ b/studio/LonaStudio/Preferences/WorkspacePreferencesViewController.swift
@@ -30,6 +30,17 @@ class WorkspacePreferencesViewController: NSViewController, MASPreferencesViewCo
     func render() {
         stackView.arrangedSubviews.forEach({ $0.removeFromSuperview() })
 
+        let workspaceNameRow = ValueSettingRow(
+            title: "Workspace Name",
+            value: CSWorkspacePreferences.workspaceNameValue, onChange: { value in
+                CSWorkspacePreferences.workspaceNameValue = CSValue(type: CSType.string, data: value)
+                CSWorkspacePreferences.save()
+
+                LonaPlugins.current.trigger(eventType: .onReloadWorkspace)
+
+                self.render()
+        })
+
         let workspaceIconRow = ValueSettingRow(
             title: "Workspace Icon",
             value: CSWorkspacePreferences.workspaceIconPathValue, onChange: { value in
@@ -84,6 +95,7 @@ class WorkspacePreferencesViewController: NSViewController, MASPreferencesViewCo
         })
 
         let views = [
+            workspaceNameRow,
             workspaceIconRow,
             compilerPathRow,
             colorsPathRow,

--- a/studio/LonaStudio/Preferences/WorkspacePreferencesViewController.swift
+++ b/studio/LonaStudio/Preferences/WorkspacePreferencesViewController.swift
@@ -27,12 +27,22 @@ class WorkspacePreferencesViewController: NSViewController, MASPreferencesViewCo
         }
     }
 
+    // Ensure that callbacks don't fire when removing from superview
+    private var loaded = false
+
     func render() {
+        loaded = false
+
+        CSUserPreferences.reload()
+        CSWorkspacePreferences.reload()
+
         stackView.arrangedSubviews.forEach({ $0.removeFromSuperview() })
 
         let workspaceNameRow = ValueSettingRow(
             title: "Workspace Name",
-            value: CSWorkspacePreferences.workspaceNameValue, onChange: { value in
+            value: CSWorkspacePreferences.workspaceNameValue, onChange: { [unowned self] value in
+                if !self.loaded { return }
+
                 CSWorkspacePreferences.workspaceNameValue = CSValue(type: CSType.string, data: value)
                 CSWorkspacePreferences.save()
 
@@ -43,7 +53,9 @@ class WorkspacePreferencesViewController: NSViewController, MASPreferencesViewCo
 
         let workspaceIconRow = ValueSettingRow(
             title: "Workspace Icon",
-            value: CSWorkspacePreferences.workspaceIconPathValue, onChange: { value in
+            value: CSWorkspacePreferences.workspaceIconPathValue, onChange: { [unowned self] value in
+                if !self.loaded { return }
+
                 CSWorkspacePreferences.workspaceIconPathValue = CSValue(type: CSWorkspacePreferences.optionalURLType, data: value)
                 CSWorkspacePreferences.save()
 
@@ -54,7 +66,9 @@ class WorkspacePreferencesViewController: NSViewController, MASPreferencesViewCo
 
         let compilerPathRow = ValueSettingRow(
             title: "Custom Compiler Path",
-            value: CSUserPreferences.compilerPathValue, onChange: { value in
+            value: CSUserPreferences.compilerPathValue, onChange: { [unowned self] value in
+                if !self.loaded { return }
+
                 CSUserPreferences.compilerPathValue = CSValue(type: CSUserPreferences.optionalURLType, data: value)
                 CSUserPreferences.save()
 
@@ -63,7 +77,9 @@ class WorkspacePreferencesViewController: NSViewController, MASPreferencesViewCo
 
         let colorsPathRow = ValueSettingRow(
             title: "Custom Colors Path",
-            value: CSWorkspacePreferences.colorsFilePathValue, onChange: { value in
+            value: CSWorkspacePreferences.colorsFilePathValue, onChange: { [unowned self] value in
+                if !self.loaded { return }
+
                 CSWorkspacePreferences.colorsFilePathValue = CSValue(type: CSWorkspacePreferences.optionalURLType, data: value)
                 CSWorkspacePreferences.save()
 
@@ -74,7 +90,9 @@ class WorkspacePreferencesViewController: NSViewController, MASPreferencesViewCo
 
         let textStylesPathRow = ValueSettingRow(
             title: "Custom Text Styles Path",
-            value: CSWorkspacePreferences.textStylesFilePathValue, onChange: { value in
+            value: CSWorkspacePreferences.textStylesFilePathValue, onChange: { [unowned self] value in
+                if !self.loaded { return }
+
                 CSWorkspacePreferences.textStylesFilePathValue = CSValue(type: CSWorkspacePreferences.optionalURLType, data: value)
                 CSWorkspacePreferences.save()
 
@@ -85,7 +103,9 @@ class WorkspacePreferencesViewController: NSViewController, MASPreferencesViewCo
 
         let canvasAreaBackgroundColorRow = ValueSettingRow(
             title: "Canvas Area Background Color",
-            value: CSUserPreferences.canvasAreaBackgroundColorValue, onChange: { value in
+            value: CSUserPreferences.canvasAreaBackgroundColorValue, onChange: { [unowned self] value in
+                if !self.loaded { return }
+
                 CSUserPreferences.canvasAreaBackgroundColorValue = CSValue(type: .string, data: value)
                 CSUserPreferences.save()
 
@@ -104,15 +124,14 @@ class WorkspacePreferencesViewController: NSViewController, MASPreferencesViewCo
         ]
 
         views.forEach({ stackView.addArrangedSubview($0) })
+
+        loaded = true
     }
 
     var stackView = NSStackView()
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        CSUserPreferences.reload()
-        CSWorkspacePreferences.reload()
 
         view = NSView(frame: NSRect(x: 0, y: 0, width: 600, height: 0))
         view.translatesAutoresizingMaskIntoConstraints = false

--- a/studio/LonaStudio/Workspace/RecentProjectsList.swift
+++ b/studio/LonaStudio/Workspace/RecentProjectsList.swift
@@ -69,7 +69,10 @@ class RecentProjectsTableCellView: NSTableCellView {
     }
 
     private func update() {
-        recentProjectView.projectName = project.lastPathComponent
+        let projectName = CSData.from(fileAtPath: project.appendingPathComponent("lona.json").path)?
+            .get(key: "workspaceName").string ?? project.lastPathComponent
+
+        recentProjectView.projectName = projectName
         recentProjectView.projectDirectoryPath = project.deletingLastPathComponent().path
         recentProjectView.selected = selected
     }

--- a/studio/LonaStudio/Workspace/WorkspaceViewController.swift
+++ b/studio/LonaStudio/Workspace/WorkspaceViewController.swift
@@ -116,7 +116,7 @@ class WorkspaceViewController: NSSplitViewController {
 
     private lazy var fileNavigator: FileNavigator = {
         let navigator = FileNavigator(rootPath: LonaModule.current.url.path)
-        navigator.titleText = LonaModule.current.url.lastPathComponent
+        navigator.titleText = CSWorkspacePreferences.workspaceName
         return navigator
     }()
     private lazy var fileNavigatorViewController: NSViewController = {

--- a/studio/LonaStudio/Workspace/WorkspaceViewController.swift
+++ b/studio/LonaStudio/Workspace/WorkspaceViewController.swift
@@ -645,7 +645,7 @@ class WorkspaceViewController: NSSplitViewController {
 
     // Subscriptions
 
-    var subscriptions: [() -> Void] = []
+    var subscriptions: [LonaPlugins.SubscriptionHandle] = []
 
     override func viewWillAppear() {
         subscriptions.append(LonaPlugins.current.register(eventType: .onReloadWorkspace) {
@@ -657,6 +657,10 @@ class WorkspaceViewController: NSSplitViewController {
                 })
 
             self.update()
+        })
+
+        subscriptions.append(LonaPlugins.current.register(eventType: .onReloadWorkspace) { [unowned self] in
+            self.fileNavigator.titleText = CSWorkspacePreferences.workspaceName
         })
     }
 

--- a/workspace/lona.json
+++ b/workspace/lona.json
@@ -1,3 +1,3 @@
 {
-
+  "workspaceName" : "Lona Studio"
 }


### PR DESCRIPTION
## What

The workspace name is customizable via preferences. Requires hit-enter-to-confirm.

This should fix the bugs around preferences saving to the wrong workspace, and the preferences UI loading twice (though not 100% sure).

cc @outdooricon 