### PR TITLE
Add access level to layer metadata

### DIFF
--- a/compiler/core/src/core/color.re
+++ b/compiler/core/src/core/color.re
@@ -10,29 +10,6 @@ type colorValue =
   | Inline(string)
   | Reference(t);
 
-module Metadata = {
-  open Json.Decode;
-  let valueDecoder = (decoder, defaultValue, json) =>
-    switch (optional(decoder, json)) {
-    | Some(value) => value
-    | None => defaultValue
-    };
-  let fieldDecoder = (decoder, defaultValue, keyPath, json) =>
-    switch (optional(at(keyPath, x => x), json)) {
-    | Some(fieldJson) => valueDecoder(decoder, defaultValue, fieldJson)
-    | None => defaultValue
-    };
-  let platformSpecificValue =
-      (pathPrefix, fieldDecoder, json: Js.Json.t)
-      : Types.platformSpecificValue('a) => {
-    iOS: fieldDecoder(pathPrefix @ ["ios"], json),
-    macOS: fieldDecoder(pathPrefix @ ["macos"], json),
-    reactDom: fieldDecoder(pathPrefix @ ["reactdom"], json),
-    reactNative: fieldDecoder(pathPrefix @ ["reactnative"], json),
-    reactSketchapp: fieldDecoder(pathPrefix @ ["reactSketchapp"], json),
-  };
-};
-
 let parseFile = content => {
   let parsed = content |> Js.Json.parseExn;
   open Json.Decode;
@@ -43,9 +20,9 @@ let parseFile = content => {
     comment: json |> optional(field("comment", string)),
     shouldGenerateCode:
       json
-      |> Metadata.platformSpecificValue(
+      |> DecodeMetadata.platformSpecificValue(
            ["metadata", "shouldGenerateCode"],
-           Metadata.fieldDecoder(Json.Decode.bool, true),
+           DecodeMetadata.fieldDecoder(Json.Decode.bool, true),
          ),
   };
   field("colors", list(parseColor), parsed);

--- a/compiler/core/src/core/types.re
+++ b/compiler/core/src/core/types.re
@@ -99,7 +99,13 @@ type platformSpecificValue('a) = {
   reactSketchapp: 'a,
 };
 
+type accessLevel =
+  | Private
+  | Internal
+  | Public;
+
 type layerMetadata = {
+  accessLevel: platformSpecificValue(accessLevel),
   backingElementClass: platformSpecificValue(option(string)),
 };
 

--- a/compiler/core/src/decode/decode.re
+++ b/compiler/core/src/decode/decode.re
@@ -120,29 +120,6 @@ module Parameters = {
   };
 };
 
-module Metadata = {
-  let optionalFieldString = (key, decoder, json) =>
-    switch (optional(field(key, x => x), json)) {
-    | Some(data) => optional(decoder, data)
-    | None => None
-    };
-  let emptyPlatformSpecificValue = (): platformSpecificValue(option('a)) => {
-    iOS: None,
-    macOS: None,
-    reactDom: None,
-    reactNative: None,
-    reactSketchapp: None,
-  };
-  let platformSpecificValue =
-      (json: Js.Json.t): platformSpecificValue(option('a)) => {
-    iOS: optionalFieldString("ios", string, json),
-    macOS: optionalFieldString("macos", string, json),
-    reactDom: optionalFieldString("reactdom", string, json),
-    reactNative: optionalFieldString("reactnative", string, json),
-    reactSketchapp: optionalFieldString("reactSketchapp", string, json),
-  };
-};
-
 module Layer = {
   let layerType = json =>
     switch (string(json)) {
@@ -211,13 +188,21 @@ module Layer = {
           raise(e);
         },
       metadata: {
+        accessLevel:
+          json
+          |> DecodeMetadata.platformSpecificValue(
+               ["metadata", "accessLevel"],
+               DecodeMetadata.fieldDecoder(
+                 DecodeMetadata.accessLevel,
+                 Types.Private,
+               ),
+             ),
         backingElementClass:
-          switch (
-            optional(at(["metadata", "backingElementClass"], x => x), json)
-          ) {
-          | Some(data) => Metadata.platformSpecificValue(data)
-          | None => Metadata.emptyPlatformSpecificValue()
-          },
+          json
+          |> DecodeMetadata.platformSpecificValue(
+               ["metadata", "backingElementClass"],
+               DecodeMetadata.fieldDecoder(optional(string), None),
+             ),
       },
     };
   };

--- a/compiler/core/src/decode/decodeMetadata.re
+++ b/compiler/core/src/decode/decodeMetadata.re
@@ -1,0 +1,33 @@
+exception UnknownAccessLevel(string);
+
+let accessLevel = (json: Js.Json.t) =>
+  switch (Json.Decode.string(json)) {
+  | "private" => Types.Private
+  | "internal" => Types.Internal
+  | "public" => Types.Public
+  | level =>
+    Js.log("ERROR: Bad access level");
+    raise(UnknownAccessLevel(level));
+  };
+
+let valueDecoder = (decoder, defaultValue, json) =>
+  switch (Json.Decode.optional(decoder, json)) {
+  | Some(value) => value
+  | None => defaultValue
+  };
+
+let fieldDecoder = (decoder, defaultValue, keyPath, json) =>
+  switch (Json.Decode.optional(Json.Decode.at(keyPath, x => x), json)) {
+  | Some(fieldJson) => valueDecoder(decoder, defaultValue, fieldJson)
+  | None => defaultValue
+  };
+
+let platformSpecificValue =
+    (pathPrefix, fieldDecoder, json: Js.Json.t)
+    : Types.platformSpecificValue('a) => {
+  iOS: fieldDecoder(pathPrefix @ ["ios"], json),
+  macOS: fieldDecoder(pathPrefix @ ["macos"], json),
+  reactDom: fieldDecoder(pathPrefix @ ["reactdom"], json),
+  reactNative: fieldDecoder(pathPrefix @ ["reactnative"], json),
+  reactSketchapp: fieldDecoder(pathPrefix @ ["reactSketchapp"], json),
+};

--- a/examples/generated/test/swift/interactivity/Button.swift
+++ b/examples/generated/test/swift/interactivity/Button.swift
@@ -72,7 +72,7 @@ public class Button: LonaControlView {
 
   // MARK: Private
 
-  private var textView = UILabel()
+  public var textView = UILabel()
 
   private var textViewTextStyle = TextStyles.button
 

--- a/examples/test/interactivity/Button.component
+++ b/examples/test/interactivity/Button.component
@@ -189,6 +189,11 @@
     "children" : [
       {
         "id" : "Text",
+        "metadata" : {
+          "accessLevel" : {
+            "ios" : "public"
+          }
+        },
         "params" : {
           "font" : "button",
           "text" : "Text goes here"

--- a/studio/LonaStudio/Models/CSType.swift
+++ b/studio/LonaStudio/Models/CSType.swift
@@ -460,6 +460,26 @@ extension CSType {
     }
 }
 
+// MARK: - Platform-specific types
+
+extension CSType {
+    init(platformSpecificTypeWithContentType contentType: CSType) {
+        self = .dictionary([
+            "ios": (type: contentType, access: .write),
+            "macos": (type: contentType, access: .write),
+            "reactdom": (type: contentType, access: .write),
+            "reactnative": (type: contentType, access: .write),
+            "reactsketchapp": (type: contentType, access: .write)
+            ])
+    }
+
+    static let accessLevel = CSType.variant(tags: ["private", "internal", "public"])
+    static let platformSpecificString = CSType(platformSpecificTypeWithContentType: CSType.string)
+    static let platformSpecificAccessLevel = CSType(platformSpecificTypeWithContentType: CSType.accessLevel)
+}
+
+// MARK: - Predefined types
+
 let CSAnyType = CSType.any
 let CSGenericTypeA = CSType.generic("a'", CSType.any)
 let CSGenericArrayOfTypeA = CSType.array(CSGenericTypeA)
@@ -526,11 +546,3 @@ let CSLayerType = CSType.dictionary([
     // Children
     "children": (type: .array(.any), access: .write)
 ])
-
-let PlatformSpecificString = CSType.dictionary([
-    "ios": (type: .string, access: .write),
-    "macos": (type: .string, access: .write),
-    "reactdom": (type: .string, access: .write),
-    "reactnative": (type: .string, access: .write),
-    "reactsketchapp": (type: .string, access: .write)
-    ])

--- a/studio/LonaStudio/Workspace/Inspector View/CoreComponentInspectorView.swift
+++ b/studio/LonaStudio/Workspace/Inspector View/CoreComponentInspectorView.swift
@@ -88,6 +88,7 @@ class CoreComponentInspectorView: NSStackView {
         case animationSpeed
 
         // Metadata
+        case accessLevel
         case backingElementClass
     }
 
@@ -161,9 +162,18 @@ class CoreComponentInspectorView: NSStackView {
         valueToTitle: ["cover": "Aspect-preserving Fill", "contain": "Aspect-preserving Fit", "stretch": "Stretch Fill"]
     )
 
+    var accessLevelElement = CSValueField(
+        value: CSValue(
+            type: CSType.platformSpecificAccessLevel,
+            data: CSData.Object([:])))
+    var accessLevelRow = NSStackView(
+        views: [NSTextField(labelWithString: "Access Level")],
+        orientation: .horizontal,
+        stretched: true)
+
     var backingElement = CSValueField(
         value: CSValue(
-            type: PlatformSpecificString,
+            type: CSType.platformSpecificString,
             data: CSData.Object([:])))
     var backingRow = NSStackView(
         views: [NSTextField(labelWithString: "Backing Element")],
@@ -433,8 +443,11 @@ class CoreComponentInspectorView: NSStackView {
     }
 
     func renderMetadataSection() -> DisclosureContentRow {
-        let backgroundSection = renderSection(title: "Metadata", views: [backingRow])
-        return backgroundSection
+        let metadataSection = renderSection(title: "Metadata", views: [accessLevelRow, backingRow])
+        [accessLevelRow].forEach {
+            metadataSection.addContentSpacing(of: 14, after: $0)
+        }
+        return metadataSection
     }
 
     func renderTextSection() -> DisclosureContentRow {
@@ -733,11 +746,27 @@ class CoreComponentInspectorView: NSStackView {
                 backingElement.view.removeFromSuperview()
                 backingElement = CSValueField(
                     value: CSValue(
-                        type: PlatformSpecificString,
+                        type: CSType.platformSpecificString,
                         data: value))
                 backingRow.addArrangedSubview(backingElement.view, stretched: true)
                 backingElement.onChangeData = { data in
                     self.handlePropertyChange(for: .backingElementClass, value: data)
+                    setup(value: data)
+                }
+            }
+
+            setup(value: value)
+        }
+        if let value = properties[.accessLevel] {
+            func setup(value: CSData) {
+                accessLevelElement.view.removeFromSuperview()
+                accessLevelElement = CSValueField(
+                    value: CSValue(
+                        type: CSType.platformSpecificAccessLevel,
+                        data: value))
+                accessLevelRow.addArrangedSubview(accessLevelElement.view, stretched: true)
+                accessLevelElement.onChangeData = { data in
+                    self.handlePropertyChange(for: .accessLevel, value: data)
                     setup(value: data)
                 }
             }
@@ -1030,6 +1059,7 @@ class CoreComponentInspectorView: NSStackView {
             CoreComponentInspectorView.Property.animationSpeed: CSData.Number(layer.animationSpeed ?? 1),
 
             // Metadata
+            CoreComponentInspectorView.Property.accessLevel: layer.metadata["accessLevel"] ?? CSData.Object([:]),
             CoreComponentInspectorView.Property.backingElementClass: layer.metadata["backingElementClass"] ?? CSData.Object([:])
         ]
     }
@@ -1094,6 +1124,7 @@ class CoreComponentInspectorView: NSStackView {
         case .animationSpeed: layer.animationSpeed = value.numberValue
 
         // Metadata
+        case .accessLevel: layer.metadata["accessLevel"] = CSData.Object(value.objectValue)
         case .backingElementClass: layer.metadata["backingElementClass"] = CSData.Object(value.objectValue)
         }
     }

--- a/studio/LonaStudio/Workspace/Inspector View/CoreComponentInspectorView.swift
+++ b/studio/LonaStudio/Workspace/Inspector View/CoreComponentInspectorView.swift
@@ -1059,7 +1059,8 @@ class CoreComponentInspectorView: NSStackView {
             CoreComponentInspectorView.Property.animationSpeed: CSData.Number(layer.animationSpeed ?? 1),
 
             // Metadata
-            CoreComponentInspectorView.Property.accessLevel: layer.metadata["accessLevel"] ?? CSData.Object([:]),
+            CoreComponentInspectorView.Property.accessLevel: CSValue.expand(
+                type: CSType.platformSpecificAccessLevel, data: layer.metadata["accessLevel"] ?? CSData.Object([:])),
             CoreComponentInspectorView.Property.backingElementClass: layer.metadata["backingElementClass"] ?? CSData.Object([:])
         ]
     }
@@ -1124,7 +1125,8 @@ class CoreComponentInspectorView: NSStackView {
         case .animationSpeed: layer.animationSpeed = value.numberValue
 
         // Metadata
-        case .accessLevel: layer.metadata["accessLevel"] = CSData.Object(value.objectValue)
+        case .accessLevel: layer.metadata["accessLevel"] = CSValue.compact(
+            type: CSType.platformSpecificAccessLevel, data: CSData.Object(value.objectValue))
         case .backingElementClass: layer.metadata["backingElementClass"] = CSData.Object(value.objectValue)
         }
     }


### PR DESCRIPTION
## What

This adds an escape hatch for directly accessing views within a component class. This is useful for scenarios when Lona doesn't/can't support a feature yet.

![screen shot 2019-01-07 at 4 27 30 pm](https://user-images.githubusercontent.com/1198882/50801485-d5eebd00-1299-11e9-9b48-88c008e47cb7.png)

Use sparingly!

## Why

I'm planning to support a subset of the accessibility properties to begin with, but there are a handful of more obscure ones that may need setting manually with this.

## Testing Plan

- [X] Tested this change locally
- [X] Checked that existing features work

cc @outdooricon 