### PR TITLE
Fix JS keyboard focus issues

### DIFF
--- a/compiler/core/src/javaScript/javaScriptFocus.re
+++ b/compiler/core/src/javaScript/javaScriptFocus.re
@@ -25,17 +25,27 @@ module Methods = {
           id: None,
           params: [],
           body: [
+            VariableDeclaration(
+              AssignmentExpression({
+                left: Identifier(["elements"]),
+                right:
+                  ArrayLiteral(
+                    rootLayer
+                    |> JavaScriptLayer.Hierarchy.accessibilityElements
+                    |> List.map((layer: Types.layer) =>
+                         JavaScriptAst.Identifier([
+                           "this",
+                           "_" ++ JavaScriptFormat.elementName(layer.name),
+                         ])
+                       ),
+                  ),
+              }),
+            ),
             Return(
-              ArrayLiteral(
-                rootLayer
-                |> JavaScriptLayer.Hierarchy.accessibilityElements
-                |> List.map((layer: Types.layer) =>
-                     JavaScriptAst.Identifier([
-                       "this",
-                       "_" ++ JavaScriptFormat.elementName(layer.name),
-                     ])
-                   ),
-              ),
+              CallExpression({
+                callee: Identifier(["elements.filter"]),
+                arguments: [Identifier(["Boolean"])],
+              }),
             ),
           ],
         }),
