### PR TITLE
Support styled-components v3 by using innerRef

### DIFF
--- a/compiler/core/src/javaScript/javaScriptComponent.re
+++ b/compiler/core/src/javaScript/javaScriptComponent.re
@@ -650,7 +650,10 @@ let rec layerToJavaScriptAST =
       needsRef ?
         [
           JSXAttribute({
-            name: "ref",
+            name:
+              config.options.javaScript.styledComponentsVersion == V3
+              && Layer.isPrimitiveTypeName(layer.typeName) ?
+                "innerRef" : "ref",
             value:
               ArrowFunctionExpression({
                 id: None,

--- a/compiler/core/src/javaScript/javaScriptOptions.re
+++ b/compiler/core/src/javaScript/javaScriptOptions.re
@@ -8,8 +8,13 @@ type styleFramework =
   | None
   | StyledComponents;
 
+type styledComponentsVersion =
+  | V3
+  | Latest;
+
 [@bs.deriving jsConverter]
 type options = {
   framework,
   styleFramework,
+  styledComponentsVersion,
 };

--- a/compiler/core/src/main.re
+++ b/compiler/core/src/main.re
@@ -56,6 +56,11 @@ let javaScriptOptions: JavaScriptOptions.options = {
     | Some("styledcomponents") => JavaScriptOptions.StyledComponents
     | _ => JavaScriptOptions.None
     },
+  styledComponentsVersion:
+    switch (getArgument("styledComponentsVersion")) {
+    | Some(value) when Js.String.startsWith("3", value) => V3
+    | _ => Latest
+    },
 };
 
 let options: LonaCompilerCore.Options.options = {


### PR DESCRIPTION
## What

Adds a compiler flag, `--styledComponentsVersion=3`, which uses `innerRef` instead of `ref` on styled components.

@outdooricon 