### PR TITLE
Keyboard focus falls back to browser control

### DIFF
--- a/compiler/core/src/javaScript/javaScriptComponent.re
+++ b/compiler/core/src/javaScript/javaScriptComponent.re
@@ -644,11 +644,21 @@ let rec layerToJavaScriptAST =
               [
                 JSXAttribute({
                   name: "onFocusNext",
-                  value: Identifier(["this", "focusNext"]),
+                  value:
+                    BinaryExpression({
+                      left: Identifier(["this", "props", "onFocusNext"]),
+                      operator: And,
+                      right: Identifier(["this", "focusNext"]),
+                    }),
                 }),
                 JSXAttribute({
                   name: "onFocusPrevious",
-                  value: Identifier(["this", "focusPrevious"]),
+                  value:
+                    BinaryExpression({
+                      left: Identifier(["this", "props", "onFocusPrevious"]),
+                      operator: And,
+                      right: Identifier(["this", "focusPrevious"]),
+                    }),
                 }),
               ] :
               []
@@ -921,6 +931,10 @@ let importComponents =
                 ++ "/utils/focusUtils",
               specifiers: [
                 Ast.ImportSpecifier({imported: "isFocused", local: None}),
+                Ast.ImportSpecifier({imported: "focusFirst", local: None}),
+                Ast.ImportSpecifier({imported: "focusLast", local: None}),
+                Ast.ImportSpecifier({imported: "focusNext", local: None}),
+                Ast.ImportSpecifier({imported: "focusPrevious", local: None}),
               ],
             }),
           ];

--- a/compiler/core/src/javaScript/javaScriptComponent.re
+++ b/compiler/core/src/javaScript/javaScriptComponent.re
@@ -624,8 +624,7 @@ let rec layerToJavaScriptAST =
               value: Literal(LonaValue.boolean(true)),
             }),
           ]
-        | ReactDOM =>
-          [
+        | ReactDOM => [
             JSXAttribute({
               name: "tabIndex",
               value: Literal(LonaValue.number(-1.)),
@@ -639,30 +638,6 @@ let rec layerToJavaScriptAST =
               value: Identifier(["this", "_handleKeyDown"]),
             }),
           ]
-          @ (
-            Layer.isComponentLayer(layer) ?
-              [
-                JSXAttribute({
-                  name: "onFocusNext",
-                  value:
-                    BinaryExpression({
-                      left: Identifier(["this", "props", "onFocusNext"]),
-                      operator: And,
-                      right: Identifier(["this", "focusNext"]),
-                    }),
-                }),
-                JSXAttribute({
-                  name: "onFocusPrevious",
-                  value:
-                    BinaryExpression({
-                      left: Identifier(["this", "props", "onFocusPrevious"]),
-                      operator: And,
-                      right: Identifier(["this", "focusPrevious"]),
-                    }),
-                }),
-              ] :
-              []
-          )
         | ReactSketchapp => []
         } :
         []

--- a/compiler/core/src/javaScript/javaScriptFocus.re
+++ b/compiler/core/src/javaScript/javaScriptFocus.re
@@ -123,15 +123,17 @@ module Methods = {
               arguments: [Identifier(["focusRing"])],
             }),
             Empty,
-            CallExpression({
-              callee: Identifier(["focusFirst"]),
-              arguments: [
-                CallExpression({
-                  callee: Identifier(["this", "_getFocusElements"]),
-                  arguments: [],
-                }),
-              ],
-            }),
+            Return(
+              CallExpression({
+                callee: Identifier(["focusFirst"]),
+                arguments: [
+                  CallExpression({
+                    callee: Identifier(["this", "_getFocusElements"]),
+                    arguments: [],
+                  }),
+                ],
+              }),
+            ),
           ],
         }),
     });
@@ -149,15 +151,17 @@ module Methods = {
               arguments: [Identifier(["focusRing"])],
             }),
             Empty,
-            CallExpression({
-              callee: Identifier(["focusLast"]),
-              arguments: [
-                CallExpression({
-                  callee: Identifier(["this", "_getFocusElements"]),
-                  arguments: [],
-                }),
-              ],
-            }),
+            Return(
+              CallExpression({
+                callee: Identifier(["focusLast"]),
+                arguments: [
+                  CallExpression({
+                    callee: Identifier(["this", "_getFocusElements"]),
+                    arguments: [],
+                  }),
+                ],
+              }),
+            ),
           ],
         }),
     });
@@ -175,36 +179,17 @@ module Methods = {
               arguments: [Identifier(["focusRing"])],
             }),
             Empty,
-            IfStatement({
-              test:
-                CallExpression({
-                  callee: Identifier(["focusNext"]),
-                  arguments: [
-                    CallExpression({
-                      callee: Identifier(["this", "_getFocusElements"]),
-                      arguments: [],
-                    }),
-                  ],
-                }),
-
-              consequent: [Return(Literal(LonaValue.boolean(true)))],
-              alternate: [],
-            }),
-            Empty,
-            IfStatement({
-              test: Identifier(["this", "props", "onFocusNext"]),
-              consequent: [
-                CallExpression({
-                  callee: Identifier(["this", "props", "onFocusNext"]),
-                  arguments: [],
-                }),
-                Empty,
-                Return(Literal(LonaValue.boolean(true))),
-              ],
-              alternate: [],
-            }),
-            Empty,
-            Return(Literal(LonaValue.boolean(false))),
+            Return(
+              CallExpression({
+                callee: Identifier(["focusNext"]),
+                arguments: [
+                  CallExpression({
+                    callee: Identifier(["this", "_getFocusElements"]),
+                    arguments: [],
+                  }),
+                ],
+              }),
+            ),
           ],
         }),
     });
@@ -222,36 +207,17 @@ module Methods = {
               arguments: [Identifier(["focusRing"])],
             }),
             Empty,
