### PR TITLE
Use classNames to style JS DOM focus ring

### DIFF
--- a/compiler/core/src/javaScript/javaScriptComponent.re
+++ b/compiler/core/src/javaScript/javaScriptComponent.re
@@ -159,7 +159,6 @@ module StyledComponents = {
         rootLayer: Types.layer,
         layer: Types.layer,
       ) => {
-    let usesProps = JavaScriptLayer.canBeFocused(config, layer);
     let styles =
       JavaScriptStyles.Object.forLayer(
         config,
@@ -208,7 +207,7 @@ module StyledComponents = {
                     };
                   },
                 ]),
-              arguments: [usesProps ? createPropsFunction(styles) : styles],
+              arguments: [styles],
             }),
         }),
       )
@@ -630,8 +629,11 @@ let rec layerToJavaScriptAST =
               value: Literal(LonaValue.number(-1.)),
             }),
             JSXAttribute({
-              name: "focusRing",
-              value: Identifier(["this", "state", "focusRing"]),
+              name: "className",
+              value:
+                Identifier([
+                  "this.state.focusRing ? 'lona--focus-ring' : 'lona--no-focus-ring'",
+                ]),
             }),
             JSXAttribute({
               name: "onKeyDown",

--- a/compiler/core/src/javaScript/javaScriptStyles.re
+++ b/compiler/core/src/javaScript/javaScriptStyles.re
@@ -563,25 +563,6 @@ module Object = {
                getStylePropertyWithUnits(config, framework, key, value)
              )
         )
-        @ (
-          switch (focusStyles(config, layer)) {
-          | Some(property) => [
-              SpreadElement(
-                UnaryExpression({
-                  prefix: true,
-                  operator: "!",
-                  argument:
-                    BinaryExpression({
-                      left: Identifier(["props", "focusRing"]),
-                      operator: And,
-                      right: ObjectLiteral([property]),
-                    }),
-                }),
-              ),
-            ]
-          | None => []
-          }
-        ),
       )
     );
   };

--- a/examples/LonaViewer/web/src/index.css
+++ b/examples/LonaViewer/web/src/index.css
@@ -20,3 +20,7 @@ code {
   border-style: solid;
   border-width: 0;
 }
+
+.lona--no-focus-ring:focus {
+  outline: none;
+}

