### PR TITLE
Add a11y checkbox role

### DIFF
--- a/compiler/core/src/core/layer.re
+++ b/compiler/core/src/core/layer.re
@@ -78,6 +78,7 @@ let getParameterCategory = (x: ParameterKey.t) =>
   | AccessibilityRole => Prop
   | AccessibilityElements => Prop
   | OnAccessibilityActivate => Prop
+  | AccessibilityChecked => Prop
   | Custom(_) => Prop
   /* Meta: these are treated like props within Lona for simplicity, but they are
      not actually props. These must be translated into something platform-specific

--- a/compiler/core/src/core/lonaValue.re
+++ b/compiler/core/src/core/lonaValue.re
@@ -78,6 +78,7 @@ let parameterDefaultValue = key =>
   | ParameterKey.AccessibilityType => string("default")
   | ParameterKey.AccessibilityElements => stringArray([])
   | ParameterKey.OnAccessibilityActivate => null()
+  | ParameterKey.AccessibilityChecked => boolean(false)
   /* Interactivity */
   | ParameterKey.Pressed => boolean(false)
   | ParameterKey.Hovered => boolean(false)

--- a/compiler/core/src/core/parameterKey.re
+++ b/compiler/core/src/core/parameterKey.re
@@ -48,6 +48,7 @@ type t =
   | AccessibilityRole
   | AccessibilityElements
   | OnAccessibilityActivate
+  | AccessibilityChecked
   /* Interactivity */
   | Pressed
   | Hovered
@@ -102,6 +103,7 @@ let fromString = string =>
   | "accessibilityRole" => AccessibilityRole
   | "accessibilityElements" => AccessibilityElements
   | "onAccessibilityActivate" => OnAccessibilityActivate
+  | "accessibilityChecked" => AccessibilityChecked;
   /* Interactivity */
   | "pressed" => Pressed
   | "hovered" => Hovered
@@ -158,6 +160,7 @@ let toString = key =>
   | AccessibilityRole => "accessibilityRole"
   | AccessibilityElements => "accessibilityElements"
   | OnAccessibilityActivate => "onAccessibilityActivate"
+  | AccessibilityChecked => "accessibilityChecked"
   /* Interactivity */
   | Pressed => "pressed"
   | Hovered => "hovered"

--- a/compiler/core/src/decode/decode.re
+++ b/compiler/core/src/decode/decode.re
@@ -53,6 +53,7 @@ let parameterType = key =>
   | AccessibilityRole => Types.stringType
   | AccessibilityElements => Types.Array(Types.stringType)
   | OnAccessibilityActivate => Types.handlerType
+  | AccessibilityChecked => Types.booleanType
   /* Custom */
   /* | Custom("font") => Types.textStyleType */
   | Custom(name) =>

--- a/compiler/core/src/javaScript/javaScriptComponent.re
+++ b/compiler/core/src/javaScript/javaScriptComponent.re
@@ -69,7 +69,6 @@ let removeSpecialProps =
   |> ParameterMap.filter((key: ParameterKey.t, _) =>
        switch (key, options.framework) {
        | (ParameterKey.AccessibilityHint, _)
-       | (ParameterKey.AccessibilityRole, _)
        | (ParameterKey.AccessibilityValue, _)
        | (ParameterKey.AccessibilityType, _)
        | (ParameterKey.AccessibilityElements, _) => false
@@ -79,6 +78,11 @@ let removeSpecialProps =
            ParameterKey.OnAccessibilityActivate,
            JavaScriptOptions.ReactSketchapp,
          ) =>
+         false
+       | (ParameterKey.AccessibilityRole, JavaScriptOptions.ReactNative)
+       | (ParameterKey.AccessibilityRole, JavaScriptOptions.ReactSketchapp)
+       | (ParameterKey.AccessibilityChecked, JavaScriptOptions.ReactNative)
+       | (ParameterKey.AccessibilityChecked, JavaScriptOptions.ReactSketchapp) =>
          false
        | (ParameterKey.NumberOfLines, JavaScriptOptions.ReactDOM) => false
        | (ParameterKey.Text, _) => false

--- a/compiler/core/src/javaScript/utils/reactDomTranslators.re
+++ b/compiler/core/src/javaScript/utils/reactDomTranslators.re
@@ -45,6 +45,8 @@ let variableNames = variable =>
   | ParameterKey.Image => "src"
   | ParameterKey.OnPress => "onClick"
   | ParameterKey.AccessibilityLabel => "aria-label"
+  | ParameterKey.AccessibilityChecked => "aria-checked"
+  | ParameterKey.AccessibilityRole => "role"
   | _ => variable |> ParameterKey.toString
   };
 

