### PR TITLE
Fix focusUtils file not getting copied to output directory

### DIFF
--- a/compiler/core/src/main.re
+++ b/compiler/core/src/main.re
@@ -294,7 +294,7 @@ let copyStaticFiles = outputDirectory =>
   | Types.JavaScript =>
     switch (javaScriptOptions.framework) {
     | ReactDOM =>
-      let staticFiles = ["createActivatableComponent"];
+      let staticFiles = ["createActivatableComponent", "focusUtils"];
       staticFiles
       |> List.iter(file =>
            copySync(

--- a/examples/generated/test/react-dom/utils/focusUtils.js
+++ b/examples/generated/test/react-dom/utils/focusUtils.js
@@ -1,0 +1,7 @@
+export const isFocused = componentOrDomNode => {
+  if (componentOrDomNode.isReactComponent) {
+    return componentOrDomNode.isFocused();
+  }
+
+  return componentOrDomNode === document.activeElement;
+};


### PR DESCRIPTION
## What

Adds focusUtils to the list of JS files to be copied when converting the workspace to ReactDOM.

cc @outdooricon 