@@ -94,6 +104,57 @@ module Methods = {
               consequent: [
                 CallExpression({
                   callee: Identifier(["focusElements[0]", "focus"]),
+                  arguments: [],
+                }),
+              ],
+              alternate: [],
+            }),
+          ],
+        }),
+    });
+
+  let focusLast = (): JavaScriptAst.node =>
+    AssignmentExpression({
+      left: Identifier(["focusLast"]),
+      right:
+        ArrowFunctionExpression({
+          id: None,
+          params: [focusOptionsParam()],
+          body: [
+            CallExpression({
+              callee: Identifier(["this", "setFocusRing"]),
+              arguments: [Identifier(["focusRing"])],
+            }),
+            Empty,
+            VariableDeclaration(
+              AssignmentExpression({
+                left: Identifier(["focusElements"]),
+                right:
+                  CallExpression({
+                    callee: Identifier(["this", "_getFocusElements"]),
+                    arguments: [],
+                  }),
+              }),
+            ),
+            IfStatement({
+              test:
+                BinaryExpression({
+                  left:
+                    Identifier(["focusElements[focusElements.length - 1]"]),
+                  operator: And,
+                  right:
+                    Identifier([
+                      "focusElements[focusElements.length - 1]",
+                      "focus",
+                    ]),
+                }),
+              consequent: [
+                CallExpression({
+                  callee:
+                    Identifier([
+                      "focusElements[focusElements.length - 1]",
+                      "focus",
+                    ]),
                   arguments: [],
                 }),
               ],
@@ -322,6 +383,7 @@ let focusMethods = (rootLayer: Types.layer): list(JavaScriptAst.node) =>
   Methods.[
     setFocusRing(),
     focus(),
+    focusLast(),
     focusNext(),
     focusPrevious(),
     handleKeyDown(),

--- a/compiler/core/src/javaScript/javaScriptRender.re
+++ b/compiler/core/src/javaScript/javaScriptRender.re
@@ -64,11 +64,8 @@ let rec render = ast: Prettier.Doc.t('a) =>
   | IfStatement(o) =>
     let ifPart =
       group(
-        s("if")
-        <+> line
-        <+> s("(")
-        <+> softline
-        <+> render(o.test)
+        s("if (")
+        <+> indent(softline <+> render(o.test))
         <+> softline
         <+> s(") "),
       )

--- a/examples/LonaViewer/LonaViewer.xcodeproj/project.pbxproj
+++ b/examples/LonaViewer/LonaViewer.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		6B39170621643C7C00B20F9E /* Shadows.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B39170521643C7C00B20F9E /* Shadows.swift */; };
 		6B39170821643EF300B20F9E /* ShadowsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B39170721643EF300B20F9E /* ShadowsTest.swift */; };
 		6B39170A2164492600B20F9E /* Shadow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3917092164492600B20F9E /* Shadow.swift */; };
+		6B61E06F21FA7E8F0057E8DF /* AccessibilityVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B61E06E21FA7E8F0057E8DF /* AccessibilityVisibility.swift */; };
 		6B6D4423218BCF150016262C /* LNATextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6D4422218BCF150016262C /* LNATextField.swift */; };
 		6B6D4425218E31EF0016262C /* ImageCropping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6D4424218E31EF0016262C /* ImageCropping.swift */; };
 		6B6D4429218F565C0016262C /* CGSize+Resizing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6D4428218F565C0016262C /* CGSize+Resizing.swift */; };
@@ -181,6 +182,7 @@
 		6B39170521643C7C00B20F9E /* Shadows.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Shadows.swift; sourceTree = "<group>"; };
 		6B39170721643EF300B20F9E /* ShadowsTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShadowsTest.swift; sourceTree = "<group>"; };
 		6B3917092164492600B20F9E /* Shadow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Shadow.swift; sourceTree = "<group>"; };
+		6B61E06E21FA7E8F0057E8DF /* AccessibilityVisibility.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccessibilityVisibility.swift; sourceTree = "<group>"; };
 		6B6D4422218BCF150016262C /* LNATextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LNATextField.swift; sourceTree = "<group>"; };
 		6B6D4424218E31EF0016262C /* ImageCropping.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageCropping.swift; sourceTree = "<group>"; };
 		6B6D4428218F565C0016262C /* CGSize+Resizing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CGSize+Resizing.swift"; sourceTree = "<group>"; };
@@ -440,6 +442,7 @@
 			isa = PBXGroup;
 			children = (
 				6B06ADB221E8FB0400136BC8 /* AccessibilityTest.swift */,
+				6B61E06E21FA7E8F0057E8DF /* AccessibilityVisibility.swift */,
 				30F870BA20864AEE007ADA5B /* Button.swift */,
 				12BBFDF8206B02AC0041620C /* PressableRootView.swift */,
 			);
@@ -623,6 +626,7 @@
 				6B29133B219CB84200A1DDB4 /* OpacityTest.swift in Sources */,
 				6B29134D219E504E00A1DDB4 /* LonaViewModel.swift in Sources */,
 				12BBFE11206B02AC0041620C /* Colors.swift in Sources */,
+				6B61E06F21FA7E8F0057E8DF /* AccessibilityVisibility.swift in Sources */,
 				30F870B920864A88007ADA5B /* NestedButtons.swift in Sources */,
 				6B291347219E189A00A1DDB4 /* NestedLayout.swift in Sources */,
 				12BBFE0D206B02AC0041620C /* FixedParentFitChild.swift in Sources */,

--- a/examples/LonaViewer/web/src/App.js
+++ b/examples/LonaViewer/web/src/App.js
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import "./App.css";
 
 import AccessibilityTest from "./generated/interactivity/AccessibilityTest";
+import AccessibilityVisibility from "./generated/interactivity/AccessibilityVisibility";
 
 class App extends Component {
   state = {
@@ -36,6 +37,18 @@ class App extends Component {
           onToggleCheckbox={() =>
             this.setState({ checked: !this.state.checked })
           }
+          onFocusNext={() => {
+            this.accessibilityVisibility.focus();
+          }}
+        />
+        <AccessibilityVisibility
+          ref={ref => {
+            this.accessibilityVisibility = ref;
+          }}
+          showText={this.state.checked}
+          onFocusPrevious={() => {
+            this.accessibilityTest.focusLast();
+          }}
         />
       </div>
     );

--- a/examples/generated/test/appkit/interactivity/AccessibilityVisibility.swift
+++ b/examples/generated/test/appkit/interactivity/AccessibilityVisibility.swift
@@ -1,0 +1,206 @@
+import AppKit
+import Foundation
+
+// MARK: - AccessibilityVisibility
+
+public class AccessibilityVisibility: NSBox {
+
+  // MARK: Lifecycle
+
+  public init(_ parameters: Parameters) {
+    self.parameters = parameters
+
+    super.init(frame: .zero)
+
+    setUpViews()
+    setUpConstraints()
+
+    update()
+  }
+
+  public convenience init(showText: Bool) {
+    self.init(Parameters(showText: showText))
+  }
+
+  public convenience init() {
+    self.init(Parameters())
+  }
+
+  public required init?(coder aDecoder: NSCoder) {
+    self.parameters = Parameters()
+
+    super.init(coder: aDecoder)
+
+    setUpViews()
+    setUpConstraints()
+
+    update()
+  }
+
+  // MARK: Public
+
+  public var showText: Bool {
+    get { return parameters.showText }
+    set {
+      if parameters.showText != newValue {
+        parameters.showText = newValue
+      }
+    }
+  }
+
+  public var parameters: Parameters {
+    didSet {
+      if parameters != oldValue {
+        update()
+      }
+    }
+  }
+
+  // MARK: Private
+
+  private var greyBoxView = NSBox()
+  private var textView = LNATextField(labelWithString: "")
+
+  private var textViewTextStyle = TextStyles.body1
+
+  private var greyBoxViewBottomAnchorBottomAnchorConstraint: NSLayoutConstraint?
+  private var textViewBottomAnchorBottomAnchorConstraint: NSLayoutConstraint?
+  private var textViewTopAnchorGreyBoxViewBottomAnchorConstraint: NSLayoutConstraint?
+  private var textViewLeadingAnchorLeadingAnchorConstraint: NSLayoutConstraint?
+  private var textViewTrailingAnchorTrailingAnchorConstraint: NSLayoutConstraint?
+
+  private func setUpViews() {
+    boxType = .custom
+    borderType = .noBorder
+    contentViewMargins = .zero
+    greyBoxView.boxType = .custom
+    greyBoxView.borderType = .noBorder
+    greyBoxView.contentViewMargins = .zero
+    textView.lineBreakMode = .byWordWrapping
+
+    addSubview(greyBoxView)
+    addSubview(textView)
+
+
+
+    greyBoxView.fillColor = #colorLiteral(red: 0.847058823529, green: 0.847058823529, blue: 0.847058823529, alpha: 1)
+
+
+    textView.attributedStringValue = textViewTextStyle.apply(to: "Sometimes hidden")
+
+
+  }
+
+  private func setUpConstraints() {
+    translatesAutoresizingMaskIntoConstraints = false
+    greyBoxView.translatesAutoresizingMaskIntoConstraints = false
+    textView.translatesAutoresizingMaskIntoConstraints = false
+
+    let greyBoxViewTopAnchorConstraint = greyBoxView.topAnchor.constraint(equalTo: topAnchor)
+    let greyBoxViewLeadingAnchorConstraint = greyBoxView.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let greyBoxViewHeightAnchorConstraint = greyBoxView.heightAnchor.constraint(equalToConstant: 40)
+    let greyBoxViewWidthAnchorConstraint = greyBoxView.widthAnchor.constraint(equalToConstant: 100)
+    let greyBoxViewBottomAnchorBottomAnchorConstraint = greyBoxView.bottomAnchor.constraint(equalTo: bottomAnchor)
+    let textViewBottomAnchorBottomAnchorConstraint = textView.bottomAnchor.constraint(equalTo: bottomAnchor)
+    let textViewTopAnchorGreyBoxViewBottomAnchorConstraint = textView
+      .topAnchor
+      .constraint(equalTo: greyBoxView.bottomAnchor)
+    let textViewLeadingAnchorLeadingAnchorConstraint = textView.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let textViewTrailingAnchorTrailingAnchorConstraint = textView
+      .trailingAnchor
+      .constraint(lessThanOrEqualTo: trailingAnchor)
+
+    self.greyBoxViewBottomAnchorBottomAnchorConstraint = greyBoxViewBottomAnchorBottomAnchorConstraint
+    self.textViewBottomAnchorBottomAnchorConstraint = textViewBottomAnchorBottomAnchorConstraint
+    self.textViewTopAnchorGreyBoxViewBottomAnchorConstraint = textViewTopAnchorGreyBoxViewBottomAnchorConstraint
+    self.textViewLeadingAnchorLeadingAnchorConstraint = textViewLeadingAnchorLeadingAnchorConstraint
+    self.textViewTrailingAnchorTrailingAnchorConstraint = textViewTrailingAnchorTrailingAnchorConstraint
+
+    NSLayoutConstraint.activate(
+      [
+        greyBoxViewTopAnchorConstraint,
+        greyBoxViewLeadingAnchorConstraint,
+        greyBoxViewHeightAnchorConstraint,
+        greyBoxViewWidthAnchorConstraint
+      ] +
+        conditionalConstraints(textViewIsHidden: textView.isHidden))
+  }
+
+  private func conditionalConstraints(textViewIsHidden: Bool) -> [NSLayoutConstraint] {
+    var constraints: [NSLayoutConstraint?]
+
+    switch (textViewIsHidden) {
+      case (true):
+        constraints = [greyBoxViewBottomAnchorBottomAnchorConstraint]
+      case (false):
+        constraints = [
+          textViewBottomAnchorBottomAnchorConstraint,
+          textViewTopAnchorGreyBoxViewBottomAnchorConstraint,
+          textViewLeadingAnchorLeadingAnchorConstraint,
+          textViewTrailingAnchorTrailingAnchorConstraint
+        ]
+    }
+
+    return constraints.compactMap({ $0 })
+  }
+
+  private func update() {
+    let textViewIsHidden = textView.isHidden
+
+    textView.isHidden = !showText
+
+    if textView.isHidden != textViewIsHidden {
+      NSLayoutConstraint.deactivate(conditionalConstraints(textViewIsHidden: textViewIsHidden))
+      NSLayoutConstraint.activate(conditionalConstraints(textViewIsHidden: textView.isHidden))
+    }
+  }
+}
+
+// MARK: - Parameters
+
+extension AccessibilityVisibility {
+  public struct Parameters: Equatable {
+    public var showText: Bool
+
+    public init(showText: Bool) {
+      self.showText = showText
+    }
+
+    public init() {
+      self.init(showText: false)
+    }
+
+    public static func ==(lhs: Parameters, rhs: Parameters) -> Bool {
+      return lhs.showText == rhs.showText
+    }
+  }
+}
+
+// MARK: - Model
+
+extension AccessibilityVisibility {
+  public struct Model: LonaViewModel, Equatable {
+    public var id: String?
+    public var parameters: Parameters
+    public var type: String {
+      return "AccessibilityVisibility"
+    }
+
+    public init(id: String? = nil, parameters: Parameters) {
+      self.id = id
+      self.parameters = parameters
+    }
+
+    public init(_ parameters: Parameters) {
+      self.parameters = parameters
+    }
+
+    public init(showText: Bool) {
+      self.init(Parameters(showText: showText))
+    }
+
+    public init() {
+      self.init(showText: false)
+    }
+  }
+}

--- a/examples/generated/test/react-dom/interactivity/AccessibilityTest.js
+++ b/examples/generated/test/react-dom/interactivity/AccessibilityTest.js
@@ -24,10 +24,9 @@ export default class AccessibilityTest extends React.Component {
     this.setFocusRing(focusRing)
 
     let focusElements = this._getFocusElements()
-    if
-    (
-    focusElements[focusElements.length - 1] &&
-    focusElements[focusElements.length - 1].focus
+    if (
+      focusElements[focusElements.length - 1] &&
+      focusElements[focusElements.length - 1].focus
     ) {
       focusElements[focusElements.length - 1].focus()
     }

--- a/examples/generated/test/react-dom/interactivity/AccessibilityTest.js
+++ b/examples/generated/test/react-dom/interactivity/AccessibilityTest.js
@@ -20,6 +20,19 @@ export default class AccessibilityTest extends React.Component {
     }
   }
 
+  focusLast = ({ focusRing = true } = { focusRing: true }) => {
+    this.setFocusRing(focusRing)
+
+    let focusElements = this._getFocusElements()
+    if
+    (
+    focusElements[focusElements.length - 1] &&
+    focusElements[focusElements.length - 1].focus
+    ) {
+      focusElements[focusElements.length - 1].focus()
+    }
+  }
+
   focusNext = ({ focusRing = true } = { focusRing: true }) => {
     this.setFocusRing(focusRing)
 
@@ -63,9 +76,15 @@ export default class AccessibilityTest extends React.Component {
     }
   }
 
-  _getFocusElements = () => (
-    [this._CheckboxRow, this._Element, this._AccessibleText, this._Image]
-  )
+  _getFocusElements = () => {
+    let elements = [
+      this._CheckboxRow,
+      this._Element,
+      this._AccessibleText,
+      this._Image
+    ]
+    return elements.filter(Boolean);
+  }
 
   render() {
 

--- a/examples/generated/test/react-dom/interactivity/AccessibilityVisibility.js
+++ b/examples/generated/test/react-dom/interactivity/AccessibilityVisibility.js
@@ -23,10 +23,9 @@ export default class AccessibilityVisibility extends React.Component {
     this.setFocusRing(focusRing)
 
     let focusElements = this._getFocusElements()
-    if
-    (
-    focusElements[focusElements.length - 1] &&
-    focusElements[focusElements.length - 1].focus
+    if (
+      focusElements[focusElements.length - 1] &&
+      focusElements[focusElements.length - 1].focus
     ) {
       focusElements[focusElements.length - 1].focus()
     }

--- a/examples/generated/test/react-dom/interactivity/AccessibilityVisibility.js
+++ b/examples/generated/test/react-dom/interactivity/AccessibilityVisibility.js
@@ -1,0 +1,144 @@
+import React from "react"
+import styled from "styled-components"
+
+import colors from "../colors"
+import shadows from "../shadows"
+import textStyles from "../textStyles"
+
+export default class AccessibilityVisibility extends React.Component {
+  state = { focusRing: false }
+
+  setFocusRing = (focusRing) => { this.setState({ focusRing }) }
+
+  focus = ({ focusRing = true } = { focusRing: true }) => {
+    this.setFocusRing(focusRing)
+
+    let focusElements = this._getFocusElements()
+    if (focusElements[0] && focusElements[0].focus) {
+      focusElements[0].focus()
+    }
+  }
+
+  focusLast = ({ focusRing = true } = { focusRing: true }) => {
+    this.setFocusRing(focusRing)
+
+    let focusElements = this._getFocusElements()
+    if
+    (
+    focusElements[focusElements.length - 1] &&
+    focusElements[focusElements.length - 1].focus
+    ) {
+      focusElements[focusElements.length - 1].focus()
+    }
+  }
+
+  focusNext = ({ focusRing = true } = { focusRing: true }) => {
+    this.setFocusRing(focusRing)
+
+    let focusElements = this._getFocusElements()
+    let nextIndex = focusElements.indexOf(document.activeElement) + 1
+
+    if (nextIndex >= focusElements.length) {
+      this.props.onFocusNext && this.props.onFocusNext()
+      return ;
+    }
+
+    focusElements[nextIndex].focus && focusElements[nextIndex].focus()
+  }
+
+  focusPrevious = ({ focusRing = true } = { focusRing: true }) => {
+    this.setFocusRing(focusRing)
+
+    let focusElements = this._getFocusElements()
+    let previousIndex = focusElements.indexOf(document.activeElement) - 1
+
+    if (previousIndex < 0) {
+      this.props.onFocusPrevious && this.props.onFocusPrevious()
+      return ;
+    }
+
+    focusElements[previousIndex].focus && focusElements[previousIndex].focus()
+  }
+
+  _handleKeyDown = (event) => {
+    if (event.key === "Tab") {
+      this.setFocusRing(true)
+
+      if (event.shiftKey) {
+        this.focusPrevious()
+      } else {
+        this.focusNext()
+      }
+
+      event.stopPropagation()
+      event.preventDefault()
+    }
+  }
+
+  _getFocusElements = () => {
+    let elements = [this._GreyBox, this._Text]
+    return elements.filter(Boolean);
+  }
+
+  render() {
+
+
+    let Text$visible
+
+    Text$visible = this.props.showText
+    return (
+      <View>
+        <GreyBox
+          aria-label={"Grey box"}
+          tabIndex={-1}
+          focusRing={this.state.focusRing}
+          onKeyDown={this._handleKeyDown}
+          ref={(ref) => { this._GreyBox = ref }}
+
+        />
+        {
+          Text$visible &&
+          <Text
+            aria-label={"Some text that is sometimes hidden"}
+            tabIndex={-1}
+            focusRing={this.state.focusRing}
+            onKeyDown={this._handleKeyDown}
+            ref={(ref) => { this._Text = ref }}
+          >
+            {"Sometimes hidden"}
+          </Text>
+        }
+      </View>
+    );
+  }
+};
+
+let View = styled.div({
+  alignItems: "flex-start",
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let GreyBox = styled.div((props) => ({
+  alignItems: "flex-start",
+  backgroundColor: "#D8D8D8",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  width: "100px",
+  height: "40px",
+  ...!props.focusRing && { ":focus": { outline: 0 } }
+}))
+
+let Text = styled.span((props) => ({
+  textAlign: "left",
+  ...textStyles.body1,
+  alignItems: "flex-start",
+  display: "block",
+  flex: "0 0 auto",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  ...!props.focusRing && { ":focus": { outline: 0 } }
+}))

--- a/examples/generated/test/react-native/interactivity/AccessibilityVisibility.js
+++ b/examples/generated/test/react-native/interactivity/AccessibilityVisibility.js
@@ -1,0 +1,61 @@
+import React from "react"
+import { Text, View, StyleSheet } from "react-native"
+
+import colors from "../colors"
+import shadows from "../shadows"
+import textStyles from "../textStyles"
+
+export default class AccessibilityVisibility extends React.Component {
+  render() {
+
+
+    let Text$visible
+
+    Text$visible = this.props.showText
+    return (
+      <View style={styles.view}>
+        <View
+          style={styles.greyBox}
+          accessibilityLabel={"Grey box"}
+          accessible={true}
+
+        />
+        {
+          Text$visible &&
+          <Text
+            style={styles.text}
+            accessibilityLabel={"Some text that is sometimes hidden"}
+            accessible={true}
+          >
+            {"Sometimes hidden"}
+          </Text>
+        }
+      </View>
+    );
+  }
+};
+
+let styles = StyleSheet.create({
+  view: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  greyBox: {
+    alignItems: "flex-start",
+    backgroundColor: "#D8D8D8",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: 100,
+    height: 40
+  },
+  text: {
+    ...textStyles.body1,
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  }
+})

--- a/examples/generated/test/sketchJs/interactivity/AccessibilityVisibility.js
+++ b/examples/generated/test/sketchJs/interactivity/AccessibilityVisibility.js
@@ -1,0 +1,53 @@
+import React from "react"
+import { Text, View, StyleSheet, TextStyles } from
+  "@mathieudutour/react-sketchapp"
+
+import colors from "../colors"
+import shadows from "../shadows"
+import textStyles from "../textStyles"
+
+export default class AccessibilityVisibility extends React.Component {
+  render() {
+
+
+    let Text$visible
+
+    Text$visible = this.props.showText
+    return (
+      <View style={styles.view}>
+        <View style={styles.greyBox} />
+        {
+          Text$visible &&
+          <Text style={styles.text}>
+            {"Sometimes hidden"}
+          </Text>
+        }
+      </View>
+    );
+  }
+};
+
+let styles = StyleSheet.create({
+  view: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  greyBox: {
+    alignItems: "flex-start",
+    backgroundColor: "#D8D8D8",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    width: 100,
+    height: 40
+  },
+  text: {
+    ...TextStyles.get("body1"),
+    alignItems: "flex-start",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  }
+})

--- a/examples/generated/test/swift/LonaCollectionView.swift
+++ b/examples/generated/test/swift/LonaCollectionView.swift
@@ -155,6 +155,7 @@ public class LonaCollectionView: UICollectionView,
     register(LocalAssetCell.self, forCellWithReuseIdentifier: LocalAssetCell.identifier)
     register(VectorAssetCell.self, forCellWithReuseIdentifier: VectorAssetCell.identifier)
     register(AccessibilityTestCell.self, forCellWithReuseIdentifier: AccessibilityTestCell.identifier)
+    register(AccessibilityVisibilityCell.self, forCellWithReuseIdentifier: AccessibilityVisibilityCell.identifier)
     register(ButtonCell.self, forCellWithReuseIdentifier: ButtonCell.identifier)
     register(PressableRootViewCell.self, forCellWithReuseIdentifier: PressableRootViewCell.identifier)
     register(FillWidthFitHeightCardCell.self, forCellWithReuseIdentifier: FillWidthFitHeightCardCell.identifier)
@@ -299,6 +300,11 @@ public class LonaCollectionView: UICollectionView,
       }
     case AccessibilityTestCell.identifier:
       if let cell = cell as? AccessibilityTestCell, let item = item as? AccessibilityTest.Model {
+        cell.parameters = item.parameters
+        cell.scrollDirection = scrollDirection
+      }
+    case AccessibilityVisibilityCell.identifier:
+      if let cell = cell as? AccessibilityVisibilityCell, let item = item as? AccessibilityVisibility.Model {
         cell.parameters = item.parameters
         cell.scrollDirection = scrollDirection
       }
@@ -713,6 +719,16 @@ public class AccessibilityTestCell: LonaCollectionViewCell<AccessibilityTest> {
   }
   public static var identifier: String {
     return "AccessibilityTest"
+  }
+}
+
+public class AccessibilityVisibilityCell: LonaCollectionViewCell<AccessibilityVisibility> {
+  public var parameters: AccessibilityVisibility.Parameters {
+    get { return view.parameters }
+    set { view.parameters = newValue }
+  }
+  public static var identifier: String {
+    return "AccessibilityVisibility"
   }
 }
 

--- a/examples/generated/test/swift/interactivity/AccessibilityVisibility.swift
+++ b/examples/generated/test/swift/interactivity/AccessibilityVisibility.swift
@@ -1,0 +1,201 @@
+import UIKit
+import Foundation
+
+// MARK: - AccessibilityVisibility
+
+public class AccessibilityVisibility: UIView {
+
+  // MARK: Lifecycle
+
+  public init(_ parameters: Parameters) {
+    self.parameters = parameters
+
+    super.init(frame: .zero)
+
+    setUpViews()
+    setUpConstraints()
+
+    update()
+  }
+
+  public convenience init(showText: Bool) {
+    self.init(Parameters(showText: showText))
+  }
+
+  public convenience init() {
+    self.init(Parameters())
+  }
+
+  public required init?(coder aDecoder: NSCoder) {
+    self.parameters = Parameters()
+
+    super.init(coder: aDecoder)
+
+    setUpViews()
+    setUpConstraints()
+
+    update()
+  }
+
+  // MARK: Public
+
+  public var showText: Bool {
+    get { return parameters.showText }
+    set {
+      if parameters.showText != newValue {
+        parameters.showText = newValue
+      }
+    }
+  }
+
+  public var parameters: Parameters {
+    didSet {
+      if parameters != oldValue {
+        update()
+      }
+    }
+  }
+
+  // MARK: Private
+
+  private var greyBoxView = UIView(frame: .zero)
+  private var textView = UILabel()
+
+  private var textViewTextStyle = TextStyles.body1
+
+  private var greyBoxViewBottomAnchorBottomAnchorConstraint: NSLayoutConstraint?
+  private var textViewBottomAnchorBottomAnchorConstraint: NSLayoutConstraint?
+  private var textViewTopAnchorGreyBoxViewBottomAnchorConstraint: NSLayoutConstraint?
+  private var textViewLeadingAnchorLeadingAnchorConstraint: NSLayoutConstraint?
+  private var textViewTrailingAnchorTrailingAnchorConstraint: NSLayoutConstraint?
+
+  private func setUpViews() {
+    textView.isUserInteractionEnabled = false
+    textView.numberOfLines = 0
+
+    addSubview(greyBoxView)
+    addSubview(textView)
+
+    isAccessibilityElement = false
+    accessibilityElements = [greyBoxView, textView]
+    greyBoxView.backgroundColor = #colorLiteral(red: 0.847058823529, green: 0.847058823529, blue: 0.847058823529, alpha: 1)
+    greyBoxView.isAccessibilityElement = true
+    greyBoxView.accessibilityLabel = "Grey box"
+    textView.attributedText = textViewTextStyle.apply(to: "Sometimes hidden")
+    textView.isAccessibilityElement = true
+    textView.accessibilityLabel = "Some text that is sometimes hidden"
+  }
+
+  private func setUpConstraints() {
+    translatesAutoresizingMaskIntoConstraints = false
+    greyBoxView.translatesAutoresizingMaskIntoConstraints = false
+    textView.translatesAutoresizingMaskIntoConstraints = false
+
+    let greyBoxViewTopAnchorConstraint = greyBoxView.topAnchor.constraint(equalTo: topAnchor)
+    let greyBoxViewLeadingAnchorConstraint = greyBoxView.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let greyBoxViewHeightAnchorConstraint = greyBoxView.heightAnchor.constraint(equalToConstant: 40)
+    let greyBoxViewWidthAnchorConstraint = greyBoxView.widthAnchor.constraint(equalToConstant: 100)
+    let greyBoxViewBottomAnchorBottomAnchorConstraint = greyBoxView.bottomAnchor.constraint(equalTo: bottomAnchor)
+    let textViewBottomAnchorBottomAnchorConstraint = textView.bottomAnchor.constraint(equalTo: bottomAnchor)
+    let textViewTopAnchorGreyBoxViewBottomAnchorConstraint = textView
+      .topAnchor
+      .constraint(equalTo: greyBoxView.bottomAnchor)
+    let textViewLeadingAnchorLeadingAnchorConstraint = textView.leadingAnchor.constraint(equalTo: leadingAnchor)
+    let textViewTrailingAnchorTrailingAnchorConstraint = textView
+      .trailingAnchor
+      .constraint(lessThanOrEqualTo: trailingAnchor)
+
+    self.greyBoxViewBottomAnchorBottomAnchorConstraint = greyBoxViewBottomAnchorBottomAnchorConstraint
+    self.textViewBottomAnchorBottomAnchorConstraint = textViewBottomAnchorBottomAnchorConstraint
+    self.textViewTopAnchorGreyBoxViewBottomAnchorConstraint = textViewTopAnchorGreyBoxViewBottomAnchorConstraint
+    self.textViewLeadingAnchorLeadingAnchorConstraint = textViewLeadingAnchorLeadingAnchorConstraint
+    self.textViewTrailingAnchorTrailingAnchorConstraint = textViewTrailingAnchorTrailingAnchorConstraint
+
+    NSLayoutConstraint.activate(
+      [
+        greyBoxViewTopAnchorConstraint,
+        greyBoxViewLeadingAnchorConstraint,
+        greyBoxViewHeightAnchorConstraint,
+        greyBoxViewWidthAnchorConstraint
+      ] +
+        conditionalConstraints(textViewIsHidden: textView.isHidden))
+  }
+
+  private func conditionalConstraints(textViewIsHidden: Bool) -> [NSLayoutConstraint] {
+    var constraints: [NSLayoutConstraint?]
+
+    switch (textViewIsHidden) {
+      case (true):
+        constraints = [greyBoxViewBottomAnchorBottomAnchorConstraint]
+      case (false):
+        constraints = [
+          textViewBottomAnchorBottomAnchorConstraint,
+          textViewTopAnchorGreyBoxViewBottomAnchorConstraint,
+          textViewLeadingAnchorLeadingAnchorConstraint,
+          textViewTrailingAnchorTrailingAnchorConstraint
+        ]
+    }
+
+    return constraints.compactMap({ $0 })
+  }
+
+  private func update() {
+    let textViewIsHidden = textView.isHidden
+
+    textView.isHidden = !showText
+
+    if textView.isHidden != textViewIsHidden {
+      NSLayoutConstraint.deactivate(conditionalConstraints(textViewIsHidden: textViewIsHidden))
+      NSLayoutConstraint.activate(conditionalConstraints(textViewIsHidden: textView.isHidden))
+    }
+  }
+}
+
+// MARK: - Parameters
+
+extension AccessibilityVisibility {
+  public struct Parameters: Equatable {
+    public var showText: Bool
+
+    public init(showText: Bool) {
+      self.showText = showText
+    }
+
+    public init() {
+      self.init(showText: false)
+    }
+
+    public static func ==(lhs: Parameters, rhs: Parameters) -> Bool {
+      return lhs.showText == rhs.showText
+    }
+  }
+}
+
+// MARK: - Model
+
+extension AccessibilityVisibility {
+  public struct Model: LonaViewModel, Equatable {
+    public var id: String?
+    public var parameters: Parameters
+    public var type: String {
+      return "AccessibilityVisibility"
+    }
+
+    public init(id: String? = nil, parameters: Parameters) {
+      self.id = id
+      self.parameters = parameters
+    }
+
+    public init(_ parameters: Parameters) {
+      self.parameters = parameters
+    }
+
+    public init(showText: Bool) {
+      self.init(Parameters(showText: showText))
+    }
+
+    public init() {
+      self.init(showText: false)
+    }
+  }
+}

--- a/examples/test/interactivity/AccessibilityVisibility.component
+++ b/examples/test/interactivity/AccessibilityVisibility.component
@@ -1,0 +1,83 @@
+{
+  "devices" : [
+    {
+      "deviceId" : "iPhone SE",
+      "heightMode" : "At Least"
+    },
+    {
+      "deviceId" : "Pixel 2",
+      "heightMode" : "At Least"
+    }
+  ],
+  "examples" : [
+    {
+      "id" : "Default",
+      "name" : "Default",
+      "params" : {
+
+      }
+    },
+    {
+      "id" : "name",
+      "name" : "name",
+      "params" : {
+        "showText" : true
+      }
+    }
+  ],
+  "logic" : [
+    {
+      "assignee" : [
+        "layers",
+        "Text",
+        "visible"
+      ],
+      "content" : [
+        "parameters",
+        "showText"
+      ],
+      "type" : "AssignExpr"
+    }
+  ],
+  "params" : [
+    {
+      "name" : "showText",
+      "type" : "Boolean"
+    }
+  ],
+  "root" : {
+    "children" : [
+      {
+        "id" : "GreyBox",
+        "params" : {
+          "accessibilityLabel" : "Grey box",
+          "accessibilityType" : "element",
+          "backgroundColor" : "#D8D8D8",
+          "height" : 40,
+          "width" : 100
+        },
+        "type" : "Lona:View"
+      },
+      {
+        "id" : "Text",
+        "params" : {
+          "accessibilityLabel" : "Some text that is sometimes hidden",
+          "accessibilityType" : "element",
+          "text" : "Sometimes hidden",
+          "visible" : false
+        },
+        "type" : "Lona:Text"
+      }
+    ],
+    "id" : "View",
+    "params" : {
+      "accessibilityElements" : [
+        "GreyBox",
+        "Text"
+      ],
+      "accessibilityType" : "container",
+      "alignSelf" : "stretch"
+    },
+    "type" : "Lona:View"
+  }
+}

--- a/studio/docs/accessibility.md
+++ b/studio/docs/accessibility.md
@@ -177,6 +177,8 @@ To focus a component, you'll need to store a React `ref` to that component. Comp
 
 - **`focus(options)`** - Call this method to focus the first focusable DOM node in the component.
 
+- **`focusLast(options)`** - Call this method to focus the last focusable DOM node in the component.
+
 - **`focusNext(options)`** - Call this method to focus the next focusable DOM node in the component. If focus is not currently on a DOM node within this component, then the first focusable node is focused. If focus is on the last node within this component, focus is not changed, and instead the `onFocusNext` prop is called.
 
 - **`focusPrevious(options)`** - Call this method to focus the previous focusable DOM node in the component. If focus is on the first node within this component, focus is not changed, and instead the `onFocusPrevious` prop is called.


### PR DESCRIPTION
## What

This addresses two cases:
- Elements that are not currently rendered are now filtered out of the keyboard navigation order
- Adds a `focusLast` method to handle keyboard navigation backwards, i.e. Shift-Tabbing to a component

cc @outdooricon 
