### PR TITLE
Support ie11 via optional classname

### DIFF
--- a/compiler/core/src/javaScript/javaScriptComponent.re
+++ b/compiler/core/src/javaScript/javaScriptComponent.re
@@ -554,6 +554,8 @@ let createJSXElement =
   };
 };
 
+let ieFixClassname = "'lona--ie-flex-1-1-auto'";
+
 let rec layerToJavaScriptAST =
         (
           options: JavaScriptOptions.options,
@@ -612,6 +614,9 @@ let rec layerToJavaScriptAST =
            };
          JSXAttribute({name: key, value: attributeValue});
        });
+  let needsIeFix =
+    config.options.javaScript.minimumIeSupport == IE11
+    && JavaScriptStyles.needsIeFix(config, parent, layer);
   let attributes =
     attributes
     @ (
@@ -632,7 +637,8 @@ let rec layerToJavaScriptAST =
               name: "className",
               value:
                 Identifier([
-                  "this.state.focusRing ? 'lona--focus-ring' : 'lona--no-focus-ring'",
+                  "this.state.focusRing ? 'lona--focus-ring' : 'lona--no-focus-ring'"
+                  ++ (needsIeFix ? " + " ++ ieFixClassname : ""),
                 ]),
             }),
             JSXAttribute({
@@ -642,7 +648,17 @@ let rec layerToJavaScriptAST =
           ]
         | ReactSketchapp => []
         } :
-        []
+        (
+          switch (needsIeFix, config.options.javaScript.framework) {
+          | (true, ReactDOM) => [
+              JSXAttribute({
+                name: "className",
+                value: Identifier([ieFixClassname]),
+              }),
+            ]
+          | _ => []
+          }
+        )
     );
   let attributes =
     attributes

--- a/compiler/core/src/javaScript/javaScriptOptions.re
+++ b/compiler/core/src/javaScript/javaScriptOptions.re
@@ -12,9 +12,14 @@ type styledComponentsVersion =
   | V3
   | Latest;
 
+type minimumIeSupport =
+  | None
+  | IE11;
+
 [@bs.deriving jsConverter]
 type options = {
   framework,
   styleFramework,
   styledComponentsVersion,
+  minimumIeSupport,
 };

--- a/compiler/core/src/javaScript/javaScriptStyles.re
+++ b/compiler/core/src/javaScript/javaScriptStyles.re
@@ -393,6 +393,20 @@ let getLayoutParameters =
   };
 };
 
+let needsIeFix =
+    (config: Config.t, parent: option(Types.layer), layer: Types.layer): bool => {
+  let layoutParameters =
+    getLayoutParameters(config.options.javaScript.framework, parent, layer);
+  switch (ParameterMap.find_opt(Flex, layoutParameters)) {
+  | Some(lonaValue)
+      when
+        lonaValue.ltype == Types.stringType
+        && LonaValue.decodeString(lonaValue) == "1 1 0%" =>
+    true
+  | _ => false
+  };
+};
+
 let getStylePropertyWithUnits =
     (
       config: Config.t,
@@ -543,26 +557,24 @@ module Object = {
 
     JavaScriptAst.(
       ObjectLiteral(
-        (
-          layer.parameters
-          |> handleNumberOfLines(framework, config)
-          |> ParameterMap.assign(
-               handleBorderStyle(config, assignments, layer),
-             )
-          |> ParameterMap.filter((key, _) => Layer.parameterIsStyle(key))
-          /* Remove layout parameters stored in the component file */
-          |> ParameterMap.filter((key, _) =>
-               !List.mem(key, replacedLayoutKeys)
-             )
-          /* Add layout parameters appropriate for the framework */
-          |> ParameterMap.assign(_, layoutParameters)
-          |> ParameterMap.assign(defaultStyles(config, layer.typeName))
-          |> handleResizeMode(framework, config, parent, layer)
-          |> ParameterMap.bindings
-          |> List.map(((key, value)) =>
-               getStylePropertyWithUnits(config, framework, key, value)
-             )
-        )
+        layer.parameters
+        |> handleNumberOfLines(framework, config)
+        |> ParameterMap.assign(
+             handleBorderStyle(config, assignments, layer),
+           )
+        |> ParameterMap.filter((key, _) => Layer.parameterIsStyle(key))
+        /* Remove layout parameters stored in the component file */
+        |> ParameterMap.filter((key, _) =>
+             !List.mem(key, replacedLayoutKeys)
+           )
+        /* Add layout parameters appropriate for the framework */
+        |> ParameterMap.assign(_, layoutParameters)
+        |> ParameterMap.assign(defaultStyles(config, layer.typeName))
+        |> handleResizeMode(framework, config, parent, layer)
+        |> ParameterMap.bindings
+        |> List.map(((key, value)) =>
+             getStylePropertyWithUnits(config, framework, key, value)
+           ),
       )
     );
   };

--- a/compiler/core/src/main.re
+++ b/compiler/core/src/main.re
@@ -61,6 +61,11 @@ let javaScriptOptions: JavaScriptOptions.options = {
     | Some(value) when Js.String.startsWith("3", value) => V3
     | _ => Latest
     },
+  minimumIeSupport:
+    switch (getArgument("minimumIeSupport")) {
+    | Some("11") => IE11
+    | _ => None
+    },
 };
 
 let options: LonaCompilerCore.Options.options = {


### PR DESCRIPTION
## What

IE doesn't implement `flex: 1 1 0%` correctly, so we fall back to `flex: 1 1 auto`. We add a classname, `lona--ie-flex-1-1-auto`, to the elements that need this. It can then be targeted via CSS:

```css
@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
  .lona--ie-flex-1-1-auto {
    flex: 1 1 auto !important;
  }
}
```

Enable this with the CLI option `minimumIeSupport=11`

cc @outdooricon 