--- a/compiler/core/src/swift/swiftLogic.re
+++ b/compiler/core/src/swift/swiftLogic.re
@@ -251,6 +251,7 @@ let toSwiftAST =
                 | "none" => "UIAccessibilityTraitNone"
                 | "button" => "UIAccessibilityTraitButton"
                 | "link" => "UIAccessibilityTraitLink"
+                | "checkbox" => "UIAccessibilityTraitButton"
                 | "search" => "UIAccessibilityTraitSearchField"
                 | "image" => "UIAccessibilityTraitImage"
                 | "keyboardkey" => "UIAccessibilityTraitKeyboardKey"
@@ -265,6 +266,9 @@ let toSwiftAST =
           })
         | AppKit => Empty
         }
+      | (Ast.SwiftIdentifier(key), _)
+          when key |> keyEndsWith("accessibilityChecked") =>
+        Empty
       | (
           Ast.SwiftIdentifier(key) as left,
           Ast.LiteralExpression(Array(elements)),

--- a/examples/generated/test/appkit/interactivity/AccessibilityTest.swift
+++ b/examples/generated/test/appkit/interactivity/AccessibilityTest.swift
@@ -152,9 +152,9 @@ public class AccessibilityTest: NSBox {
 
 
 
+
     checkboxView.borderColor = Colors.grey400
     checkboxView.cornerRadius = 20
-
     checkboxView.borderWidth = 1
     checkboxCircleView.fillColor = Colors.green200
     checkboxCircleView.cornerRadius = 15
@@ -382,6 +382,7 @@ public class AccessibilityTest: NSBox {
     }
 
     checkboxViewOnPress = handleOnToggleCheckbox
+
 
     if checkboxCircleView.isHidden != checkboxCircleViewIsHidden {
       NSLayoutConstraint.deactivate(conditionalConstraints(checkboxCircleViewIsHidden: checkboxCircleViewIsHidden))

--- a/examples/generated/test/react-dom/interactivity/AccessibilityTest.js
+++ b/examples/generated/test/react-dom/interactivity/AccessibilityTest.js
@@ -72,6 +72,7 @@ export default class AccessibilityTest extends React.Component {
 
     let AccessibleText$accessibilityLabel
     let CheckboxCircle$visible
+    let CheckboxRow$accessibilityChecked
     let CheckboxRow$accessibilityValue
     let CheckboxRow$onAccessibilityActivate
     let Checkbox$onPress
@@ -91,11 +92,14 @@ export default class AccessibilityTest extends React.Component {
     }
     CheckboxRow$onAccessibilityActivate = this.props.onToggleCheckbox
     Checkbox$onPress = this.props.onToggleCheckbox
+    CheckboxRow$accessibilityChecked = this.props.checkboxValue
     return (
       <View>
         <CheckboxRowAccessibilityWrapper
           aria-label={"Checkbox row"}
+          role={"checkbox"}
           onAccessibilityActivate={CheckboxRow$onAccessibilityActivate}
+          aria-checked={CheckboxRow$accessibilityChecked}
           tabIndex={-1}
           focusRing={this.state.focusRing}
           onKeyDown={this._handleKeyDown}
@@ -111,6 +115,7 @@ export default class AccessibilityTest extends React.Component {
         <Row1>
           <Element
             aria-label={"Red box"}
+            role={"button"}
             tabIndex={-1}
             focusRing={this.state.focusRing}
             onKeyDown={this._handleKeyDown}

--- a/examples/generated/test/react-native/interactivity/AccessibilityTest.js
+++ b/examples/generated/test/react-native/interactivity/AccessibilityTest.js
@@ -11,6 +11,7 @@ export default class AccessibilityTest extends React.Component {
 
     let AccessibleText$accessibilityLabel
     let CheckboxCircle$visible
+    let CheckboxRow$accessibilityChecked
     let CheckboxRow$accessibilityValue
     let CheckboxRow$onAccessibilityActivate
     let Checkbox$onPress
@@ -30,6 +31,7 @@ export default class AccessibilityTest extends React.Component {
     }
     CheckboxRow$onAccessibilityActivate = this.props.onToggleCheckbox
     Checkbox$onPress = this.props.onToggleCheckbox
+    CheckboxRow$accessibilityChecked = this.props.checkboxValue
     return (
       <View style={styles.view}>
         <View
@@ -116,7 +118,6 @@ let styles = StyleSheet.create({
     paddingLeft: 4,
     borderColor: colors.grey400,
     borderRadius: 20,
-    borderStyle: "solid",
     borderWidth: 1,
     width: 30,
     height: 30

--- a/examples/generated/test/sketchJs/interactivity/AccessibilityTest.js
+++ b/examples/generated/test/sketchJs/interactivity/AccessibilityTest.js
@@ -12,6 +12,7 @@ export default class AccessibilityTest extends React.Component {
 
     let AccessibleText$accessibilityLabel
     let CheckboxCircle$visible
+    let CheckboxRow$accessibilityChecked
     let CheckboxRow$accessibilityValue
     let CheckboxRow$onAccessibilityActivate
     let Checkbox$onPress
@@ -31,6 +32,7 @@ export default class AccessibilityTest extends React.Component {
     }
     CheckboxRow$onAccessibilityActivate = this.props.onToggleCheckbox
     Checkbox$onPress = this.props.onToggleCheckbox
+    CheckboxRow$accessibilityChecked = this.props.checkboxValue
     return (
       <View style={styles.view}>
         <View style={styles.checkboxRow}>
@@ -102,7 +104,6 @@ let styles = StyleSheet.create({
     paddingLeft: 4,
     borderColor: colors.grey400,
     borderRadius: 20,
-    borderStyle: "solid",
     borderWidth: 1,
     width: 30,
     height: 30

--- a/examples/generated/test/swift/interactivity/AccessibilityTest.swift
+++ b/examples/generated/test/swift/interactivity/AccessibilityTest.swift
@@ -137,9 +137,9 @@ public class AccessibilityTest: UIView {
 
     checkboxRowView.isAccessibilityElement = true
     checkboxRowView.accessibilityLabel = "Checkbox row"
+    checkboxRowView.accessibilityTraits = UIAccessibilityTraitButton
     checkboxView.layer.borderColor = Colors.grey400.cgColor
     checkboxView.layer.cornerRadius = 20
-
     checkboxView.layer.borderWidth = 1
     checkboxCircleView.backgroundColor = Colors.green200
     checkboxCircleView.layer.cornerRadius = 15
@@ -372,6 +372,7 @@ public class AccessibilityTest: UIView {
     }
     checkboxRowView.onAccessibilityActivate = handleOnToggleCheckbox
     onTapCheckboxView = handleOnToggleCheckbox
+
 
     if checkboxCircleView.isHidden != checkboxCircleViewIsHidden {
       NSLayoutConstraint.deactivate(conditionalConstraints(checkboxCircleViewIsHidden: checkboxCircleViewIsHidden))

--- a/examples/test/interactivity/AccessibilityTest.component
+++ b/examples/test/interactivity/AccessibilityTest.component
@@ -150,6 +150,18 @@
         "onToggleCheckbox"
       ],
       "type" : "AssignExpr"
+    },
+    {
+      "assignee" : [
+        "layers",
+        "CheckboxRow",
+        "accessibilityChecked"
+      ],
+      "content" : [
+        "parameters",
+        "checkboxValue"
+      ],
+      "type" : "AssignExpr"
     }
   ],
   "params" : [
@@ -189,7 +201,6 @@
             "params" : {
               "borderColor" : "grey400",
               "borderRadius" : 20,
-              "borderStyle" : "solid",
               "borderWidth" : 1,
               "height" : 30,
               "marginRight" : 10,
@@ -212,6 +223,7 @@
         "id" : "CheckboxRow",
         "params" : {
           "accessibilityLabel" : "Checkbox row",
+          "accessibilityRole" : "checkbox",
           "accessibilityType" : "element",
           "alignItems" : "center",
           "alignSelf" : "stretch",

--- a/studio/LonaStudio/Generated/inspector/AccessibilityInspector.swift
+++ b/studio/LonaStudio/Generated/inspector/AccessibilityInspector.swift
@@ -25,6 +25,7 @@ public class AccessibilityInspector: NSBox {
     accessibilityHintText: String,
     accessibilityElements: [String],
     selectedElementIndices: [Int],
+    accessibilityRoles: [String],
     accessibilityRoleIndex: Int)
   {
     self
@@ -36,6 +37,7 @@ public class AccessibilityInspector: NSBox {
           accessibilityHintText: accessibilityHintText,
           accessibilityElements: accessibilityElements,
           selectedElementIndices: selectedElementIndices,
+          accessibilityRoles: accessibilityRoles,
           accessibilityRoleIndex: accessibilityRoleIndex))
   }
 
@@ -131,6 +133,15 @@ public class AccessibilityInspector: NSBox {
     set {
       if parameters.selectedElementIndices != newValue {
         parameters.selectedElementIndices = newValue
+      }
+    }
+  }
+
+  public var accessibilityRoles: [String] {
+    get { return parameters.accessibilityRoles }
+    set {
+      if parameters.accessibilityRoles != newValue {
+        parameters.accessibilityRoles = newValue
       }
     }
   }
@@ -289,19 +300,6 @@ public class AccessibilityInspector: NSBox {
     hintLabelView.attributedStringValue = hintLabelViewTextStyle.apply(to: "Hint")
     hintTextInputView.placeholderString = "Hint"
     roleLabelView.attributedStringValue = roleLabelViewTextStyle.apply(to: "Role")
-    roleDropdownView.values = [
-      "None",
-      "Button",
-      "Link",
-      "Search",
-      "Image",
-      "Keyboard Key",
-      "Text",
-      "Adjustable",
-      "Image Button",
-      "Header",
-      "Summary"
-    ]
     statesLabelView.attributedStringValue = statesLabelViewTextStyle.apply(to: "States")
     statesDropdownView.selectedIndex = 0
     statesDropdownView.values = ["None", "Selected", "Disabled", "Selected and Disabled"]
@@ -806,6 +804,7 @@ public class AccessibilityInspector: NSBox {
     accessibilityElementsInputView.selectedIndices = selectedElementIndices
     roleDropdownView.onChangeIndex = handleOnChangeAccessibilityRoleIndex
     roleDropdownView.selectedIndex = accessibilityRoleIndex
+    roleDropdownView.values = accessibilityRoles
 
     if
     containerContainerView.isHidden != containerContainerViewIsHidden ||
@@ -860,6 +859,7 @@ extension AccessibilityInspector {
     public var accessibilityHintText: String
     public var accessibilityElements: [String]
     public var selectedElementIndices: [Int]
+    public var accessibilityRoles: [String]
     public var accessibilityRoleIndex: Int
     public var onClickHeader: (() -> Void)?
     public var onChangeAccessibilityTypeIndex: ((Int) -> Void)?
@@ -875,6 +875,7 @@ extension AccessibilityInspector {
       accessibilityHintText: String,
       accessibilityElements: [String],
       selectedElementIndices: [Int],
+      accessibilityRoles: [String],
       accessibilityRoleIndex: Int,
       onClickHeader: (() -> Void)? = nil,
       onChangeAccessibilityTypeIndex: ((Int) -> Void)? = nil,
@@ -889,6 +890,7 @@ extension AccessibilityInspector {
       self.accessibilityHintText = accessibilityHintText
       self.accessibilityElements = accessibilityElements
       self.selectedElementIndices = selectedElementIndices
+      self.accessibilityRoles = accessibilityRoles
       self.accessibilityRoleIndex = accessibilityRoleIndex
       self.onClickHeader = onClickHeader
       self.onChangeAccessibilityTypeIndex = onChangeAccessibilityTypeIndex
@@ -907,6 +909,7 @@ extension AccessibilityInspector {
           accessibilityHintText: "",
           accessibilityElements: [],
           selectedElementIndices: [],
+          accessibilityRoles: [],
           accessibilityRoleIndex: 0)
     }
 
@@ -917,7 +920,8 @@ extension AccessibilityInspector {
             lhs.accessibilityHintText == rhs.accessibilityHintText &&
               lhs.accessibilityElements == rhs.accessibilityElements &&
                 lhs.selectedElementIndices == rhs.selectedElementIndices &&
-                  lhs.accessibilityRoleIndex == rhs.accessibilityRoleIndex
+                  lhs.accessibilityRoles == rhs.accessibilityRoles &&
+                    lhs.accessibilityRoleIndex == rhs.accessibilityRoleIndex
     }
   }
 }
@@ -948,6 +952,7 @@ extension AccessibilityInspector {
       accessibilityHintText: String,
       accessibilityElements: [String],
       selectedElementIndices: [Int],
+      accessibilityRoles: [String],
       accessibilityRoleIndex: Int,
       onClickHeader: (() -> Void)? = nil,
       onChangeAccessibilityTypeIndex: ((Int) -> Void)? = nil,
@@ -965,6 +970,7 @@ extension AccessibilityInspector {
             accessibilityHintText: accessibilityHintText,
             accessibilityElements: accessibilityElements,
             selectedElementIndices: selectedElementIndices,
+            accessibilityRoles: accessibilityRoles,
             accessibilityRoleIndex: accessibilityRoleIndex,
             onClickHeader: onClickHeader,
             onChangeAccessibilityTypeIndex: onChangeAccessibilityTypeIndex,
@@ -983,6 +989,7 @@ extension AccessibilityInspector {
           accessibilityHintText: "",
           accessibilityElements: [],
           selectedElementIndices: [],
+          accessibilityRoles: [],
           accessibilityRoleIndex: 0)
     }
   }

--- a/studio/LonaStudio/Models/Accessibility.swift
+++ b/studio/LonaStudio/Models/Accessibility.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 enum AccessibilityRole: String {
-    case none, button, link, search, image, keyboardkey, adjustable, imagebutton, header, summary
+    case none, button, link, checkbox, search, image, keyboardkey, adjustable, imagebutton, header, summary
 }
 
 struct AccessibilityStates: OptionSet {

--- a/studio/LonaStudio/Models/CSLayer.swift
+++ b/studio/LonaStudio/Models/CSLayer.swift
@@ -603,6 +603,7 @@ class CSLayer: CSDataDeserializable, CSDataSerializable, DataNode, NSCopying {
         "none",
         "button",
         "link",
+        "checkbox",
         "search",
         "image",
         "keyboardkey",
@@ -748,6 +749,13 @@ class CSLayer: CSDataDeserializable, CSDataSerializable, DataNode, NSCopying {
             // Children
             "children": CSData.Array([])
         ])
+
+        switch accessibility.role ?? AccessibilityRole.none {
+        case .checkbox:
+            data["accessibilityChecked"] = CSData.Bool(false)
+        default:
+            break
+        }
 
         if type == .view {
             data["pressed"] = CSData.Bool(false)

--- a/studio/LonaStudio/Models/CSType.swift
+++ b/studio/LonaStudio/Models/CSType.swift
@@ -554,6 +554,9 @@ let CSLayerType = CSType.dictionary([
     "accessibilityElements": (type: .array(.string), access: .write),
     "onAccessibilityActivate": (type: CSHandlerType, access: .write),
 
+    // Conditional accessibility
+    "accessibilityChecked": (type: .bool, access: .write),
+
     // Children
     "children": (type: .array(.any), access: .write)
 ])

--- a/studio/LonaStudio/Workspace/Inspector View/CoreComponentInspectorView.swift
+++ b/studio/LonaStudio/Workspace/Inspector View/CoreComponentInspectorView.swift
@@ -945,6 +945,7 @@ class CoreComponentInspectorView: NSStackView {
             change(property: Property.accessibilityRole, to: CSLayer.accessibilityRoles[value].toData())
         }
 
+        accessibilityInspector.accessibilityRoles = CSLayer.accessibilityRoles
         accessibilityInspector.accessibilityElements = csLayer.descendantLayerNames(includingSelf: false)
         accessibilityInspector.onChangeSelectedElementIndices = { value in
             change(property: Property.accessibilityElements, to: value.toData())

--- a/studio/docs/accessibility.md
+++ b/studio/docs/accessibility.md
@@ -82,9 +82,23 @@ Use this when working with interactive controls. For example, a number input fie
 
 _Currently supported on iOS_
 
-Type: one of `"none"`, `"button"`, `"link"`, `"search"`, `"image"`, `"keyboardkey"`, `"text"`, `"adjustable"`, `"imagebutton"`, `"header"`, `"summary"`
+Type: one of `"none"`, `"button"`, `"link"`, `"checkbox"`, `"search"`, `"image"`, `"keyboardkey"`, `"text"`, `"adjustable"`, `"imagebutton"`, `"header"`, `"summary"`
 
 These presets determine the high level behavior of the layer. Currently this list is taken from React Native and should handle mobile fairly well, but there may be more to add for web.
+
+##### Role mapping details
+
+- **`checkbox`**
+  - **web**: this maps to the `checkbox` role and allows the `accessibilityChecked` layer parameter to be assigned via logic.
+  - **iOS**: this maps to the `button` role. Use `accessibilityValue` to control how screenreaders read the value (e.g. by setting `accessibilityValue` to a localized translation of `"checked"` and `"unchecked"`)
+
+#### `accessibilityChecked` (static)
+
+_Supported on web_
+
+Type: `Boolean`
+
+This parameter can be assigned via logic when the `accessibilityRole` of a layer is set to `checkbox`. This indicates whether the checkbox is checked or not.
 
 #### `accessibilityElements` (static & dynamic†)
 

--- a/workspace/inspector/AccessibilityInspector.component
+++ b/workspace/inspector/AccessibilityInspector.component
@@ -297,6 +297,18 @@
         "accessibilityRoleIndex"
       ],
       "type" : "AssignExpr"
+    },
+    {
+      "assignee" : [
+        "layers",
+        "RoleDropdown",
+        "values"
+      ],
+      "content" : [
+        "parameters",
+        "accessibilityRoles"
+      ],
+      "type" : "AssignExpr"
     }
   ],
   "params" : [
@@ -369,6 +381,13 @@
       "type" : {
         "name" : "Array",
         "of" : "WholeNumber"
+      }
+    },
+    {
+      "name" : "accessibilityRoles",
+      "type" : {
+        "name" : "Array",
+        "of" : "String"
       }
     },
     {
@@ -472,17 +491,7 @@
                 "params" : {
                   "selectedIndex" : 0,
                   "values" : [
-                    "None",
-                    "Button",
-                    "Link",
-                    "Search",
-                    "Image",
-                    "Keyboard Key",
-                    "Text",
-                    "Adjustable",
-                    "Image Button",
-                    "Header",
-                    "Summary"
+
                   ]
                 },
                 "type" : "ControlledDropdown"


### PR DESCRIPTION
## What

This adds a role specifically for checkboxes. This requires slightly different usage on web vs iOS. I couldn't come up with a simple cross-platform solution, but I think this is acceptable.

I updated the docs with usage instructions.

cc @outdooricon 