### PR TITLE
Handle moving a11y focus between components

### DIFF
--- a/compiler/core/src/core/layer.re
+++ b/compiler/core/src/core/layer.re
@@ -569,9 +569,9 @@ let getTypeNames = rootLayer => {
    determine layout. We should still use the type, name, and children of
    the custom component layer. */
 let getProxyLayerForComponentName =
-    (getComponent: string => Js.Json.t, layer: Types.layer, name): Types.layer => {
-  let component = getComponent(name);
-  let rootLayer = component |> Decode.Component.rootLayer(getComponent);
+    (config: Config.t, layer: Types.layer, name): Types.layer => {
+  let component = Config.Find.component(config, name);
+  let rootLayer = component |> Decode.Component.rootLayer(config);
   {
     typeName: layer.typeName,
     styles: layer.styles,
@@ -586,9 +586,9 @@ let getProxyLayerForComponentName =
    This is how we layout custom components.
    TODO: When we handle "Children" components, we'll need to find/use
    a different proxy */
-let getProxyLayer = (getComponent: string => Js.Json.t, layer: Types.layer) =>
+let getProxyLayer = (config: Config.t, layer: Types.layer) =>
   switch (layer.typeName) {
   | Types.Component(name) =>
-    getProxyLayerForComponentName(getComponent, layer, name)
+    getProxyLayerForComponentName(config, layer, name)
   | _ => layer
   };

--- a/compiler/core/src/decode/decode.re
+++ b/compiler/core/src/decode/decode.re
@@ -142,7 +142,7 @@ module Layer = {
     | "Lona:Children" => Children
     | value => Component(value)
     };
-  let rec layer = (getComponent, json) => {
+  let rec layer = (config: Config.t, json) => {
     let typeName = field("type", layerType, json);
     let parameterDictionary = json =>
       json
@@ -159,7 +159,7 @@ module Layer = {
            switch (typeName) {
            | Component(name) =>
              let param =
-               getComponent(name)
+               Config.Find.component(config, name)
                |> field("params", list(Parameters.parameter))
                |> List.find((param: parameter) => param.name == key);
              switch (param) {
@@ -188,9 +188,7 @@ module Layer = {
         },
       parameters: field("params", parameterDictionary, json),
       children:
-        switch (
-          json |> optional(field("children", list(layer(getComponent))))
-        ) {
+        switch (json |> optional(field("children", list(layer(config))))) {
         | Some(result) => result
         | None => []
         | exception e =>
@@ -346,10 +344,9 @@ let rec logicNode = json => {
 };
 
 module Component = {
-  open Json.Decode;
   let parameters = json => field("params", list(Parameters.parameter), json);
-  let rootLayer = (getComponent, json) =>
-    field("root", Layer.layer(getComponent), json);
+  let rootLayer = (config: Config.t, json) =>
+    field("root", Layer.layer(config), json);
   let logic = json => Logic.Block(field("logic", list(logicNode), json));
 };
 

--- a/compiler/core/src/javaScript/javaScriptComponent.re
+++ b/compiler/core/src/javaScript/javaScriptComponent.re
@@ -932,7 +932,7 @@ let rootLayerToJavaScriptAST =
 };
 
 let defineInitialLogicValues =
-    (config: Config.t, getComponent, rootLayer, assignments, logic) => {
+    (config: Config.t, rootLayer, assignments, logic) => {
   let variableDeclarations = logic |> Logic.buildVariableDeclarations;
   let conditionalAssignments = Logic.conditionallyAssignedIdentifiers(logic);
   let isConditionallyAssigned = (layer: Types.layer, (name, _)) => {
@@ -956,7 +956,7 @@ let defineInitialLogicValues =
       | (Some(assignment), _, _) => assignment
       | (None, Component(componentName), _) =>
         let param =
-          getComponent(componentName)
+          Config.Find.component(config, componentName)
           |> Decode.Component.parameters
           |> List.find((param: Types.parameter) => param.name == name);
         Logic.assignmentForLayerParameter(
@@ -1023,12 +1023,11 @@ let generate =
       textStylesFilePath,
       config: Config.t,
       outputFile,
-      getComponent,
       getComponentFile,
       getAssetPath,
       json,
     ) => {
-  let rootLayer = json |> Decode.Component.rootLayer(getComponent);
+  let rootLayer = json |> Decode.Component.rootLayer(config);
   let logic = json |> Decode.Component.logic;
   let parameters = json |> Decode.Component.parameters;
   let assignments = Layer.parameterAssignmentsFromLogic(rootLayer, logic);
@@ -1066,7 +1065,7 @@ let generate =
 
   let logicAST =
     logic
-    |> defineInitialLogicValues(config, getComponent, rootLayer, assignments)
+    |> defineInitialLogicValues(config, rootLayer, assignments)
     |> JavaScriptLogic.toJavaScriptAST(options.framework, config)
     |> Ast.optimize;
 

--- a/compiler/core/src/javaScript/javaScriptComponent.re
+++ b/compiler/core/src/javaScript/javaScriptComponent.re
@@ -159,7 +159,7 @@ module StyledComponents = {
         rootLayer: Types.layer,
         layer: Types.layer,
       ) => {
-    let usesProps = JavaScriptLayer.canBeFocused(layer);
+    let usesProps = JavaScriptLayer.canBeFocused(config, layer);
     let styles =
       JavaScriptStyles.Object.forLayer(
         config,
@@ -571,7 +571,7 @@ let rec layerToJavaScriptAST =
   let styleVariables = JavaScriptLayer.getStyleVariables(assignments, layer);
   let propVariables = JavaScriptLayer.getPropVariables(assignments, layer);
   let needsRef = JavaScriptLayer.needsRef(config, layer);
-  let canBeFocused = JavaScriptLayer.canBeFocused(layer);
+  let canBeFocused = JavaScriptLayer.canBeFocused(config, layer);
 
   let main = ParameterMap.assign(initialProps, propVariables);
   let attributes =
@@ -1138,7 +1138,10 @@ let generate =
                 body:
                   (
                     options.framework == ReactDOM
-                    && JavaScriptLayer.Hierarchy.needsFocusHandling(rootLayer) ?
+                    && JavaScriptLayer.Hierarchy.needsFocusHandling(
+                         config,
+                         rootLayer,
+                       ) ?
                       [
                         AssignmentExpression({
                           left: Identifier(["state"]),

--- a/compiler/core/src/javaScript/javaScriptFocus.re
+++ b/compiler/core/src/javaScript/javaScriptFocus.re
@@ -71,6 +71,45 @@ module Methods = {
         }),
     });
 
+  let isFocused = (): JavaScriptAst.node =>
+    AssignmentExpression({
+      left: Identifier(["isFocused"]),
+      right:
+        ArrowFunctionExpression({
+          id: None,
+          params: [],
+          body: [
+            VariableDeclaration(
+              AssignmentExpression({
+                left: Identifier(["focusElements"]),
+                right:
+                  CallExpression({
+                    callee: Identifier(["this", "_getFocusElements"]),
+                    arguments: [],
+                  }),
+              }),
+            ),
+            Empty,
+            Return(
+              UnaryExpression({
+                prefix: true,
+                operator: "!",
+                argument:
+                  UnaryExpression({
+                    prefix: true,
+                    operator: "!",
+                    argument:
+                      CallExpression({
+                        callee: Identifier(["focusElements", "find"]),
+                        arguments: [Identifier(["isFocused"])],
+                      }),
+                  }),
+              }),
+            ),
+          ],
+        }),
+    });
+
   let focus = (): JavaScriptAst.node =>
     AssignmentExpression({
       left: Identifier(["focus"]),
@@ -194,10 +233,8 @@ module Methods = {
                   BinaryExpression({
                     left:
                       CallExpression({
-                        callee: Identifier(["focusElements", "indexOf"]),
-                        arguments: [
-                          Identifier(["document", "activeElement"]),
-                        ],
+                        callee: Identifier(["focusElements", "findIndex"]),
+                        arguments: [Identifier(["isFocused"])],
                       }),
                     operator: Plus,
                     right: Literal(LonaValue.number(1.)),
@@ -270,10 +307,8 @@ module Methods = {
                   BinaryExpression({
                     left:
                       CallExpression({
-                        callee: Identifier(["focusElements", "indexOf"]),
-                        arguments: [
-                          Identifier(["document", "activeElement"]),
-                        ],
+                        callee: Identifier(["focusElements", "findIndex"]),
+                        arguments: [Identifier(["isFocused"])],
                       }),
                     operator: Minus,
                     right: Literal(LonaValue.number(1.)),
@@ -304,15 +339,27 @@ module Methods = {
               alternate: [],
             }),
             Empty,
-            BinaryExpression({
-              left: Identifier(["focusElements[previousIndex]", "focus"]),
-              operator: And,
-              right:
+            IfStatement({
+              test: Identifier(["focusElements[previousIndex]", "focusLast"]),
+              consequent: [
                 CallExpression({
                   callee:
-                    Identifier(["focusElements[previousIndex]", "focus"]),
+                    Identifier(["focusElements[previousIndex]", "focusLast"]),
                   arguments: [],
                 }),
+              ],
+              alternate: [
+                BinaryExpression({
+                  left: Identifier(["focusElements[previousIndex]", "focus"]),
+                  operator: And,
+                  right:
+                    CallExpression({
+                      callee:
+                        Identifier(["focusElements[previousIndex]", "focus"]),
+                      arguments: [],
+                    }),
+                }),
+              ],
             }),
           ],
         }),
@@ -382,6 +429,7 @@ let initialStateProperties = (): list(JavaScriptAst.node) => [
 let focusMethods = (rootLayer: Types.layer): list(JavaScriptAst.node) =>
   Methods.[
     setFocusRing(),
+    isFocused(),
     focus(),
     focusLast(),
     focusNext(),

--- a/compiler/core/src/javaScript/javaScriptFocus.re
+++ b/compiler/core/src/javaScript/javaScriptFocus.re
@@ -175,29 +175,43 @@ module Methods = {
                   }),
               }),
             ),
+            VariableDeclaration(
+              AssignmentExpression({
+                left: Identifier(["lastElement"]),
+                right:
+                  Identifier(["focusElements[focusElements.length - 1]"]),
+              }),
+            ),
             IfStatement({
               test:
                 BinaryExpression({
-                  left:
-                    Identifier(["focusElements[focusElements.length - 1]"]),
+                  left: Identifier(["lastElement"]),
                   operator: And,
-                  right:
-                    Identifier([
-                      "focusElements[focusElements.length - 1]",
-                      "focus",
-                    ]),
+                  right: Identifier(["lastElement", "focusLast"]),
                 }),
               consequent: [
                 CallExpression({
-                  callee:
-                    Identifier([
-                      "focusElements[focusElements.length - 1]",
-                      "focus",
-                    ]),
+                  callee: Identifier(["lastElement", "focusLast"]),
                   arguments: [],
                 }),
               ],
-              alternate: [],
+              alternate: [
+                IfStatement({
+                  test:
+                    BinaryExpression({
+                      left: Identifier(["lastElement"]),
+                      operator: And,
+                      right: Identifier(["lastElement", "focus"]),
+                    }),
+                  consequent: [
+                    CallExpression({
+                      callee: Identifier(["lastElement", "focus"]),
+                      arguments: [],
+                    }),
+                  ],
+                  alternate: [],
+                }),
+              ],
             }),
           ],
         }),

--- a/compiler/core/src/javaScript/javaScriptLayer.re
+++ b/compiler/core/src/javaScript/javaScriptLayer.re
@@ -62,7 +62,12 @@ module Hierarchy = {
           elements
           |> List.map(name => Layer.findByName(name, layer))
           |> Sequence.compact
-          |> List.map(inner([]))
+          |> List.map((layer: Types.layer) =>
+               switch (layer.typeName) {
+               | Component(_) => [layer]
+               | _ => inner([], layer)
+               }
+             )
           |> List.concat
         }
       );

--- a/compiler/core/src/javaScript/javaScriptLayer.re
+++ b/compiler/core/src/javaScript/javaScriptLayer.re
@@ -1,10 +1,10 @@
 let rec canBeFocused = (config: Config.t, layer: Types.layer): bool =>
   switch (layer.typeName) {
   | Component(componentName) =>
-    let getComponent = Config.Find.component(config);
-    let component = Config.Find.component(config, componentName);
-    let rootLayer = component |> Decode.Component.rootLayer(getComponent);
-    rootLayer |> Layer.flatten |> List.exists(canBeFocused(config));
+    Config.Find.component(config, componentName)
+    |> Decode.Component.rootLayer(config)
+    |> Layer.flatten
+    |> List.exists(canBeFocused(config))
   | _ =>
     switch (Layer.accessibilityType(layer)) {
     | Element(_) => true

--- a/compiler/core/src/javaScript/javaScriptRender.re
+++ b/compiler/core/src/javaScript/javaScriptRender.re
@@ -73,6 +73,7 @@ let rec render = ast: Prettier.Doc.t('a) =>
 
     switch (o.alternate) {
     | [] => ifPart
+    | [IfStatement(_) as node] => ifPart <+> s(" else ") <+> render(node)
     | _ => ifPart <+> s(" else ") <+> renderBlockBody(o.alternate, true)
     };
   | ImportDefaultSpecifier(o) => s(o)

--- a/compiler/core/src/javaScript/javaScriptStyles.re
+++ b/compiler/core/src/javaScript/javaScriptStyles.re
@@ -116,7 +116,7 @@ module Property = {
 
 let focusStyles =
     (config: Config.t, layer: Types.layer): option(JavaScriptAst.node) => {
-  let canBeFocused = JavaScriptLayer.canBeFocused(layer);
+  let canBeFocused = JavaScriptLayer.canBeFocused(config, layer);
 
   if (canBeFocused && config.options.javaScript.framework == ReactDOM) {
     Some(

--- a/compiler/core/src/main.re
+++ b/compiler/core/src/main.re
@@ -250,7 +250,6 @@ let convertComponent =
       ),
       config,
       outputFile,
-      findComponent(config.workspacePath),
       getComponentRelativePath(config.workspacePath, name),
       getAssetRelativePath(config.workspacePath, name),
       parsed,
@@ -258,14 +257,7 @@ let convertComponent =
     |> JavaScript.Render.toString
   | Swift =>
     let result =
-      Swift.Component.generate(
-        config,
-        options,
-        swiftOptions,
-        name,
-        findComponent(config.workspacePath),
-        parsed,
-      );
+      Swift.Component.generate(config, options, swiftOptions, name, parsed);
     result |> Swift.Render.toString;
   | _ => exit("Unrecognized target")
   };
@@ -501,7 +493,6 @@ let convertWorkspace = (workspace, output) => {
              config,
              options,
              swiftOptions,
-             findComponent(config.workspacePath),
              successfulComponentNames,
            ),
            `utf8,

--- a/compiler/core/src/static/javaScript/focusUtils.js
+++ b/compiler/core/src/static/javaScript/focusUtils.js
@@ -1,0 +1,7 @@
+export const isFocused = componentOrDomNode => {
+  if (componentOrDomNode.isReactComponent) {
+    return componentOrDomNode.isFocused();
+  }
+
+  return componentOrDomNode === document.activeElement;
+};

--- a/compiler/core/src/swift/swiftComponent.re
+++ b/compiler/core/src/swift/swiftComponent.re
@@ -460,7 +460,6 @@ module Doc = {
       (
         swiftOptions: SwiftOptions.options,
         config: Config.t,
-        getComponent,
         componentParameters,
         assignmentsFromLayerParameters,
         rootLayer: Types.layer,
@@ -479,7 +478,7 @@ module Doc = {
         | (Some(assignment), _, _) => assignment
         | (None, Component(componentName), _) =>
           let param =
-            getComponent(componentName)
+            Config.Find.component(config, componentName)
             |> Decode.Component.parameters
             |> List.find((param: Types.parameter) => param.name == name);
           Logic.assignmentForLayerParameter(
@@ -508,7 +507,6 @@ module Doc = {
       (
         swiftOptions: SwiftOptions.options,
         config: Config.t,
-        getComponent,
         componentParameters,
         logic,
         assignmentsFromLayerParameters,
@@ -555,7 +553,6 @@ module Doc = {
              defineInitialLayerValue(
                swiftOptions,
                config,
-               getComponent,
                componentParameters,
                assignmentsFromLayerParameters,
                rootLayer,
@@ -826,7 +823,6 @@ module Doc = {
       (
         swiftOptions: SwiftOptions.options,
         config: Config.t,
-        getComponent,
         componentParameters,
         assignmentsFromLayerParameters,
         assignmentsFromLogic,
@@ -853,7 +849,6 @@ module Doc = {
            defineInitialLayerValue(
              swiftOptions,
              config,
-             getComponent,
              componentParameters,
              assignmentsFromLayerParameters,
              rootLayer,
@@ -1328,12 +1323,11 @@ let generate =
       options: Options.options,
       swiftOptions: SwiftOptions.options,
       name,
-      getComponent,
       json,
     ) => {
   open SwiftAst;
 
-  let rootLayer = json |> Decode.Component.rootLayer(getComponent);
+  let rootLayer = json |> Decode.Component.rootLayer(config);
   let nonRootLayers = rootLayer |> Layer.flatten |> List.tl;
   let logic = json |> Decode.Component.logic;
 
@@ -1353,7 +1347,7 @@ let generate =
 
   let visibilityCombinations =
     Constraint.visibilityCombinations(
-      getComponent,
+      config,
       assignmentsFromLogic,
       rootLayer,
     );
@@ -1585,7 +1579,6 @@ let generate =
                       Doc.setUpViews(
                         swiftOptions,
                         config,
-                        getComponent,
                         parameters,
                         logic,
                         assignmentsFromLayerParameters,
@@ -1597,7 +1590,6 @@ let generate =
                       SwiftConstraint.setUpFunction(
                         swiftOptions,
                         config,
-                        getComponent,
                         assignmentsFromLogic,
                         layerMemberExpression,
                         rootLayer,
@@ -1606,7 +1598,7 @@ let generate =
                     List.length(conditionalConstraints) > 0 ?
                       [
                         SwiftConstraint.conditionalConstraintsFunction(
-                          getComponent,
+                          config,
                           assignmentsFromLogic,
                           rootLayer,
                         ),
@@ -1616,7 +1608,6 @@ let generate =
                       Doc.update(
                         swiftOptions,
                         config,
-                        getComponent,
                         parameters,
                         assignmentsFromLayerParameters,
                         assignmentsFromLogic,

--- a/compiler/core/src/swift/swiftConstraint.re
+++ b/compiler/core/src/swift/swiftConstraint.re
@@ -294,7 +294,6 @@ let setUpFunction =
     (
       swiftOptions: SwiftOptions.options,
       config: Config.t,
-      getComponent,
       assignmentsFromLogic,
       layerMemberExpression,
       rootLayer: Types.layer,
@@ -303,7 +302,7 @@ let setUpFunction =
 
   let combinations =
     Constraint.visibilityCombinations(
-      getComponent,
+      config,
       assignmentsFromLogic,
       rootLayer,
     );

--- a/compiler/core/src/utils/constraint.re
+++ b/compiler/core/src/utils/constraint.re
@@ -169,13 +169,12 @@ let semanticEqual = (a: t, b: t): bool =>
   | _ => strictEqual(a, b)
   };
 
-let getConstraints =
-    (getComponent: string => Js.Json.t, rootLayer: Types.layer) => {
+let getConstraints = (config: Config.t, rootLayer: Types.layer) => {
   let constrainAxes = (originalLayer: Types.layer) => {
     let isComponentLayer = Layer.isComponentLayer(originalLayer);
-    let layer = Layer.getProxyLayer(getComponent, originalLayer);
+    let layer = Layer.getProxyLayer(config, originalLayer);
     let children =
-      originalLayer.children |> List.map(Layer.getProxyLayer(getComponent));
+      originalLayer.children |> List.map(Layer.getProxyLayer(config));
 
     let direction = Layer.getFlexDirection(layer.parameters);
     let isColumn = direction == "column";
@@ -201,7 +200,7 @@ let getConstraints =
     let fillChildren =
       children
       |> List.filter((child: Types.layer) => {
-           let proxyChild = Layer.getProxyLayer(getComponent, child);
+           let proxyChild = Layer.getProxyLayer(config, child);
            let childSizingRules =
              proxyChild.parameters
              |> Layer.getSizingRules(
@@ -462,7 +461,7 @@ let visibilityLayers =
      );
 
 let visibilityCombinations =
-    (getComponent, assignmentsFromLogic, rootLayer: Types.layer)
+    (config: Config.t, assignmentsFromLogic, rootLayer: Types.layer)
     : list(visibilityCombination) => {
   let layers = visibilityLayers(assignmentsFromLogic, rootLayer);
 
@@ -477,7 +476,7 @@ let visibilityCombinations =
        {
          rootLayer,
          visibleLayers,
-         constraints: getConstraints(getComponent, rootLayer),
+         constraints: getConstraints(config, rootLayer),
        };
      });
 };

--- a/examples/LonaViewer/LonaViewer.xcodeproj/project.pbxproj
+++ b/examples/LonaViewer/LonaViewer.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		6B39170821643EF300B20F9E /* ShadowsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B39170721643EF300B20F9E /* ShadowsTest.swift */; };
 		6B39170A2164492600B20F9E /* Shadow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3917092164492600B20F9E /* Shadow.swift */; };
 		6B61E06F21FA7E8F0057E8DF /* AccessibilityVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B61E06E21FA7E8F0057E8DF /* AccessibilityVisibility.swift */; };
+		6B61E07321FCE4830057E8DF /* AccessibilityNested.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B61E07221FCE4830057E8DF /* AccessibilityNested.swift */; };
 		6B6D4423218BCF150016262C /* LNATextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6D4422218BCF150016262C /* LNATextField.swift */; };
 		6B6D4425218E31EF0016262C /* ImageCropping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6D4424218E31EF0016262C /* ImageCropping.swift */; };
 		6B6D4429218F565C0016262C /* CGSize+Resizing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6D4428218F565C0016262C /* CGSize+Resizing.swift */; };
@@ -183,6 +184,7 @@
 		6B39170721643EF300B20F9E /* ShadowsTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShadowsTest.swift; sourceTree = "<group>"; };
 		6B3917092164492600B20F9E /* Shadow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Shadow.swift; sourceTree = "<group>"; };
 		6B61E06E21FA7E8F0057E8DF /* AccessibilityVisibility.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccessibilityVisibility.swift; sourceTree = "<group>"; };
+		6B61E07221FCE4830057E8DF /* AccessibilityNested.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccessibilityNested.swift; sourceTree = "<group>"; };
 		6B6D4422218BCF150016262C /* LNATextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LNATextField.swift; sourceTree = "<group>"; };
 		6B6D4424218E31EF0016262C /* ImageCropping.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageCropping.swift; sourceTree = "<group>"; };
 		6B6D4428218F565C0016262C /* CGSize+Resizing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CGSize+Resizing.swift"; sourceTree = "<group>"; };
@@ -441,6 +443,7 @@
 		12BBFDF7206B02AC0041620C /* interactivity */ = {
 			isa = PBXGroup;
 			children = (
+				6B61E07221FCE4830057E8DF /* AccessibilityNested.swift */,
 				6B06ADB221E8FB0400136BC8 /* AccessibilityTest.swift */,
 				6B61E06E21FA7E8F0057E8DF /* AccessibilityVisibility.swift */,
 				30F870BA20864AEE007ADA5B /* Button.swift */,
@@ -625,6 +628,7 @@
 				6BA5BBD5217021A000F086A7 /* Optionals.swift in Sources */,
 				6B29133B219CB84200A1DDB4 /* OpacityTest.swift in Sources */,
 				6B29134D219E504E00A1DDB4 /* LonaViewModel.swift in Sources */,
+				6B61E07321FCE4830057E8DF /* AccessibilityNested.swift in Sources */,
 				12BBFE11206B02AC0041620C /* Colors.swift in Sources */,
 				6B61E06F21FA7E8F0057E8DF /* AccessibilityVisibility.swift in Sources */,
 				30F870B920864A88007ADA5B /* NestedButtons.swift in Sources */,

--- a/examples/LonaViewer/iOS/Generated.swift
+++ b/examples/LonaViewer/iOS/Generated.swift
@@ -11,6 +11,7 @@ import UIKit
 enum Generated: String {
     case collectionTest = "Collection Test"
     case accessibilityTest = "Accessibility Test"
+    case accessibilityNested = "Accessibility Nested Components"
     case localAsset = "Local Asset"
     case vectorAsset = "Vector Asset"
     case vectorLogicActive = "Vector Logic - Active"
@@ -48,6 +49,7 @@ enum Generated: String {
     static func allValues() -> [Generated] {
         return [
             accessibilityTest,
+            accessibilityNested,
             collectionTest,
             localAsset,
             vectorAsset,
@@ -93,6 +95,14 @@ enum Generated: String {
             view.onToggleCheckbox = {
                 checked = !checked
                 view.checkboxValue = checked
+            }
+            return view
+        case .accessibilityNested:
+            var checked = false
+            let view = AccessibilityNested(isChecked: checked)
+            view.onChangeChecked = {
+                checked = !checked
+                view.isChecked = checked
             }
             return view
         case .collectionTest:
@@ -206,6 +216,7 @@ enum Generated: String {
                 equal(\.leftAnchor),
             ]
         case .accessibilityTest,
+             .accessibilityNested,
              .button,
              .pressableRootView,
              .nestedComponent,

--- a/examples/LonaViewer/web/src/App.js
+++ b/examples/LonaViewer/web/src/App.js
@@ -3,6 +3,7 @@ import "./App.css";
 
 import AccessibilityTest from "./generated/interactivity/AccessibilityTest";
 import AccessibilityVisibility from "./generated/interactivity/AccessibilityVisibility";
+import AccessibilityNested from "./generated/interactivity/AccessibilityNested";
 
 class App extends Component {
   state = {
@@ -11,7 +12,7 @@ class App extends Component {
 
   handleKeyDown = event => {
     if (event.key === "Tab" && document.activeElement === document.body) {
-      this.accessibilityTest.focus();
+      this.accessibilityNested.current.focus();
 
       event.stopPropagation();
       event.preventDefault();
@@ -26,29 +27,34 @@ class App extends Component {
     document.removeEventListener("keydown", this.handleKeyDown);
   }
 
+  accessibilityNested = React.createRef();
+  accessibilityTest = React.createRef();
+  accessibilityVisibility = React.createRef();
+
   render() {
     return (
       <div className="App">
+        <AccessibilityNested
+          ref={this.accessibilityNested}
+          onFocusNext={() => this.accessibilityTest.current.focus()}
+          isChecked={this.state.checked}
+          onChangeChecked={() =>
+            this.setState({ checked: !this.state.checked })
+          }
+        />
         <AccessibilityTest
-          ref={ref => {
-            this.accessibilityTest = ref;
-          }}
+          ref={this.accessibilityTest}
+          onFocusNext={() => this.accessibilityVisibility.current.focus()}
+          onFocusPrevious={() => this.accessibilityNested.current.focusLast()}
           checkboxValue={this.state.checked}
           onToggleCheckbox={() =>
             this.setState({ checked: !this.state.checked })
           }
-          onFocusNext={() => {
-            this.accessibilityVisibility.focus();
-          }}
         />
         <AccessibilityVisibility
-          ref={ref => {
-            this.accessibilityVisibility = ref;
-          }}
+          ref={this.accessibilityVisibility}
+          onFocusPrevious={() => this.accessibilityTest.current.focusLast()}
           showText={this.state.checked}
-          onFocusPrevious={() => {
-            this.accessibilityTest.focusLast();
-          }}
         />
       </div>
     );

--- a/examples/generated/test/appkit/interactivity/AccessibilityNested.swift
+++ b/examples/generated/test/appkit/interactivity/AccessibilityNested.swift
@@ -1,9 +1,9 @@
-import UIKit
+import AppKit
 import Foundation
 
 // MARK: - AccessibilityNested
 
-public class AccessibilityNested: UIView {
+public class AccessibilityNested: NSBox {
 
   // MARK: Lifecycle
 
@@ -67,11 +67,15 @@ public class AccessibilityNested: UIView {
   private var accessibilityVisibilityView = AccessibilityVisibility()
 
   private func setUpViews() {
+    boxType = .custom
+    borderType = .noBorder
+    contentViewMargins = .zero
+
     addSubview(accessibilityTestView)
     addSubview(accessibilityVisibilityView)
 
-    isAccessibilityElement = false
-    accessibilityElements = [accessibilityTestView, accessibilityVisibilityView]
+
+
     accessibilityTestView.customTextAccessibilityLabel = "Text"
   }
 

--- a/examples/generated/test/appkit/interactivity/AccessibilityVisibility.swift
+++ b/examples/generated/test/appkit/interactivity/AccessibilityVisibility.swift
@@ -152,6 +152,9 @@ public class AccessibilityVisibility: NSBox {
     if textView.isHidden != textViewIsHidden {
       NSLayoutConstraint.deactivate(conditionalConstraints(textViewIsHidden: textViewIsHidden))
       NSLayoutConstraint.activate(conditionalConstraints(textViewIsHidden: textView.isHidden))
+      accessibilityElements = [greyBoxView, textView].filter({
+            !$0.isHidden
+          })
     }
   }
 }

--- a/examples/generated/test/react-dom/interactivity/AccessibilityNested.js
+++ b/examples/generated/test/react-dom/interactivity/AccessibilityNested.js
@@ -32,11 +32,11 @@ export default class AccessibilityNested extends React.Component {
     this.setFocusRing(focusRing)
 
     let focusElements = this._getFocusElements()
-    if (
-      focusElements[focusElements.length - 1] &&
-      focusElements[focusElements.length - 1].focus
-    ) {
-      focusElements[focusElements.length - 1].focus()
+    let lastElement = focusElements[focusElements.length - 1]
+    if (lastElement && lastElement.focusLast) {
+      lastElement.focusLast()
+    } else if (lastElement && lastElement.focus) {
+      lastElement.focus()
     }
   }
 
@@ -97,8 +97,10 @@ export default class AccessibilityNested extends React.Component {
 
     let AccessibilityTest$checkboxValue
     let AccessibilityTest$onToggleCheckbox
+    let AccessibilityVisibility$showText
 
     AccessibilityTest$checkboxValue = this.props.isChecked
+    AccessibilityVisibility$showText = this.props.isChecked
     AccessibilityTest$onToggleCheckbox = this.props.onChangeChecked
     return (
       <Container>
@@ -118,7 +120,7 @@ export default class AccessibilityNested extends React.Component {
         </AccessibilityTestAccessibilityTestWrapper>
         <AccessibilityVisibilityAccessibilityVisibilityWrapper>
           <AccessibilityVisibility
-            showText={true}
+            showText={AccessibilityVisibility$showText}
             tabIndex={-1}
             focusRing={this.state.focusRing}
             onKeyDown={this._handleKeyDown}

--- a/examples/generated/test/react-dom/interactivity/AccessibilityNested.js
+++ b/examples/generated/test/react-dom/interactivity/AccessibilityNested.js
@@ -6,11 +6,18 @@ import shadows from "../shadows"
 import textStyles from "../textStyles"
 import AccessibilityTest from "./AccessibilityTest"
 import AccessibilityVisibility from "./AccessibilityVisibility"
+import { isFocused } from "../utils/focusUtils"
 
 export default class AccessibilityNested extends React.Component {
   state = { focusRing: false }
 
   setFocusRing = (focusRing) => { this.setState({ focusRing }) }
+
+  isFocused = () => {
+    let focusElements = this._getFocusElements()
+
+    return !!focusElements.find(isFocused);
+  }
 
   focus = ({ focusRing = true } = { focusRing: true }) => {
     this.setFocusRing(focusRing)
@@ -37,7 +44,7 @@ export default class AccessibilityNested extends React.Component {
     this.setFocusRing(focusRing)
 
     let focusElements = this._getFocusElements()
-    let nextIndex = focusElements.indexOf(document.activeElement) + 1
+    let nextIndex = focusElements.findIndex(isFocused) + 1
 
     if (nextIndex >= focusElements.length) {
       this.props.onFocusNext && this.props.onFocusNext()
@@ -51,14 +58,18 @@ export default class AccessibilityNested extends React.Component {
     this.setFocusRing(focusRing)
 
     let focusElements = this._getFocusElements()
-    let previousIndex = focusElements.indexOf(document.activeElement) - 1
+    let previousIndex = focusElements.findIndex(isFocused) - 1
 
     if (previousIndex < 0) {
       this.props.onFocusPrevious && this.props.onFocusPrevious()
       return ;
     }
 
-    focusElements[previousIndex].focus && focusElements[previousIndex].focus()
+    if (focusElements[previousIndex].focusLast) {
+      focusElements[previousIndex].focusLast()
+    } else {
+      focusElements[previousIndex].focus && focusElements[previousIndex].focus()
+    }
   }
 
   _handleKeyDown = (event) => {
@@ -77,23 +88,30 @@ export default class AccessibilityNested extends React.Component {
   }
 
   _getFocusElements = () => {
-    let elements = []
+    let elements = [this._AccessibilityTest, this._AccessibilityVisibility]
     return elements.filter(Boolean);
   }
 
   render() {
 
 
+    let AccessibilityTest$checkboxValue
+    let AccessibilityTest$onToggleCheckbox
 
+    AccessibilityTest$checkboxValue = this.props.isChecked
+    AccessibilityTest$onToggleCheckbox = this.props.onChangeChecked
     return (
       <Container>
         <AccessibilityTestAccessibilityTestWrapper>
           <AccessibilityTest
-            checkboxValue={false}
+            checkboxValue={AccessibilityTest$checkboxValue}
             customTextAccessibilityLabel={"Text"}
+            onToggleCheckbox={AccessibilityTest$onToggleCheckbox}
             tabIndex={-1}
             focusRing={this.state.focusRing}
             onKeyDown={this._handleKeyDown}
+            onFocusNext={this.focusNext}
+            onFocusPrevious={this.focusPrevious}
             ref={(ref) => { this._AccessibilityTest = ref }}
 
           />
@@ -104,6 +122,8 @@ export default class AccessibilityNested extends React.Component {
             tabIndex={-1}
             focusRing={this.state.focusRing}
             onKeyDown={this._handleKeyDown}
+            onFocusNext={this.focusNext}
+            onFocusPrevious={this.focusPrevious}
             ref={(ref) => { this._AccessibilityVisibility = ref }}
 
           />

--- a/examples/generated/test/react-dom/interactivity/AccessibilityNested.js
+++ b/examples/generated/test/react-dom/interactivity/AccessibilityNested.js
@@ -1,0 +1,142 @@
+import React from "react"
+import styled from "styled-components"
+
+import colors from "../colors"
+import shadows from "../shadows"
+import textStyles from "../textStyles"
+import AccessibilityTest from "./AccessibilityTest"
+import AccessibilityVisibility from "./AccessibilityVisibility"
+
+export default class AccessibilityNested extends React.Component {
+  state = { focusRing: false }
+
+  setFocusRing = (focusRing) => { this.setState({ focusRing }) }
+
+  focus = ({ focusRing = true } = { focusRing: true }) => {
+    this.setFocusRing(focusRing)
+
+    let focusElements = this._getFocusElements()
+    if (focusElements[0] && focusElements[0].focus) {
+      focusElements[0].focus()
+    }
+  }
+
+  focusLast = ({ focusRing = true } = { focusRing: true }) => {
+    this.setFocusRing(focusRing)
+
+    let focusElements = this._getFocusElements()
+    if (
+      focusElements[focusElements.length - 1] &&
+      focusElements[focusElements.length - 1].focus
+    ) {
+      focusElements[focusElements.length - 1].focus()
+    }
+  }
+
+  focusNext = ({ focusRing = true } = { focusRing: true }) => {
+    this.setFocusRing(focusRing)
+
+    let focusElements = this._getFocusElements()
+    let nextIndex = focusElements.indexOf(document.activeElement) + 1
+
+    if (nextIndex >= focusElements.length) {
+      this.props.onFocusNext && this.props.onFocusNext()
+      return ;
+    }
+
+    focusElements[nextIndex].focus && focusElements[nextIndex].focus()
+  }
+
+  focusPrevious = ({ focusRing = true } = { focusRing: true }) => {
+    this.setFocusRing(focusRing)
+
+    let focusElements = this._getFocusElements()
+    let previousIndex = focusElements.indexOf(document.activeElement) - 1
+
+    if (previousIndex < 0) {
+      this.props.onFocusPrevious && this.props.onFocusPrevious()
+      return ;
+    }
+
+    focusElements[previousIndex].focus && focusElements[previousIndex].focus()
+  }
+
+  _handleKeyDown = (event) => {
+    if (event.key === "Tab") {
+      this.setFocusRing(true)
+
+      if (event.shiftKey) {
+        this.focusPrevious()
+      } else {
+        this.focusNext()
+      }
+
+      event.stopPropagation()
+      event.preventDefault()
+    }
+  }
+
+  _getFocusElements = () => {
+    let elements = []
+    return elements.filter(Boolean);
+  }
+
+  render() {
+
+
+
+    return (
+      <Container>
+        <AccessibilityTestAccessibilityTestWrapper>
+          <AccessibilityTest
+            checkboxValue={false}
+            customTextAccessibilityLabel={"Text"}
+            tabIndex={-1}
+            focusRing={this.state.focusRing}
+            onKeyDown={this._handleKeyDown}
+            ref={(ref) => { this._AccessibilityTest = ref }}
+
+          />
+        </AccessibilityTestAccessibilityTestWrapper>
+        <AccessibilityVisibilityAccessibilityVisibilityWrapper>
+          <AccessibilityVisibility
+            showText={true}
+            tabIndex={-1}
+            focusRing={this.state.focusRing}
+            onKeyDown={this._handleKeyDown}
+            ref={(ref) => { this._AccessibilityVisibility = ref }}
+
+          />
+        </AccessibilityVisibilityAccessibilityVisibilityWrapper>
+      </Container>
+    );
+  }
+};
+
+let Container = styled.div({
+  alignItems: "flex-start",
+  display: "flex",
+  flex: "1 1 0%",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+})
+
+let AccessibilityTestAccessibilityTestWrapper = styled.div((props) => ({
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  display: "flex",
+  flex: "1 1 auto",
+  flexDirection: "row",
+  justifyContent: "flex-start",
+  ...!props.focusRing && { ":focus": { outline: 0 } }
+}))
+
+let AccessibilityVisibilityAccessibilityVisibilityWrapper = styled.div((props) => ({
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  display: "flex",
+  flex: "1 1 auto",
+  flexDirection: "row",
+  justifyContent: "flex-start",
+  ...!props.focusRing && { ":focus": { outline: 0 } }
+}))

--- a/examples/generated/test/react-dom/interactivity/AccessibilityTest.js
+++ b/examples/generated/test/react-dom/interactivity/AccessibilityTest.js
@@ -31,11 +31,11 @@ export default class AccessibilityTest extends React.Component {
     this.setFocusRing(focusRing)
 
     let focusElements = this._getFocusElements()
-    if (
-      focusElements[focusElements.length - 1] &&
-      focusElements[focusElements.length - 1].focus
-    ) {
-      focusElements[focusElements.length - 1].focus()
+    let lastElement = focusElements[focusElements.length - 1]
+    if (lastElement && lastElement.focusLast) {
+      lastElement.focusLast()
+    } else if (lastElement && lastElement.focus) {
+      lastElement.focus()
     }
   }
 

--- a/examples/generated/test/react-dom/interactivity/AccessibilityTest.js
+++ b/examples/generated/test/react-dom/interactivity/AccessibilityTest.js
@@ -5,11 +5,18 @@ import colors from "../colors"
 import shadows from "../shadows"
 import textStyles from "../textStyles"
 import createActivatableComponent from "../utils/createActivatableComponent"
+import { isFocused } from "../utils/focusUtils"
 
 export default class AccessibilityTest extends React.Component {
   state = { focusRing: false }
 
   setFocusRing = (focusRing) => { this.setState({ focusRing }) }
+
+  isFocused = () => {
+    let focusElements = this._getFocusElements()
+
+    return !!focusElements.find(isFocused);
+  }
 
   focus = ({ focusRing = true } = { focusRing: true }) => {
     this.setFocusRing(focusRing)
@@ -36,7 +43,7 @@ export default class AccessibilityTest extends React.Component {
     this.setFocusRing(focusRing)
 
     let focusElements = this._getFocusElements()
-    let nextIndex = focusElements.indexOf(document.activeElement) + 1
+    let nextIndex = focusElements.findIndex(isFocused) + 1
 
     if (nextIndex >= focusElements.length) {
       this.props.onFocusNext && this.props.onFocusNext()
@@ -50,14 +57,18 @@ export default class AccessibilityTest extends React.Component {
     this.setFocusRing(focusRing)
 
     let focusElements = this._getFocusElements()
-    let previousIndex = focusElements.indexOf(document.activeElement) - 1
+    let previousIndex = focusElements.findIndex(isFocused) - 1
 
     if (previousIndex < 0) {
       this.props.onFocusPrevious && this.props.onFocusPrevious()
       return ;
     }
 
-    focusElements[previousIndex].focus && focusElements[previousIndex].focus()
+    if (focusElements[previousIndex].focusLast) {
+      focusElements[previousIndex].focusLast()
+    } else {
+      focusElements[previousIndex].focus && focusElements[previousIndex].focus()
+    }
   }
 
   _handleKeyDown = (event) => {

--- a/examples/generated/test/react-dom/interactivity/AccessibilityVisibility.js
+++ b/examples/generated/test/react-dom/interactivity/AccessibilityVisibility.js
@@ -30,11 +30,11 @@ export default class AccessibilityVisibility extends React.Component {
     this.setFocusRing(focusRing)
 
     let focusElements = this._getFocusElements()
-    if (
-      focusElements[focusElements.length - 1] &&
-      focusElements[focusElements.length - 1].focus
-    ) {
-      focusElements[focusElements.length - 1].focus()
+    let lastElement = focusElements[focusElements.length - 1]
+    if (lastElement && lastElement.focusLast) {
+      lastElement.focusLast()
+    } else if (lastElement && lastElement.focus) {
+      lastElement.focus()
     }
   }
 

--- a/examples/generated/test/react-dom/interactivity/AccessibilityVisibility.js
+++ b/examples/generated/test/react-dom/interactivity/AccessibilityVisibility.js
@@ -4,11 +4,18 @@ import styled from "styled-components"
 import colors from "../colors"
 import shadows from "../shadows"
 import textStyles from "../textStyles"
+import { isFocused } from "../utils/focusUtils"
 
 export default class AccessibilityVisibility extends React.Component {
   state = { focusRing: false }
 
   setFocusRing = (focusRing) => { this.setState({ focusRing }) }
+
+  isFocused = () => {
+    let focusElements = this._getFocusElements()
+
+    return !!focusElements.find(isFocused);
+  }
 
   focus = ({ focusRing = true } = { focusRing: true }) => {
     this.setFocusRing(focusRing)
@@ -35,7 +42,7 @@ export default class AccessibilityVisibility extends React.Component {
     this.setFocusRing(focusRing)
 
     let focusElements = this._getFocusElements()
-    let nextIndex = focusElements.indexOf(document.activeElement) + 1
+    let nextIndex = focusElements.findIndex(isFocused) + 1
 
     if (nextIndex >= focusElements.length) {
       this.props.onFocusNext && this.props.onFocusNext()
@@ -49,14 +56,18 @@ export default class AccessibilityVisibility extends React.Component {
     this.setFocusRing(focusRing)
 
     let focusElements = this._getFocusElements()
-    let previousIndex = focusElements.indexOf(document.activeElement) - 1
+    let previousIndex = focusElements.findIndex(isFocused) - 1
 
     if (previousIndex < 0) {
       this.props.onFocusPrevious && this.props.onFocusPrevious()
       return ;
     }
 
-    focusElements[previousIndex].focus && focusElements[previousIndex].focus()
+    if (focusElements[previousIndex].focusLast) {
+      focusElements[previousIndex].focusLast()
+    } else {
+      focusElements[previousIndex].focus && focusElements[previousIndex].focus()
+    }
   }
 
   _handleKeyDown = (event) => {

--- a/examples/generated/test/react-native/interactivity/AccessibilityNested.js
+++ b/examples/generated/test/react-native/interactivity/AccessibilityNested.js
@@ -1,0 +1,62 @@
+import React from "react"
+import { View, StyleSheet } from "react-native"
+
+import colors from "../colors"
+import shadows from "../shadows"
+import textStyles from "../textStyles"
+import AccessibilityTest from "./AccessibilityTest"
+import AccessibilityVisibility from "./AccessibilityVisibility"
+
+export default class AccessibilityNested extends React.Component {
+  render() {
+
+
+    let AccessibilityTest$checkboxValue
+    let AccessibilityTest$onToggleCheckbox
+    let AccessibilityVisibility$showText
+
+    AccessibilityTest$checkboxValue = this.props.isChecked
+    AccessibilityVisibility$showText = this.props.isChecked
+    AccessibilityTest$onToggleCheckbox = this.props.onChangeChecked
+    return (
+      <View style={styles.container}>
+        <AccessibilityTest
+          checkboxValue={AccessibilityTest$checkboxValue}
+          customTextAccessibilityLabel={"Text"}
+          onToggleCheckbox={AccessibilityTest$onToggleCheckbox}
+          accessible={true}
+
+        />
+        <AccessibilityVisibility
+          showText={AccessibilityVisibility$showText}
+          accessible={true}
+
+        />
+      </View>
+    );
+  }
+};
+
+let styles = StyleSheet.create({
+  container: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  accessibilityTest: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  },
+  accessibilityVisibility: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  }
+})

--- a/examples/generated/test/sketchJs/interactivity/AccessibilityNested.js
+++ b/examples/generated/test/sketchJs/interactivity/AccessibilityNested.js
@@ -1,0 +1,57 @@
+import React from "react"
+import { View, StyleSheet, TextStyles } from "@mathieudutour/react-sketchapp"
+
+import colors from "../colors"
+import shadows from "../shadows"
+import textStyles from "../textStyles"
+import AccessibilityTest from "./AccessibilityTest"
+import AccessibilityVisibility from "./AccessibilityVisibility"
+
+export default class AccessibilityNested extends React.Component {
+  render() {
+
+
+    let AccessibilityTest$checkboxValue
+    let AccessibilityTest$onToggleCheckbox
+    let AccessibilityVisibility$showText
+
+    AccessibilityTest$checkboxValue = this.props.isChecked
+    AccessibilityVisibility$showText = this.props.isChecked
+    AccessibilityTest$onToggleCheckbox = this.props.onChangeChecked
+    return (
+      <View style={styles.container}>
+        <AccessibilityTest
+          checkboxValue={AccessibilityTest$checkboxValue}
+          customTextAccessibilityLabel={"Text"}
+          onToggleCheckbox={AccessibilityTest$onToggleCheckbox}
+
+        />
+        <AccessibilityVisibility showText={AccessibilityVisibility$showText} />
+      </View>
+    );
+  }
+};
+
+let styles = StyleSheet.create({
+  container: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 0,
+    flexDirection: "column",
+    justifyContent: "flex-start"
+  },
+  accessibilityTest: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  },
+  accessibilityVisibility: {
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  }
+})

--- a/examples/generated/test/swift/LonaCollectionView.swift
+++ b/examples/generated/test/swift/LonaCollectionView.swift
@@ -154,6 +154,7 @@ public class LonaCollectionView: UICollectionView,
     register(ImageCroppingCell.self, forCellWithReuseIdentifier: ImageCroppingCell.identifier)
     register(LocalAssetCell.self, forCellWithReuseIdentifier: LocalAssetCell.identifier)
     register(VectorAssetCell.self, forCellWithReuseIdentifier: VectorAssetCell.identifier)
+    register(AccessibilityNestedCell.self, forCellWithReuseIdentifier: AccessibilityNestedCell.identifier)
     register(AccessibilityTestCell.self, forCellWithReuseIdentifier: AccessibilityTestCell.identifier)
     register(AccessibilityVisibilityCell.self, forCellWithReuseIdentifier: AccessibilityVisibilityCell.identifier)
     register(ButtonCell.self, forCellWithReuseIdentifier: ButtonCell.identifier)
@@ -295,6 +296,11 @@ public class LonaCollectionView: UICollectionView,
       }
     case VectorAssetCell.identifier:
       if let cell = cell as? VectorAssetCell, let item = item as? VectorAsset.Model {
+        cell.parameters = item.parameters
+        cell.scrollDirection = scrollDirection
+      }
+    case AccessibilityNestedCell.identifier:
+      if let cell = cell as? AccessibilityNestedCell, let item = item as? AccessibilityNested.Model {
         cell.parameters = item.parameters
         cell.scrollDirection = scrollDirection
       }
@@ -709,6 +715,16 @@ public class VectorAssetCell: LonaCollectionViewCell<VectorAsset> {
   }
   public static var identifier: String {
     return "VectorAsset"
+  }
+}
+
+public class AccessibilityNestedCell: LonaCollectionViewCell<AccessibilityNested> {
+  public var parameters: AccessibilityNested.Parameters {
+    get { return view.parameters }
+    set { view.parameters = newValue }
+  }
+  public static var identifier: String {
+    return "AccessibilityNested"
   }
 }
 

--- a/examples/generated/test/swift/interactivity/AccessibilityNested.swift
+++ b/examples/generated/test/swift/interactivity/AccessibilityNested.swift
@@ -1,0 +1,130 @@
+import UIKit
+import Foundation
+
+// MARK: - AccessibilityNested
+
+public class AccessibilityNested: UIView {
+
+  // MARK: Lifecycle
+
+  public init(_ parameters: Parameters) {
+    self.parameters = parameters
+
+    super.init(frame: .zero)
+
+    setUpViews()
+    setUpConstraints()
+
+    update()
+  }
+
+  public convenience init() {
+    self.init(Parameters())
+  }
+
+  public required init?(coder aDecoder: NSCoder) {
+    self.parameters = Parameters()
+
+    super.init(coder: aDecoder)
+
+    setUpViews()
+    setUpConstraints()
+
+    update()
+  }
+
+  // MARK: Public
+
+  public var parameters: Parameters {
+    didSet {
+      if parameters != oldValue {
+        update()
+      }
+    }
+  }
+
+  // MARK: Private
+
+  private var accessibilityTestView = AccessibilityTest()
+  private var accessibilityVisibilityView = AccessibilityVisibility()
+
+  private func setUpViews() {
+    addSubview(accessibilityTestView)
+    addSubview(accessibilityVisibilityView)
+
+    accessibilityTestView.checkboxValue = false
+    accessibilityTestView.customTextAccessibilityLabel = "Text"
+    accessibilityVisibilityView.showText = false
+  }
+
+  private func setUpConstraints() {
+    translatesAutoresizingMaskIntoConstraints = false
+    accessibilityTestView.translatesAutoresizingMaskIntoConstraints = false
+    accessibilityVisibilityView.translatesAutoresizingMaskIntoConstraints = false
+
+    let accessibilityTestViewTopAnchorConstraint = accessibilityTestView.topAnchor.constraint(equalTo: topAnchor)
+    let accessibilityTestViewLeadingAnchorConstraint = accessibilityTestView
+      .leadingAnchor
+      .constraint(equalTo: leadingAnchor)
+    let accessibilityTestViewTrailingAnchorConstraint = accessibilityTestView
+      .trailingAnchor
+      .constraint(equalTo: trailingAnchor)
+    let accessibilityVisibilityViewBottomAnchorConstraint = accessibilityVisibilityView
+      .bottomAnchor
+      .constraint(equalTo: bottomAnchor)
+    let accessibilityVisibilityViewTopAnchorConstraint = accessibilityVisibilityView
+      .topAnchor
+      .constraint(equalTo: accessibilityTestView.bottomAnchor)
+    let accessibilityVisibilityViewLeadingAnchorConstraint = accessibilityVisibilityView
+      .leadingAnchor
+      .constraint(equalTo: leadingAnchor)
+    let accessibilityVisibilityViewTrailingAnchorConstraint = accessibilityVisibilityView
+      .trailingAnchor
+      .constraint(equalTo: trailingAnchor)
+
+    NSLayoutConstraint.activate([
+      accessibilityTestViewTopAnchorConstraint,
+      accessibilityTestViewLeadingAnchorConstraint,
+      accessibilityTestViewTrailingAnchorConstraint,
+      accessibilityVisibilityViewBottomAnchorConstraint,
+      accessibilityVisibilityViewTopAnchorConstraint,
+      accessibilityVisibilityViewLeadingAnchorConstraint,
+      accessibilityVisibilityViewTrailingAnchorConstraint
+    ])
+  }
+
+  private func update() {}
+}
+
+// MARK: - Parameters
+
+extension AccessibilityNested {
+  public struct Parameters: Equatable {
+    public init() {}
+  }
+}
+
+// MARK: - Model
+
+extension AccessibilityNested {
+  public struct Model: LonaViewModel, Equatable {
+    public var id: String?
+    public var parameters: Parameters
+    public var type: String {
+      return "AccessibilityNested"
+    }
+
+    public init(id: String? = nil, parameters: Parameters) {
+      self.id = id
+      self.parameters = parameters
+    }
+
+    public init(_ parameters: Parameters) {
+      self.parameters = parameters
+    }
+
+    public init() {
+      self.init(Parameters())
+    }
+  }
+}

--- a/examples/material-design/components/Card.component
+++ b/examples/material-design/components/Card.component
@@ -139,6 +139,9 @@
           {
             "id" : "Headline",
             "params" : {
+              "accessibilityRole" : "header",
+              "accessibilityType" : "element",
+              "alignSelf" : "stretch",
               "font" : "headline",
               "text" : "Headline"
             },
@@ -147,6 +150,8 @@
           {
             "id" : "Body",
             "params" : {
+              "accessibilityType" : "element",
+              "alignSelf" : "stretch",
               "font" : "body2",
               "numberOfLines" : 2,
               "text" : "Body",
@@ -168,6 +173,11 @@
     ],
     "id" : "View",
     "params" : {
+      "accessibilityElements" : [
+        "Headline",
+        "Body"
+      ],
+      "accessibilityType" : "container",
       "alignSelf" : "stretch"
     },
     "type" : "Lona:View"

--- a/examples/material-design/components/ListItem.component
+++ b/examples/material-design/components/ListItem.component
@@ -116,6 +116,8 @@
     ],
     "id" : "View",
     "params" : {
+      "accessibilityRole" : "button",
+      "accessibilityType" : "element",
       "alignSelf" : "stretch",
       "flexDirection" : "row",
       "paddingBottom" : 16,

--- a/examples/test/interactivity/AccessibilityNested.component
+++ b/examples/test/interactivity/AccessibilityNested.component
@@ -19,10 +19,42 @@
     }
   ],
   "logic" : [
-
+    {
+      "assignee" : [
+        "layers",
+        "AccessibilityTest",
+        "checkboxValue"
+      ],
+      "content" : [
+        "parameters",
+        "isChecked"
+      ],
+      "type" : "AssignExpr"
+    },
+    {
+      "assignee" : [
+        "layers",
+        "AccessibilityTest",
+        "onToggleCheckbox"
+      ],
+      "content" : [
+        "parameters",
+        "onChangeChecked"
+      ],
+      "type" : "AssignExpr"
+    }
   ],
   "params" : [
-
+    {
+      "name" : "isChecked",
+      "type" : "Boolean"
+    },
+    {
+      "name" : "onChangeChecked",
+      "type" : {
+        "name" : "Function"
+      }
+    }
   ],
   "root" : {
     "children" : [

--- a/examples/test/interactivity/AccessibilityNested.component
+++ b/examples/test/interactivity/AccessibilityNested.component
@@ -1,0 +1,56 @@
+{
+  "devices" : [
+    {
+      "deviceId" : "iPhone SE",
+      "heightMode" : "At Least"
+    },
+    {
+      "deviceId" : "Pixel 2",
+      "heightMode" : "At Least"
+    }
+  ],
+  "examples" : [
+    {
+      "id" : "Default",
+      "name" : "Default",
+      "params" : {
+
+      }
+    }
+  ],
+  "logic" : [
+
+  ],
+  "params" : [
+
+  ],
+  "root" : {
+    "children" : [
+      {
+        "id" : "AccessibilityTest",
+        "params" : {
+          "checkboxValue" : false,
+          "customTextAccessibilityLabel" : "Text"
+        },
+        "type" : "AccessibilityTest"
+      },
+      {
+        "id" : "AccessibilityVisibility",
+        "params" : {
+          "showText" : true
+        },
+        "type" : "AccessibilityVisibility"
+      }
+    ],
+    "id" : "Container",
+    "params" : {
+      "accessibilityElements" : [
+        "AccessibilityTest",
+        "AccessibilityVisibility"
+      ],
+      "accessibilityType" : "container",
+      "alignSelf" : "stretch"
+    },
+    "type" : "Lona:View"
+  }
+}

--- a/examples/test/interactivity/AccessibilityNested.component
+++ b/examples/test/interactivity/AccessibilityNested.component
@@ -34,6 +34,18 @@
     {
       "assignee" : [
         "layers",
+        "AccessibilityVisibility",
+        "showText"
+      ],
+      "content" : [
+        "parameters",
+        "isChecked"
+      ],
+      "type" : "AssignExpr"
+    },
+    {
+      "assignee" : [
+        "layers",
         "AccessibilityTest",
         "onToggleCheckbox"
       ],

--- a/studio/LonaStudio/Canvas/CSView.swift
+++ b/studio/LonaStudio/Canvas/CSView.swift
@@ -48,6 +48,7 @@ class CSView: NSBox, CSRendering {
     }
 
     var layerName: String?
+    var layerPath: [String] = []
 
     var onClick: (() -> Void)?
 

--- a/studio/LonaStudio/Canvas/ConfiguredLayer.swift
+++ b/studio/LonaStudio/Canvas/ConfiguredLayer.swift
@@ -15,6 +15,7 @@ let imageCache = ImageCache<NSImage>()
 let svgRenderCache = LRUCache<String, NSImage>()
 
 struct ConfiguredLayer {
+    let layerPath: [String]
     let layer: CSLayer
     let config: ComponentConfiguration
     let children: [ConfiguredLayer]
@@ -88,6 +89,7 @@ struct ConfiguredLayer {
         var renderableView = RenderableViewAttributes()
 
         renderableView.layerName = layer.name
+        renderableView.layerPath = layerPath
         renderableView.frame = NSRect(x: layout.left, y: layout.top, width: layout.width, height: layout.height)
 
         if layer.text == nil, let color = config.get(attribute: "backgroundColor", for: layer.name).string ?? layer.backgroundColor {

--- a/studio/LonaStudio/Canvas/RenderableElement.swift
+++ b/studio/LonaStudio/Canvas/RenderableElement.swift
@@ -20,6 +20,7 @@ enum RenderableType: Equatable {
 struct RenderableViewAttributes: Equatable {
     init() {
         layerName = ""
+        layerPath = []
         frame = .zero
         multipliedFillColor = .clear
         opacity = 1
@@ -32,6 +33,7 @@ struct RenderableViewAttributes: Equatable {
     }
 
     var layerName: String
+    var layerPath: [String]
     var frame: NSRect
     var multipliedFillColor: NSColor
     var opacity: CGFloat
@@ -53,6 +55,7 @@ struct RenderableViewAttributes: Equatable {
     func configureView(_ view: CSView) {
         view.frame = frame
         view.layerName = layerName
+        view.layerPath = layerPath
         view.multipliedFillColor = multipliedFillColor
         view.opacity = opacity
         view.cornerRadius = cornerRadius

--- a/studio/LonaStudio/Models/CSLayer.swift
+++ b/studio/LonaStudio/Models/CSLayer.swift
@@ -186,13 +186,13 @@ class CSLayer: CSDataDeserializable, CSDataSerializable, DataNode, NSCopying {
                 return innerResults
             }
 
-            switch accessibility {
+            switch layer.accessibility {
             case .auto:
                 return Array(layer.children.map { inner(prefix: prefix, layer: $0) }.joined())
             case .none:
                 return []
             case .element:
-                return [[layer.name]]
+                return [prefix + [layer.name]]
             case .container(let elements):
                 return elements.map { prefix + [$0] }
             }


### PR DESCRIPTION
## What

This fixes moving focus between nested Lona components. 

> Note: For this to work, it's best to follow the recommended pattern of the top-level layer being a `container` and specifying `accessibilityElements` to navigate between.

Some more improvements I want to make:
- Move some of the component focus boilerplate code into utils, so that it's easier for custom components and ghosts to follow the same patterns, and to reduce bundle size
- Fix cases where the accessibility overlay doesn't show when nested

cc @outdooricon