-            IfStatement({
-              test:
-                CallExpression({
-                  callee: Identifier(["focusPrevious"]),
-                  arguments: [
-                    CallExpression({
-                      callee: Identifier(["this", "_getFocusElements"]),
-                      arguments: [],
-                    }),
-                  ],
-                }),
-
-              consequent: [Return(Literal(LonaValue.boolean(true)))],
-              alternate: [],
-            }),
-            Empty,
-            IfStatement({
-              test: Identifier(["this", "props", "onFocusPrevious"]),
-              consequent: [
-                CallExpression({
-                  callee: Identifier(["this", "props", "onFocusPrevious"]),
-                  arguments: [],
-                }),
-                Empty,
-                Return(Literal(LonaValue.boolean(true))),
-              ],
-              alternate: [],
-            }),
-            Empty,
-            Return(Literal(LonaValue.boolean(false))),
+            Return(
+              CallExpression({
+                callee: Identifier(["focusPrevious"]),
+                arguments: [
+                  CallExpression({
+                    callee: Identifier(["this", "_getFocusElements"]),
+                    arguments: [],
+                  }),
+                ],
+              }),
+            ),
           ],
         }),
     });
@@ -297,7 +263,35 @@ module Methods = {
                         }),
                         Return(Empty),
                       ],
-                      alternate: [],
+                      alternate: [
+                        IfStatement({
+                          test:
+                            Identifier(["this", "props", "onFocusPrevious"]),
+                          consequent: [
+                            CallExpression({
+                              callee:
+                                Identifier([
+                                  "this",
+                                  "props",
+                                  "onFocusPrevious",
+                                ]),
+                              arguments: [],
+                            }),
+                            Empty,
+                            CallExpression({
+                              callee:
+                                Identifier(["event", "stopPropagation"]),
+                              arguments: [],
+                            }),
+                            CallExpression({
+                              callee: Identifier(["event", "preventDefault"]),
+                              arguments: [],
+                            }),
+                            Return(Empty),
+                          ],
+                          alternate: [],
+                        }),
+                      ],
                     }),
                   ],
                   alternate: [
@@ -318,7 +312,30 @@ module Methods = {
                         }),
                         Return(Empty),
                       ],
-                      alternate: [],
+                      alternate: [
+                        IfStatement({
+                          test: Identifier(["this", "props", "onFocusNext"]),
+                          consequent: [
+                            CallExpression({
+                              callee:
+                                Identifier(["this", "props", "onFocusNext"]),
+                              arguments: [],
+                            }),
+                            Empty,
+                            CallExpression({
+                              callee:
+                                Identifier(["event", "stopPropagation"]),
+                              arguments: [],
+                            }),
+                            CallExpression({
+                              callee: Identifier(["event", "preventDefault"]),
+                              arguments: [],
+                            }),
+                            Return(Empty),
+                          ],
+                          alternate: [],
+                        }),
+                      ],
                     }),
                   ],
                 }),