--- a/examples/generated/test/react-dom/interactivity/AccessibilityNested.js
+++ b/examples/generated/test/react-dom/interactivity/AccessibilityNested.js
@@ -101,7 +101,7 @@ export default class AccessibilityNested extends React.Component {
             customTextAccessibilityLabel={"Text"}
             onToggleCheckbox={AccessibilityTest$onToggleCheckbox}
             tabIndex={-1}
-            focusRing={this.state.focusRing}
+            className={this.state.focusRing ? 'lona--focus-ring' : 'lona--no-focus-ring'}
             onKeyDown={this._handleKeyDown}
             ref={(ref) => { this._AccessibilityTest = ref }}
 
@@ -111,7 +111,7 @@ export default class AccessibilityNested extends React.Component {
           <AccessibilityVisibility
             showText={AccessibilityVisibility$showText}
             tabIndex={-1}
-            focusRing={this.state.focusRing}
+            className={this.state.focusRing ? 'lona--focus-ring' : 'lona--no-focus-ring'}
             onKeyDown={this._handleKeyDown}
             ref={(ref) => { this._AccessibilityVisibility = ref }}
 
@@ -130,22 +130,20 @@ let Container = styled.div({
   justifyContent: "flex-start"
 })
 
-let AccessibilityTestAccessibilityTestWrapper = styled.div((props) => ({
+let AccessibilityTestAccessibilityTestWrapper = styled.div({
   alignItems: "flex-start",
   alignSelf: "stretch",
   display: "flex",
   flex: "1 1 auto",
   flexDirection: "row",
-  justifyContent: "flex-start",
-  ...!props.focusRing && { ":focus": { outline: 0 } }
-}))
+  justifyContent: "flex-start"
+})
 
-let AccessibilityVisibilityAccessibilityVisibilityWrapper = styled.div((props) => ({
+let AccessibilityVisibilityAccessibilityVisibilityWrapper = styled.div({
   alignItems: "flex-start",
   alignSelf: "stretch",
   display: "flex",
   flex: "1 1 auto",
   flexDirection: "row",
-  justifyContent: "flex-start",
-  ...!props.focusRing && { ":focus": { outline: 0 } }
-}))
+  justifyContent: "flex-start"
+})

--- a/examples/generated/test/react-dom/interactivity/AccessibilityTest.js
+++ b/examples/generated/test/react-dom/interactivity/AccessibilityTest.js
@@ -121,7 +121,7 @@ export default class AccessibilityTest extends React.Component {
           onAccessibilityActivate={CheckboxRow$onAccessibilityActivate}
           aria-checked={CheckboxRow$accessibilityChecked}
           tabIndex={-1}
-          focusRing={this.state.focusRing}
+          className={this.state.focusRing ? 'lona--focus-ring' : 'lona--no-focus-ring'}
           onKeyDown={this._handleKeyDown}
           ref={(ref) => { this._CheckboxRow = ref }}
         >
@@ -137,7 +137,7 @@ export default class AccessibilityTest extends React.Component {
             aria-label={"Red box"}
             role={"button"}
             tabIndex={-1}
-            focusRing={this.state.focusRing}
+            className={this.state.focusRing ? 'lona--focus-ring' : 'lona--no-focus-ring'}
             onKeyDown={this._handleKeyDown}
             ref={(ref) => { this._Element = ref }}
           >
@@ -148,7 +148,7 @@ export default class AccessibilityTest extends React.Component {
               src={require("../assets/icon_128x128.png")}
               aria-label={"My image"}
               tabIndex={-1}
-              focusRing={this.state.focusRing}
+              className={this.state.focusRing ? 'lona--focus-ring' : 'lona--no-focus-ring'}
               onKeyDown={this._handleKeyDown}
               ref={(ref) => { this._Image = ref }}
 
@@ -156,7 +156,7 @@ export default class AccessibilityTest extends React.Component {
             <AccessibleText
               aria-label={AccessibleText$accessibilityLabel}
               tabIndex={-1}
-              focusRing={this.state.focusRing}
+              className={this.state.focusRing ? 'lona--focus-ring' : 'lona--no-focus-ring'}
               onKeyDown={this._handleKeyDown}
               ref={(ref) => { this._AccessibleText = ref }}
             >
@@ -177,7 +177,7 @@ let View = styled.div({
   justifyContent: "flex-start"
 })
 
-let CheckboxRow = styled.div((props) => ({
+let CheckboxRow = styled.div({
   alignItems: "center",
   alignSelf: "stretch",
   display: "flex",
@@ -187,9 +187,8 @@ let CheckboxRow = styled.div((props) => ({
   paddingTop: "10px",
   paddingRight: "10px",
   paddingBottom: "10px",
-  paddingLeft: "10px",
-  ...!props.focusRing && { ":focus": { outline: 0 } }
-}))
+  paddingLeft: "10px"
+})
 
 let Checkbox = styled.div({
   alignItems: "flex-start",
@@ -243,7 +242,7 @@ let Row1 = styled.div({
   paddingLeft: "10px"
 })
 
-let Element = styled.div((props) => ({
+let Element = styled.div({
   alignItems: "flex-start",
   backgroundColor: colors.red600,
   display: "flex",
@@ -255,9 +254,8 @@ let Element = styled.div((props) => ({
   paddingBottom: "10px",
   paddingLeft: "10px",
   width: "50px",
-  height: "50px",
-  ...!props.focusRing && { ":focus": { outline: 0 } }
-}))
+  height: "50px"
+})
 
 let Inner = styled.div({
   alignItems: "flex-start",
@@ -277,7 +275,7 @@ let Container = styled.div({
   justifyContent: "flex-start"
 })
 
-let Image = styled.img((props) => ({
+let Image = styled.img({
   alignItems: "flex-start",
   display: "flex",
   flexDirection: "column",
@@ -287,19 +285,17 @@ let Image = styled.img((props) => ({
   width: "50px",
   height: "50px",
   objectFit: "cover",
-  position: "relative",
-  ...!props.focusRing && { ":focus": { outline: 0 } }
-}))
+  position: "relative"
+})
 
-let AccessibleText = styled.span((props) => ({
+let AccessibleText = styled.span({
   textAlign: "left",
   ...textStyles.body1,
   alignItems: "flex-start",
   display: "block",
   flex: "0 0 auto",
   flexDirection: "column",
-  justifyContent: "flex-start",
-  ...!props.focusRing && { ":focus": { outline: 0 } }
-}))
+  justifyContent: "flex-start"
+})
 
 let CheckboxRowAccessibilityWrapper = createActivatableComponent(CheckboxRow)

--- a/examples/generated/test/react-dom/interactivity/AccessibilityVisibility.js
+++ b/examples/generated/test/react-dom/interactivity/AccessibilityVisibility.js
@@ -92,7 +92,7 @@ export default class AccessibilityVisibility extends React.Component {
         <GreyBox
           aria-label={"Grey box"}
           tabIndex={-1}
-          focusRing={this.state.focusRing}
+          className={this.state.focusRing ? 'lona--focus-ring' : 'lona--no-focus-ring'}
           onKeyDown={this._handleKeyDown}
           ref={(ref) => { this._GreyBox = ref }}
 
@@ -102,7 +102,7 @@ export default class AccessibilityVisibility extends React.Component {
           <Text
             aria-label={"Some text that is sometimes hidden"}
             tabIndex={-1}
-            focusRing={this.state.focusRing}
+            className={this.state.focusRing ? 'lona--focus-ring' : 'lona--no-focus-ring'}
             onKeyDown={this._handleKeyDown}
             ref={(ref) => { this._Text = ref }}
           >
@@ -122,24 +122,22 @@ let View = styled.div({
   justifyContent: "flex-start"
 })
 
-let GreyBox = styled.div((props) => ({
+let GreyBox = styled.div({
   alignItems: "flex-start",
   backgroundColor: "#D8D8D8",
   display: "flex",
   flexDirection: "column",
   justifyContent: "flex-start",
   width: "100px",
-  height: "40px",
-  ...!props.focusRing && { ":focus": { outline: 0 } }
-}))
+  height: "40px"
+})
 
-let Text = styled.span((props) => ({
+let Text = styled.span({
   textAlign: "left",
   ...textStyles.body1,
   alignItems: "flex-start",
   display: "block",
   flex: "0 0 auto",
   flexDirection: "column",
-  justifyContent: "flex-start",
-  ...!props.focusRing && { ":focus": { outline: 0 } }
-}))
+  justifyContent: "flex-start"
+})

--- a/examples/generated/test/sketchJs/interactivity/AccessibilityNested.js
+++ b/examples/generated/test/sketchJs/interactivity/AccessibilityNested.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { View, StyleSheet, TextStyles } from "@mathieudutour/react-sketchapp"
+import { View, StyleSheet, TextStyles } from "react-sketchapp"
 
 import colors from "../colors"
 import shadows from "../shadows"

--- a/examples/generated/test/sketchJs/interactivity/AccessibilityTest.js
+++ b/examples/generated/test/sketchJs/interactivity/AccessibilityTest.js
@@ -1,6 +1,5 @@
 import React from "react"
-import { Image, Text, View, StyleSheet, TextStyles } from
-  "@mathieudutour/react-sketchapp"
+import { Image, Text, View, StyleSheet, TextStyles } from "react-sketchapp"
 
 import colors from "../colors"
 import shadows from "../shadows"

--- a/examples/generated/test/sketchJs/interactivity/AccessibilityVisibility.js
+++ b/examples/generated/test/sketchJs/interactivity/AccessibilityVisibility.js
@@ -1,6 +1,5 @@
 import React from "react"
-import { Text, View, StyleSheet, TextStyles } from
-  "@mathieudutour/react-sketchapp"
+import { Text, View, StyleSheet, TextStyles } from "react-sketchapp"
 
 import colors from "../colors"
 import shadows from "../shadows"

--- a/examples/generated/test/sketchJs/style/BorderStyleTest.js
+++ b/examples/generated/test/sketchJs/style/BorderStyleTest.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { View, StyleSheet, TextStyles } from "@mathieudutour/react-sketchapp"
+import { View, StyleSheet, TextStyles } from "react-sketchapp"
 
 import colors from "../colors"
 import shadows from "../shadows"


### PR DESCRIPTION
## What

Support styled-components 3 (with minimal effort) by using classNames to style focus ring, instead of prop-based styled-components.

cc @outdooricon 