--- a/compiler/core/src/javaScript/javaScriptFocus.re
+++ b/compiler/core/src/javaScript/javaScriptFocus.re
@@ -266,14 +266,18 @@ module Methods = {
                       alternate: [
                         IfStatement({
                           test:
-                            Identifier(["this", "props", "onFocusPrevious"]),
+                            Identifier([
+                              "this",
+                              "props",
+                              "onFocusExitPrevious",
+                            ]),
                           consequent: [
                             CallExpression({
                               callee:
                                 Identifier([
                                   "this",
                                   "props",
-                                  "onFocusPrevious",
+                                  "onFocusExitPrevious",
                                 ]),
                               arguments: [],
                             }),
@@ -314,11 +318,16 @@ module Methods = {
                       ],
                       alternate: [
                         IfStatement({
-                          test: Identifier(["this", "props", "onFocusNext"]),
+                          test:
+                            Identifier(["this", "props", "onFocusExitNext"]),
                           consequent: [
                             CallExpression({
                               callee:
-                                Identifier(["this", "props", "onFocusNext"]),
+                                Identifier([
+                                  "this",
+                                  "props",
+                                  "onFocusExitNext",
+                                ]),
                               arguments: [],
                             }),
                             Empty,

--- a/compiler/core/src/javaScript/javaScriptFocus.re
+++ b/compiler/core/src/javaScript/javaScriptFocus.re
@@ -123,30 +123,14 @@ module Methods = {
               arguments: [Identifier(["focusRing"])],
             }),
             Empty,
-            VariableDeclaration(
-              AssignmentExpression({
-                left: Identifier(["focusElements"]),
-                right:
-                  CallExpression({
-                    callee: Identifier(["this", "_getFocusElements"]),
-                    arguments: [],
-                  }),
-              }),
-            ),
-            IfStatement({
-              test:
-                BinaryExpression({
-                  left: Identifier(["focusElements[0]"]),
-                  operator: And,
-                  right: Identifier(["focusElements[0]", "focus"]),
-                }),
-              consequent: [
+            CallExpression({
+              callee: Identifier(["focusFirst"]),
+              arguments: [
                 CallExpression({
-                  callee: Identifier(["focusElements[0]", "focus"]),
+                  callee: Identifier(["this", "_getFocusElements"]),
                   arguments: [],
                 }),
               ],
-              alternate: [],
             }),
           ],
         }),
@@ -165,51 +149,12 @@ module Methods = {
               arguments: [Identifier(["focusRing"])],
             }),
             Empty,
-            VariableDeclaration(
-              AssignmentExpression({
-                left: Identifier(["focusElements"]),
-                right:
-                  CallExpression({
-                    callee: Identifier(["this", "_getFocusElements"]),
-                    arguments: [],
-                  }),
-              }),
-            ),
-            VariableDeclaration(
-              AssignmentExpression({
-                left: Identifier(["lastElement"]),
-                right:
-                  Identifier(["focusElements[focusElements.length - 1]"]),
-              }),
-            ),
-            IfStatement({
-              test:
-                BinaryExpression({
-                  left: Identifier(["lastElement"]),
-                  operator: And,
-                  right: Identifier(["lastElement", "focusLast"]),
-                }),
-              consequent: [
+            CallExpression({
+              callee: Identifier(["focusLast"]),
+              arguments: [
                 CallExpression({
-                  callee: Identifier(["lastElement", "focusLast"]),
+                  callee: Identifier(["this", "_getFocusElements"]),
                   arguments: [],
-                }),
-              ],
-              alternate: [
-                IfStatement({
-                  test:
-                    BinaryExpression({
-                      left: Identifier(["lastElement"]),
-                      operator: And,
-                      right: Identifier(["lastElement", "focus"]),
-                    }),
-                  consequent: [
-                    CallExpression({
-                      callee: Identifier(["lastElement", "focus"]),
-                      arguments: [],
-                    }),
-                  ],
-                  alternate: [],
                 }),
               ],
             }),
@@ -230,63 +175,36 @@ module Methods = {
               arguments: [Identifier(["focusRing"])],
             }),
             Empty,
-            VariableDeclaration(
-              AssignmentExpression({
-                left: Identifier(["focusElements"]),
-                right:
-                  CallExpression({
-                    callee: Identifier(["this", "_getFocusElements"]),
-                    arguments: [],
-                  }),
-              }),
-            ),
-            VariableDeclaration(
-              AssignmentExpression({
-                left: Identifier(["nextIndex"]),
-                right:
-                  BinaryExpression({
-                    left:
-                      CallExpression({
-                        callee: Identifier(["focusElements", "findIndex"]),
-                        arguments: [Identifier(["isFocused"])],
-                      }),
-                    operator: Plus,
-                    right: Literal(LonaValue.number(1.)),
-                  }),
-              }),
-            ),
-            Empty,
             IfStatement({
               test:
-                BinaryExpression({
-                  left: Identifier(["nextIndex"]),
-                  operator: Gte,
-                  right: Identifier(["focusElements", "length"]),
-                }),
-              consequent: [
-                BinaryExpression({
-                  left: Identifier(["this", "props", "onFocusNext"]),
-                  operator: And,
-                  right:
+                CallExpression({
+                  callee: Identifier(["focusNext"]),
+                  arguments: [
                     CallExpression({
-                      callee: Identifier(["this", "props", "onFocusNext"]),
+                      callee: Identifier(["this", "_getFocusElements"]),
                       arguments: [],
                     }),
+                  ],
                 }),
-                Return(Empty),
+
+              consequent: [Return(Literal(LonaValue.boolean(true)))],
+              alternate: [],
+            }),
+            Empty,
+            IfStatement({
+              test: Identifier(["this", "props", "onFocusNext"]),
+              consequent: [
+                CallExpression({
+                  callee: Identifier(["this", "props", "onFocusNext"]),
+                  arguments: [],
+                }),
+                Empty,
+                Return(Literal(LonaValue.boolean(true))),
               ],
               alternate: [],
             }),
             Empty,
-            BinaryExpression({
-              left: Identifier(["focusElements[nextIndex]", "focus"]),
-              operator: And,
-              right:
-                CallExpression({
-                  callee: Identifier(["focusElements[nextIndex]", "focus"]),
-                  arguments: [],
-                }),
-            }),
+            Return(Literal(LonaValue.boolean(false))),
           ],
         }),
     });
@@ -304,77 +222,36 @@ module Methods = {
               arguments: [Identifier(["focusRing"])],
             }),
             Empty,
-            VariableDeclaration(
-              AssignmentExpression({
-                left: Identifier(["focusElements"]),
-                right:
-                  CallExpression({
-                    callee: Identifier(["this", "_getFocusElements"]),
-                    arguments: [],
-                  }),
-              }),
-            ),
-            VariableDeclaration(
-              AssignmentExpression({
-                left: Identifier(["previousIndex"]),
-                right:
-                  BinaryExpression({
-                    left:
-                      CallExpression({
-                        callee: Identifier(["focusElements", "findIndex"]),
-                        arguments: [Identifier(["isFocused"])],
-                      }),
-                    operator: Minus,
-                    right: Literal(LonaValue.number(1.)),
-                  }),
-              }),
-            ),
-            Empty,
             IfStatement({
               test:
-                BinaryExpression({
-                  left: Identifier(["previousIndex"]),
-                  operator: Lt,
-                  right: Literal(LonaValue.number(0.)),
-                }),
-              consequent: [
-                BinaryExpression({
-                  left: Identifier(["this", "props", "onFocusPrevious"]),
-                  operator: And,
-                  right:
+                CallExpression({
+                  callee: Identifier(["focusPrevious"]),
+                  arguments: [
                     CallExpression({
-                      callee:
-                        Identifier(["this", "props", "onFocusPrevious"]),
+                      callee: Identifier(["this", "_getFocusElements"]),
                       arguments: [],
                     }),
+                  ],
                 }),
-                Return(Empty),
-              ],
+
+              consequent: [Return(Literal(LonaValue.boolean(true)))],
               alternate: [],
             }),
             Empty,
             IfStatement({
-              test: Identifier(["focusElements[previousIndex]", "focusLast"]),
+              test: Identifier(["this", "props", "onFocusPrevious"]),
               consequent: [
                 CallExpression({
-                  callee:
-                    Identifier(["focusElements[previousIndex]", "focusLast"]),
+                  callee: Identifier(["this", "props", "onFocusPrevious"]),
                   arguments: [],
                 }),
+                Empty,
+                Return(Literal(LonaValue.boolean(true))),
               ],
-              alternate: [
-                BinaryExpression({
-                  left: Identifier(["focusElements[previousIndex]", "focus"]),
-                  operator: And,
-                  right:
-                    CallExpression({
-                      callee:
-                        Identifier(["focusElements[previousIndex]", "focus"]),
-                      arguments: [],
-                    }),
-                }),
-              ],
+              alternate: [],
             }),
+            Empty,
+            Return(Literal(LonaValue.boolean(false))),
           ],
         }),
     });
@@ -402,28 +279,59 @@ module Methods = {
                 Empty,
                 IfStatement({
                   test: Identifier(["event", "shiftKey"]),
-
                   consequent: [
-                    CallExpression({
-                      callee: Identifier(["this", "focusPrevious"]),
-                      arguments: [],
+                    IfStatement({
+                      test:
+                        CallExpression({
+                          callee: Identifier(["this", "focusPrevious"]),
+                          arguments: [],
+                        }),
+                      consequent: [
+                        CallExpression({
+                          callee: Identifier(["event", "stopPropagation"]),
+                          arguments: [],
+                        }),
+                        CallExpression({
+                          callee: Identifier(["event", "preventDefault"]),
+                          arguments: [],
+                        }),
+                        Return(Empty),
+                      ],
+                      alternate: [],
                     }),
                   ],
                   alternate: [
-                    CallExpression({
-                      callee: Identifier(["this", "focusNext"]),
-                      arguments: [],
+                    IfStatement({
+                      test:
+                        CallExpression({
+                          callee: Identifier(["this", "focusNext"]),
+                          arguments: [],
+                        }),
+                      consequent: [
+                        CallExpression({
+                          callee: Identifier(["event", "stopPropagation"]),
+                          arguments: [],
+                        }),
+                        CallExpression({
+                          callee: Identifier(["event", "preventDefault"]),
+                          arguments: [],
+                        }),
+                        Return(Empty),
+                      ],
+                      alternate: [],
                     }),
                   ],
                 }),
-                Empty,
+              ],
+              alternate: [],
+            }),
+            Empty,
+            IfStatement({
+              test: Identifier(["this", "props", "onKeyDown"]),
+              consequent: [
                 CallExpression({
-                  callee: Identifier(["event", "stopPropagation"]),
-                  arguments: [],
-                }),
-                CallExpression({
-                  callee: Identifier(["event", "preventDefault"]),
-                  arguments: [],
+                  callee: Identifier(["this", "props", "onKeyDown"]),
+                  arguments: [Identifier(["event"])],
                 }),
               ],
               alternate: [],

--- a/compiler/core/src/static/javaScript/focusUtils.js
+++ b/compiler/core/src/static/javaScript/focusUtils.js
@@ -5,3 +5,65 @@ export const isFocused = componentOrDomNode => {
 
   return componentOrDomNode === document.activeElement;
 };
+
+export const focusFirst = elements => {
+  if (elements[0] && elements[0].focus) {
+    elements[0].focus();
+
+    return true;
+  }
+
+  return false;
+};
+
+export const focusLast = elements => {
+  let lastElement = elements[elements.length - 1];
+
+  if (lastElement && lastElement.focusLast) {
+    lastElement.focusLast();
+
+    return true;
+  } else if (lastElement && lastElement.focus) {
+    lastElement.focus();
+
+    return true;
+  }
+
+  return false;
+};
+
+export const focusNext = elements => {
+  let nextIndex = elements.findIndex(isFocused) + 1;
+
+  if (nextIndex >= elements.length) {
+    return false;
+  }
+
+  if (elements[nextIndex].focus) {
+    elements[nextIndex].focus();
+
+    return true;
+  }
+
+  return false;
+};
+
+export const focusPrevious = elements => {
+  let previousIndex = elements.findIndex(isFocused) - 1;
+
+  if (previousIndex < 0) {
+    return false;
+  }
+
+  if (elements[previousIndex].focusLast) {
+    elements[previousIndex].focusLast();
+
+    return true;
+  } else if (elements[previousIndex].focus) {
+    elements[previousIndex].focus();
+
+    return true;
+  }
+
+  return false;
+};

--- a/examples/LonaViewer/web/src/App.js
+++ b/examples/LonaViewer/web/src/App.js
@@ -31,7 +31,7 @@ class App extends Component {
         />
         <AccessibilityNested
           ref={this.accessibilityNested}
-          onFocusNext={() => this.accessibilityTest.current.focus()}
+          onFocusExitNext={() => this.accessibilityTest.current.focus()}
           isChecked={this.state.checked}
           onChangeChecked={() =>
             this.setState({ checked: !this.state.checked })
@@ -39,8 +39,10 @@ class App extends Component {
         />
         <AccessibilityTest
           ref={this.accessibilityTest}
-          onFocusNext={() => this.accessibilityVisibility.current.focus()}
-          onFocusPrevious={() => this.accessibilityNested.current.focusLast()}
+          onFocusExitNext={() => this.accessibilityVisibility.current.focus()}
+          onFocusExitPrevious={() =>
+            this.accessibilityNested.current.focusLast()
+          }
           checkboxValue={this.state.checked}
           onToggleCheckbox={() =>
             this.setState({ checked: !this.state.checked })
@@ -48,7 +50,7 @@ class App extends Component {
         />
         <AccessibilityVisibility
           ref={this.accessibilityVisibility}
-          onFocusPrevious={() => this.accessibilityTest.current.focusLast()}
+          onFocusExitPrevious={() => this.accessibilityTest.current.focusLast()}
           showText={this.state.checked}
         />
         <div

--- a/examples/LonaViewer/web/src/App.js
+++ b/examples/LonaViewer/web/src/App.js
@@ -10,23 +10,6 @@ class App extends Component {
     checked: false
   };
 
-  handleKeyDown = event => {
-    if (event.key === "Tab" && document.activeElement === document.body) {
-      this.accessibilityNested.current.focus();
-
-      event.stopPropagation();
-      event.preventDefault();
-    }
-  };
-
-  componentDidMount() {
-    document.addEventListener("keydown", this.handleKeyDown);
-  }
-
-  componentWillUnmount() {
-    document.removeEventListener("keydown", this.handleKeyDown);
-  }
-
   accessibilityNested = React.createRef();
   accessibilityTest = React.createRef();
   accessibilityVisibility = React.createRef();
@@ -34,6 +17,18 @@ class App extends Component {
   render() {
     return (
       <div className="App">
+        <div
+          tabIndex={0}
+          style={styles.focusTrap}
+          onKeyDown={e => {
+            if (e.key === "Tab" && !e.shiftKey) {
+              this.accessibilityNested.current.focus();
+
+              e.stopPropagation();
+              e.preventDefault();
+            }
+          }}
+        />
         <AccessibilityNested
           ref={this.accessibilityNested}
           onFocusNext={() => this.accessibilityTest.current.focus()}
@@ -56,9 +51,29 @@ class App extends Component {
           onFocusPrevious={() => this.accessibilityTest.current.focusLast()}
           showText={this.state.checked}
         />
+        <div
+          tabIndex={0}
+          style={styles.focusTrap}
+          onKeyDown={e => {
+            if (e.key === "Tab" && e.shiftKey) {
+              this.accessibilityVisibility.current.focusLast();
+
+              e.stopPropagation();
+              e.preventDefault();
+            }
+          }}
+        />
       </div>
     );
   }
 }
 
 export default App;
+
+const styles = {
+  focusTrap: {
+    width: 200,
+    height: 10,
+    background: "green"
+  }
+};

--- a/examples/LonaViewer/web/src/App.js
+++ b/examples/LonaViewer/web/src/App.js
@@ -72,7 +72,6 @@ export default App;
 
 const styles = {
   focusTrap: {
-    width: 200,
     height: 10,
     background: "green"
   }

--- a/examples/generated/test/react-dom/interactivity/AccessibilityNested.js
+++ b/examples/generated/test/react-dom/interactivity/AccessibilityNested.js
@@ -53,8 +53,8 @@ export default class AccessibilityNested extends React.Component {
           event.stopPropagation()
           event.preventDefault()
           return ;
-        } else if (this.props.onFocusPrevious) {
-          this.props.onFocusPrevious()
+        } else if (this.props.onFocusExitPrevious) {
+          this.props.onFocusExitPrevious()
 
           event.stopPropagation()
           event.preventDefault()
@@ -64,8 +64,8 @@ export default class AccessibilityNested extends React.Component {
         event.stopPropagation()
         event.preventDefault()
         return ;
-      } else if (this.props.onFocusNext) {
-        this.props.onFocusNext()
+      } else if (this.props.onFocusExitNext) {
+        this.props.onFocusExitNext()
 
         event.stopPropagation()
         event.preventDefault()

--- a/examples/generated/test/react-dom/interactivity/AccessibilityNested.js
+++ b/examples/generated/test/react-dom/interactivity/AccessibilityNested.js
@@ -23,45 +23,25 @@ export default class AccessibilityNested extends React.Component {
   focus = ({ focusRing = true } = { focusRing: true }) => {
     this.setFocusRing(focusRing)
 
-    focusFirst(this._getFocusElements())
+    return focusFirst(this._getFocusElements());
   }
 
   focusLast = ({ focusRing = true } = { focusRing: true }) => {
     this.setFocusRing(focusRing)
 
-    focusLast(this._getFocusElements())
+    return focusLast(this._getFocusElements());
   }
 
   focusNext = ({ focusRing = true } = { focusRing: true }) => {
     this.setFocusRing(focusRing)
 
-    if (focusNext(this._getFocusElements())) {
-      return true;
-    }
-
-    if (this.props.onFocusNext) {
-      this.props.onFocusNext()
-
-      return true;
-    }
-
-    return false;
+    return focusNext(this._getFocusElements());
   }
 
   focusPrevious = ({ focusRing = true } = { focusRing: true }) => {
     this.setFocusRing(focusRing)
 
-    if (focusPrevious(this._getFocusElements())) {
-      return true;
-    }
-
-    if (this.props.onFocusPrevious) {
-      this.props.onFocusPrevious()
-
-      return true;
-    }
-
-    return false;
+    return focusPrevious(this._getFocusElements());
   }
 
   _handleKeyDown = (event) => {
@@ -73,8 +53,20 @@ export default class AccessibilityNested extends React.Component {
           event.stopPropagation()
           event.preventDefault()
           return ;
+        } else if (this.props.onFocusPrevious) {
+          this.props.onFocusPrevious()
+
+          event.stopPropagation()
+          event.preventDefault()
+          return ;
         }
       } else if (this.focusNext()) {
+        event.stopPropagation()
+        event.preventDefault()
+        return ;
+      } else if (this.props.onFocusNext) {
+        this.props.onFocusNext()
+
         event.stopPropagation()
         event.preventDefault()
         return ;
@@ -111,8 +103,6 @@ export default class AccessibilityNested extends React.Component {
             tabIndex={-1}
             focusRing={this.state.focusRing}
             onKeyDown={this._handleKeyDown}
-            onFocusNext={this.props.onFocusNext && this.focusNext}
-            onFocusPrevious={this.props.onFocusPrevious && this.focusPrevious}
             ref={(ref) => { this._AccessibilityTest = ref }}
 
           />
@@ -123,8 +113,6 @@ export default class AccessibilityNested extends React.Component {
             tabIndex={-1}
             focusRing={this.state.focusRing}
             onKeyDown={this._handleKeyDown}
-            onFocusNext={this.props.onFocusNext && this.focusNext}
-            onFocusPrevious={this.props.onFocusPrevious && this.focusPrevious}
             ref={(ref) => { this._AccessibilityVisibility = ref }}
 
           />

--- a/examples/generated/test/react-dom/interactivity/AccessibilityTest.js
+++ b/examples/generated/test/react-dom/interactivity/AccessibilityTest.js
@@ -5,7 +5,8 @@ import colors from "../colors"
 import shadows from "../shadows"
 import textStyles from "../textStyles"
 import createActivatableComponent from "../utils/createActivatableComponent"
-import { isFocused } from "../utils/focusUtils"
+import { isFocused, focusFirst, focusLast, focusNext, focusPrevious } from
+  "../utils/focusUtils"
 
 export default class AccessibilityTest extends React.Component {
   state = { focusRing: false }
@@ -21,54 +22,45 @@ export default class AccessibilityTest extends React.Component {
   focus = ({ focusRing = true } = { focusRing: true }) => {
     this.setFocusRing(focusRing)
 
-    let focusElements = this._getFocusElements()
-    if (focusElements[0] && focusElements[0].focus) {
-      focusElements[0].focus()
-    }
+    focusFirst(this._getFocusElements())
   }
 
   focusLast = ({ focusRing = true } = { focusRing: true }) => {
     this.setFocusRing(focusRing)
 
-    let focusElements = this._getFocusElements()
-    let lastElement = focusElements[focusElements.length - 1]
-    if (lastElement && lastElement.focusLast) {
-      lastElement.focusLast()
-    } else if (lastElement && lastElement.focus) {
-      lastElement.focus()
-    }
+    focusLast(this._getFocusElements())
   }
 
   focusNext = ({ focusRing = true } = { focusRing: true }) => {
     this.setFocusRing(focusRing)
 
-    let focusElements = this._getFocusElements()
-    let nextIndex = focusElements.findIndex(isFocused) + 1
-
-    if (nextIndex >= focusElements.length) {
-      this.props.onFocusNext && this.props.onFocusNext()
-      return ;
+    if (focusNext(this._getFocusElements())) {
+      return true;
     }
 
-    focusElements[nextIndex].focus && focusElements[nextIndex].focus()
+    if (this.props.onFocusNext) {
+      this.props.onFocusNext()
+
+      return true;
+    }
+
+    return false;
   }
 
   focusPrevious = ({ focusRing = true } = { focusRing: true }) => {
     this.setFocusRing(focusRing)
 
-    let focusElements = this._getFocusElements()
-    let previousIndex = focusElements.findIndex(isFocused) - 1
-
-    if (previousIndex < 0) {
-      this.props.onFocusPrevious && this.props.onFocusPrevious()
-      return ;
+    if (focusPrevious(this._getFocusElements())) {
+      return true;
     }
 
-    if (focusElements[previousIndex].focusLast) {
-      focusElements[previousIndex].focusLast()
-    } else {
-      focusElements[previousIndex].focus && focusElements[previousIndex].focus()
+    if (this.props.onFocusPrevious) {
+      this.props.onFocusPrevious()
+
+      return true;
     }
+
+    return false;
   }
 
   _handleKeyDown = (event) => {
@@ -76,13 +68,20 @@ export default class AccessibilityTest extends React.Component {
       this.setFocusRing(true)
 
       if (event.shiftKey) {
-        this.focusPrevious()
-      } else {
-        this.focusNext()
+        if (this.focusPrevious()) {
+          event.stopPropagation()
+          event.preventDefault()
+          return ;
+        }
+      } else if (this.focusNext()) {
+        event.stopPropagation()
+        event.preventDefault()
+        return ;
       }
+    }
 
-      event.stopPropagation()
-      event.preventDefault()
+    if (this.props.onKeyDown) {
+      this.props.onKeyDown(event)
     }
   }
 

--- a/examples/generated/test/react-dom/interactivity/AccessibilityTest.js
+++ b/examples/generated/test/react-dom/interactivity/AccessibilityTest.js
@@ -52,8 +52,8 @@ export default class AccessibilityTest extends React.Component {
           event.stopPropagation()
           event.preventDefault()
           return ;
-        } else if (this.props.onFocusPrevious) {
-          this.props.onFocusPrevious()
+        } else if (this.props.onFocusExitPrevious) {
+          this.props.onFocusExitPrevious()
 
           event.stopPropagation()
           event.preventDefault()
@@ -63,8 +63,8 @@ export default class AccessibilityTest extends React.Component {
         event.stopPropagation()
         event.preventDefault()
         return ;
-      } else if (this.props.onFocusNext) {
-        this.props.onFocusNext()
+      } else if (this.props.onFocusExitNext) {
+        this.props.onFocusExitNext()
 
         event.stopPropagation()
         event.preventDefault()

--- a/examples/generated/test/react-dom/interactivity/AccessibilityTest.js
+++ b/examples/generated/test/react-dom/interactivity/AccessibilityTest.js
@@ -22,45 +22,25 @@ export default class AccessibilityTest extends React.Component {
   focus = ({ focusRing = true } = { focusRing: true }) => {
     this.setFocusRing(focusRing)
 
-    focusFirst(this._getFocusElements())
+    return focusFirst(this._getFocusElements());
   }
 
   focusLast = ({ focusRing = true } = { focusRing: true }) => {
     this.setFocusRing(focusRing)
 
-    focusLast(this._getFocusElements())
+    return focusLast(this._getFocusElements());
   }
 
   focusNext = ({ focusRing = true } = { focusRing: true }) => {
     this.setFocusRing(focusRing)
 
-    if (focusNext(this._getFocusElements())) {
-      return true;
-    }
-
-    if (this.props.onFocusNext) {
-      this.props.onFocusNext()
-
-      return true;
-    }
-
-    return false;
+    return focusNext(this._getFocusElements());
   }
 
   focusPrevious = ({ focusRing = true } = { focusRing: true }) => {
     this.setFocusRing(focusRing)
 
-    if (focusPrevious(this._getFocusElements())) {
-      return true;
-    }
-
-    if (this.props.onFocusPrevious) {
-      this.props.onFocusPrevious()
-
-      return true;
-    }
-
-    return false;
+    return focusPrevious(this._getFocusElements());
   }
 
   _handleKeyDown = (event) => {
@@ -72,8 +52,20 @@ export default class AccessibilityTest extends React.Component {
           event.stopPropagation()
           event.preventDefault()
           return ;
+        } else if (this.props.onFocusPrevious) {
+          this.props.onFocusPrevious()
+
+          event.stopPropagation()
+          event.preventDefault()
+          return ;
         }
       } else if (this.focusNext()) {
+        event.stopPropagation()
+        event.preventDefault()
+        return ;
+      } else if (this.props.onFocusNext) {
+        this.props.onFocusNext()
+
         event.stopPropagation()
         event.preventDefault()
         return ;

--- a/examples/generated/test/react-dom/interactivity/AccessibilityVisibility.js
+++ b/examples/generated/test/react-dom/interactivity/AccessibilityVisibility.js
@@ -51,8 +51,8 @@ export default class AccessibilityVisibility extends React.Component {
           event.stopPropagation()
           event.preventDefault()
           return ;
-        } else if (this.props.onFocusPrevious) {
-          this.props.onFocusPrevious()
+        } else if (this.props.onFocusExitPrevious) {
+          this.props.onFocusExitPrevious()
 
           event.stopPropagation()
           event.preventDefault()
@@ -62,8 +62,8 @@ export default class AccessibilityVisibility extends React.Component {
         event.stopPropagation()
         event.preventDefault()
         return ;
-      } else if (this.props.onFocusNext) {
-        this.props.onFocusNext()
+      } else if (this.props.onFocusExitNext) {
+        this.props.onFocusExitNext()
 
         event.stopPropagation()
         event.preventDefault()

--- a/examples/generated/test/react-dom/interactivity/AccessibilityVisibility.js
+++ b/examples/generated/test/react-dom/interactivity/AccessibilityVisibility.js
@@ -21,45 +21,25 @@ export default class AccessibilityVisibility extends React.Component {
   focus = ({ focusRing = true } = { focusRing: true }) => {
     this.setFocusRing(focusRing)
 
-    focusFirst(this._getFocusElements())
+    return focusFirst(this._getFocusElements());
   }
 
   focusLast = ({ focusRing = true } = { focusRing: true }) => {
     this.setFocusRing(focusRing)
 
-    focusLast(this._getFocusElements())
+    return focusLast(this._getFocusElements());
   }
 
   focusNext = ({ focusRing = true } = { focusRing: true }) => {
     this.setFocusRing(focusRing)
 
-    if (focusNext(this._getFocusElements())) {
-      return true;
-    }
-
-    if (this.props.onFocusNext) {
-      this.props.onFocusNext()
-
-      return true;
-    }
-
-    return false;
+    return focusNext(this._getFocusElements());
   }
 
   focusPrevious = ({ focusRing = true } = { focusRing: true }) => {
     this.setFocusRing(focusRing)
 
-    if (focusPrevious(this._getFocusElements())) {
-      return true;
-    }
-
-    if (this.props.onFocusPrevious) {
-      this.props.onFocusPrevious()
-
-      return true;
-    }
-
-    return false;
+    return focusPrevious(this._getFocusElements());
   }
 
   _handleKeyDown = (event) => {
@@ -71,8 +51,20 @@ export default class AccessibilityVisibility extends React.Component {
           event.stopPropagation()
           event.preventDefault()
           return ;
+        } else if (this.props.onFocusPrevious) {
+          this.props.onFocusPrevious()
+
+          event.stopPropagation()
+          event.preventDefault()
+          return ;
         }
       } else if (this.focusNext()) {
+        event.stopPropagation()
+        event.preventDefault()
+        return ;
+      } else if (this.props.onFocusNext) {
+        this.props.onFocusNext()
+
         event.stopPropagation()
         event.preventDefault()
         return ;

--- a/examples/generated/test/react-dom/interactivity/AccessibilityVisibility.js
+++ b/examples/generated/test/react-dom/interactivity/AccessibilityVisibility.js
@@ -4,7 +4,8 @@ import styled from "styled-components"
 import colors from "../colors"
 import shadows from "../shadows"
 import textStyles from "../textStyles"
-import { isFocused } from "../utils/focusUtils"
+import { isFocused, focusFirst, focusLast, focusNext, focusPrevious } from
+  "../utils/focusUtils"
 
 export default class AccessibilityVisibility extends React.Component {
   state = { focusRing: false }
@@ -20,54 +21,45 @@ export default class AccessibilityVisibility extends React.Component {
   focus = ({ focusRing = true } = { focusRing: true }) => {
     this.setFocusRing(focusRing)
 
-    let focusElements = this._getFocusElements()
-    if (focusElements[0] && focusElements[0].focus) {
-      focusElements[0].focus()
-    }
+    focusFirst(this._getFocusElements())
   }
 
   focusLast = ({ focusRing = true } = { focusRing: true }) => {
     this.setFocusRing(focusRing)
 
-    let focusElements = this._getFocusElements()
-    let lastElement = focusElements[focusElements.length - 1]
-    if (lastElement && lastElement.focusLast) {
-      lastElement.focusLast()
-    } else if (lastElement && lastElement.focus) {
-      lastElement.focus()
-    }
+    focusLast(this._getFocusElements())
   }
 
   focusNext = ({ focusRing = true } = { focusRing: true }) => {
     this.setFocusRing(focusRing)
 
-    let focusElements = this._getFocusElements()
-    let nextIndex = focusElements.findIndex(isFocused) + 1
-
-    if (nextIndex >= focusElements.length) {
-      this.props.onFocusNext && this.props.onFocusNext()
-      return ;
+    if (focusNext(this._getFocusElements())) {
+      return true;
     }
 
-    focusElements[nextIndex].focus && focusElements[nextIndex].focus()
+    if (this.props.onFocusNext) {
+      this.props.onFocusNext()
+
+      return true;
+    }
+
+    return false;
   }
 
   focusPrevious = ({ focusRing = true } = { focusRing: true }) => {
     this.setFocusRing(focusRing)
 
-    let focusElements = this._getFocusElements()
-    let previousIndex = focusElements.findIndex(isFocused) - 1
-
-    if (previousIndex < 0) {
-      this.props.onFocusPrevious && this.props.onFocusPrevious()
-      return ;
+    if (focusPrevious(this._getFocusElements())) {
+      return true;
     }
 
-    if (focusElements[previousIndex].focusLast) {
-      focusElements[previousIndex].focusLast()
-    } else {
-      focusElements[previousIndex].focus && focusElements[previousIndex].focus()
+    if (this.props.onFocusPrevious) {
+      this.props.onFocusPrevious()
+
+      return true;
     }
+
+    return false;
   }
 
   _handleKeyDown = (event) => {
@@ -75,13 +67,20 @@ export default class AccessibilityVisibility extends React.Component {
       this.setFocusRing(true)
 
       if (event.shiftKey) {
-        this.focusPrevious()
-      } else {
-        this.focusNext()
+        if (this.focusPrevious()) {
+          event.stopPropagation()
+          event.preventDefault()
+          return ;
+        }
+      } else if (this.focusNext()) {
+        event.stopPropagation()
+        event.preventDefault()
+        return ;
       }
+    }
 
-      event.stopPropagation()
-      event.preventDefault()
+    if (this.props.onKeyDown) {
+      this.props.onKeyDown(event)
     }
   }
 

--- a/examples/generated/test/react-dom/utils/focusUtils.js
+++ b/examples/generated/test/react-dom/utils/focusUtils.js
@@ -5,3 +5,65 @@ export const isFocused = componentOrDomNode => {
 
   return componentOrDomNode === document.activeElement;
 };
+
+export const focusFirst = elements => {
+  if (elements[0] && elements[0].focus) {
+    elements[0].focus();
+
+    return true;
+  }
+
+  return false;
+};
+
+export const focusLast = elements => {
+  let lastElement = elements[elements.length - 1];
+
+  if (lastElement && lastElement.focusLast) {
+    lastElement.focusLast();
+
+    return true;
+  } else if (lastElement && lastElement.focus) {
+    lastElement.focus();
+
+    return true;
+  }
+
+  return false;
+};
+
+export const focusNext = elements => {
+  let nextIndex = elements.findIndex(isFocused) + 1;
+
+  if (nextIndex >= elements.length) {
+    return false;
+  }
+
+  if (elements[nextIndex].focus) {
+    elements[nextIndex].focus();
+
+    return true;
+  }
+
+  return false;
+};
+
+export const focusPrevious = elements => {
+  let previousIndex = elements.findIndex(isFocused) - 1;
+
+  if (previousIndex < 0) {
+    return false;
+  }
+
+  if (elements[previousIndex].focusLast) {
+    elements[previousIndex].focusLast();
+
+    return true;
+  } else if (elements[previousIndex].focus) {
+    elements[previousIndex].focus();
+
+    return true;
+  }
+
+  return false;
+};

--- a/studio/docs/accessibility.md
+++ b/studio/docs/accessibility.md
@@ -175,13 +175,13 @@ To focus a component, you'll need to store a React `ref` to that component. Comp
 
 #### Component methods
 
-- **`focus(options)`** - Call this method to focus the first focusable DOM node in the component.
+- **`focus(options)`** - Call this method to focus the first focusable DOM node in the component. Returns true if a DOM node was focused and false otherwise.
 
-- **`focusLast(options)`** - Call this method to focus the last focusable DOM node in the component.
+- **`focusLast(options)`** - Call this method to focus the last focusable DOM node in the component. Returns true if a DOM node was focused and false otherwise.
 
-- **`focusNext(options)`** - Call this method to focus the next focusable DOM node in the component. If focus is not currently on a DOM node within this component, then the first focusable node is focused. If focus is on the last node within this component, focus is not changed, and instead the `onFocusNext` prop is called.
+- **`focusNext(options)`** - Call this method to focus the next focusable DOM node in the component. If focus is not currently on a DOM node within this component, then the first focusable node is focused. If focus is on the last node within this component, focus is not changed. Returns true if a DOM node was focused and false otherwise.
 
-- **`focusPrevious(options)`** - Call this method to focus the previous focusable DOM node in the component. If focus is on the first node within this component, focus is not changed, and instead the `onFocusPrevious` prop is called.
+- **`focusPrevious(options)`** - Call this method to focus the previous focusable DOM node in the component. If focus is on the first node within this component, focus is not changed. Returns true if a DOM node was focused and false otherwise.
 
 Each of these methods can be passed an `options` object, containing:
 
@@ -193,9 +193,9 @@ By default, clicking on a focusable DOM node will _not_ show the focus ring. Onl
 
 Components that contain accessible layers may be passed the following props:
 
-- **`onFocusNext`** _(function)_ - This function is called when the focus is on the last focusable DOM node within the component and the user presses `Tab`. Within this callback, you should programatically set focus on the next component in the UI.
+- **`onFocusExitNext`** _(function)_ - This function is called when the focus is on the last focusable DOM node within the component and the user presses `Tab`. Within this callback, you can programatically set focus on the next component in the UI. This prop is for convenience -- if you don't pass this prop, the tab key event will bubble as normal, and you can handle it in either the `onKeyDown` prop of this component or a parent component.
 
-- **`onFocusPrevious`** _(function)_ - This function is called when the focus is on the first focusable DOM node within the component and the user presses `Shift+Tab`. Within this callback, you should programatically set focus on the previous component in the UI.
+- **`onFocusExitPrevious`** _(function)_ - This function is called when the focus is on the first focusable DOM node within the component and the user presses `Shift+Tab`. Within this callback, you can programatically set focus on the previous component in the UI. This prop is for convenience -- if you don't pass this prop, the tab key event will bubble as normal, and you can handle it in either the `onKeyDown` prop of this component or a parent component.
 
 ### React Native
 


### PR DESCRIPTION
## What

This simplifies focus handling by relying more on browser keyboard order. The `onFocusNext` and `onFocusPrevious` props are now optional and just for convenience. I renamed them to `onFocusExitNext` and `onFocusExitPrevious`.

cc @outdooricon 