### PR TITLE
Update file tree to support create, move, and delete

### DIFF
--- a/studio/Cartfile.resolved
+++ b/studio/Cartfile.resolved
@@ -1,5 +1,6 @@
 github "dabbott/ColorPicker" "c1e637d2af9813ddba6a9b8e5e51f164780981ba"
 github "dabbott/ControlledComponents" "264729ba7769e8fd2a66eb4fad63fd6348eae767"
-github "dabbott/FileTree" "5b96e92a4a09f5cc3a2ac4efa744b8f1c1ad6b99"
+github "dabbott/FileTree" "d575c6fadc5723528b9ac413e6b864f3b2088c3a"
 github "dylan/colors" "0.9.10"
 github "njdehoog/Witness" "0.1.3"
+github "tonyarnold/Differ" "1.3.0"

--- a/studio/Cartfile.resolved
+++ b/studio/Cartfile.resolved
@@ -1,6 +1,6 @@
 github "dabbott/ColorPicker" "c1e637d2af9813ddba6a9b8e5e51f164780981ba"
 github "dabbott/ControlledComponents" "264729ba7769e8fd2a66eb4fad63fd6348eae767"
-github "dabbott/FileTree" "d575c6fadc5723528b9ac413e6b864f3b2088c3a"
+github "dabbott/FileTree" "999b773a14d19b8b4d70916f03095afd2be7a3d3"
 github "dylan/colors" "0.9.10"
 github "njdehoog/Witness" "0.1.3"
 github "tonyarnold/Differ" "1.3.0"

--- a/studio/LonaStudio.xcodeproj/project.pbxproj
+++ b/studio/LonaStudio.xcodeproj/project.pbxproj
@@ -247,6 +247,8 @@
 		6BD96653217FB0DB0012F173 /* default-workspace-thumbnail@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6BD96651217FB0DB0012F173 /* default-workspace-thumbnail@2x.png */; };
 		6BDF4D2E20A67272006E99C4 /* BrowserToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDF4D2D20A67272006E99C4 /* BrowserToolbar.swift */; };
 		6BE89BBC21B7452800F35AC3 /* LonaViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE89BBB21B7452800F35AC3 /* LonaViewModel.swift */; };
+		6BF894D32214E3DD000CD863 /* Differ.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6BF894D12214E3CD000CD863 /* Differ.framework */; };
+		6BF894D42214E3DD000CD863 /* Differ.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6BF894D12214E3CD000CD863 /* Differ.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		6BFC4E0621C9C5A10030938B /* CanvasInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFC4E0521C9C5A10030938B /* CanvasInspector.swift */; };
 		76AB58E053220594F098A3C5 /* Pods_LonaStudioTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EDA2F7370DB15639E08B399A /* Pods_LonaStudioTests.framework */; };
 		783A74CD337C61784E60C467 /* Pods_LonaStudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7949560983378CFD6EC6FFD5 /* Pods_LonaStudio.framework */; };
@@ -286,6 +288,7 @@
 				6BBE0F6B212B26C900CEE8C1 /* FileTree.framework in Embed Frameworks */,
 				6B2DC1AE21361C4700679668 /* Colors.framework in Embed Frameworks */,
 				6B2DC1AC21361C4700679668 /* ColorPicker.framework in Embed Frameworks */,
+				6BF894D42214E3DD000CD863 /* Differ.framework in Embed Frameworks */,
 				6B5886872134D6BB00CCA69F /* ControlledComponents.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -532,6 +535,7 @@
 		6BD96651217FB0DB0012F173 /* default-workspace-thumbnail@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "default-workspace-thumbnail@2x.png"; sourceTree = "<group>"; };
 		6BDF4D2D20A67272006E99C4 /* BrowserToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserToolbar.swift; sourceTree = "<group>"; };
 		6BE89BBB21B7452800F35AC3 /* LonaViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LonaViewModel.swift; sourceTree = "<group>"; };
+		6BF894D12214E3CD000CD863 /* Differ.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Differ.framework; path = Carthage/Build/Mac/Differ.framework; sourceTree = "<group>"; };
 		6BFC4E0521C9C5A10030938B /* CanvasInspector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CanvasInspector.swift; sourceTree = "<group>"; };
 		7949560983378CFD6EC6FFD5 /* Pods_LonaStudio.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_LonaStudio.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		834F922A5808C8E689B2FD19 /* Pods-LonaStudioTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LonaStudioTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-LonaStudioTests/Pods-LonaStudioTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -565,6 +569,7 @@
 				6BBE0F6A212B26C900CEE8C1 /* FileTree.framework in Frameworks */,
 				6B5886862134D6BB00CCA69F /* ControlledComponents.framework in Frameworks */,
 				6B2DC1AB21361C4700679668 /* ColorPicker.framework in Frameworks */,
+				6BF894D32214E3DD000CD863 /* Differ.framework in Frameworks */,
 				6B2DC1AD21361C4700679668 /* Colors.framework in Frameworks */,
 				783A74CD337C61784E60C467 /* Pods_LonaStudio.framework in Frameworks */,
 			);
@@ -950,6 +955,7 @@
 		391EE9FEA8350B93A55FBF6F /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				6BF894D12214E3CD000CD863 /* Differ.framework */,
 				6B2DC1A921361C4700679668 /* ColorPicker.framework */,
 				6B2DC1AA21361C4700679668 /* Colors.framework */,
 				6B5886852134D6BB00CCA69F /* ControlledComponents.framework */,
@@ -1357,7 +1363,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/SwiftLint/swiftlint\"";
+			shellScript = "\"${PODS_ROOT}/SwiftLint/swiftlint\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/studio/LonaStudio/Workspace/FileNavigator.swift
+++ b/studio/LonaStudio/Workspace/FileNavigator.swift
@@ -116,6 +116,8 @@ class FileNavigator: NSBox {
         fileTree.displayNameForFile = self.displayNameForFile
         fileTree.menuForFile = { [unowned self] path in self.menuForFile(atPath: path) }
 
+        fileTree.filterFiles = { path in !(path.hasPrefix(".") || path.hasPrefix("~")) }
+
         fileTree.onDeleteFile = { path, options in
             Swift.print("Deleted", path)
         }

--- a/studio/LonaStudio/Workspace/FileNavigator.swift
+++ b/studio/LonaStudio/Workspace/FileNavigator.swift
@@ -82,6 +82,21 @@ class FileNavigator: NSBox {
         set { fileTree.onAction = newValue }
     }
 
+    public var onDeleteFile: ((FileTree.Path, FileTree.FileEventOptions) -> Void)? {
+        get { return fileTree.onDeleteFile }
+        set { fileTree.onDeleteFile = newValue }
+    }
+
+    public var validateProposedMove: ((FileTree.Path, FileTree.Path) -> Bool)? {
+        get { return fileTree.validateProposedMove }
+        set { fileTree.validateProposedMove = newValue }
+    }
+
+    public var performMoveFile: ((FileTree.Path, FileTree.Path) -> Bool)? {
+        get { return fileTree.performMoveFile }
+        set { fileTree.performMoveFile = newValue }
+    }
+
     // MARK: - Private
 
     private var headerView = FileNavigatorHeaderWithMenu()
@@ -175,7 +190,7 @@ class FileNavigator: NSBox {
                     }
                 }
 
-                self.fileTree.reloadData()
+//                self.fileTree.reloadData()
             }))
         }
 

--- a/studio/LonaStudio/Workspace/FileNavigator.swift
+++ b/studio/LonaStudio/Workspace/FileNavigator.swift
@@ -113,9 +113,9 @@ class FileNavigator: NSBox {
         contentViewMargins = .zero
 
         fileTree.showRootFile = false
-        fileTree.rowViewForFile = { path, _ in self.rowViewForFile(atPath: path) }
-        fileTree.imageForFile = self.imageForFile
-        fileTree.displayNameForFile = self.displayNameForFile
+        fileTree.rowViewForFile = { [unowned self] path, _ in self.rowViewForFile(atPath: path) }
+        fileTree.imageForFile = { [unowned self] path, size in self.imageForFile(atPath: path, size: size) }
+        fileTree.displayNameForFile = { [unowned self] path in self.displayNameForFile(atPath: path) }
         fileTree.menuForFile = { [unowned self] path in self.menuForFile(atPath: path) }
         fileTree.filterFiles = { path in !(path.hasPrefix(".") || path.hasPrefix("~")) }
 

--- a/studio/LonaStudio/Workspace/WorkspaceViewController.swift
+++ b/studio/LonaStudio/Workspace/WorkspaceViewController.swift
@@ -329,48 +329,6 @@ class WorkspaceViewController: NSSplitViewController {
         splitView.autosaveName = NSSplitView.AutosaveName(rawValue: splitViewResorationIdentifier)
         splitView.identifier = NSUserInterfaceItemIdentifier(rawValue: splitViewResorationIdentifier)
 
-        fileNavigator.defaultFont = NSFont.systemFont(ofSize: NSFont.systemFontSize(for: .small))
-        fileNavigator.displayNameForFile = { path in
-            let url = URL(fileURLWithPath: path)
-            return url.pathExtension == "component" ? url.deletingPathExtension().lastPathComponent : url.lastPathComponent
-        }
-
-        fileNavigator.imageForFile = { path, size in
-            let url = URL(fileURLWithPath: path)
-
-            func defaultImage(for path: String) -> NSImage {
-                return NSWorkspace.shared.icon(forFile: path)
-            }
-
-            if url.pathExtension == "component" {
-                guard let component = LonaModule.current.component(named: url.deletingPathExtension().lastPathComponent),
-                    let canvas = component.computedCanvases().first,
-                    let caseItem = component.computedCases(for: canvas).first
-                    else { return defaultImage(for: path) }
-
-                let config = ComponentConfiguration(
-                    component: component,
-                    arguments: caseItem.value.objectValue,
-                    canvas: canvas
-                )
-
-                let canvasView = CanvasView(
-                    canvas: canvas,
-                    rootLayer: component.rootLayer,
-                    config: config,
-                    options: [RenderOption.assetScale(1)]
-                )
-
-                guard let data = canvasView.dataRepresentation(scaledBy: 0.25),
-                    let image = NSImage(data: data)
-                    else { return defaultImage(for: path) }
-                image.size = NSSize(width: size.width, height: (image.size.height / image.size.width) * size.height)
-                return image
-            } else {
-                return defaultImage(for: path)
-            }
-        }
-
         fileNavigator.onAction = self.openDocument
         directoryViewController.onSelectComponent = self.openDocument
     }


### PR DESCRIPTION
## What

The FIleTree framework now supports context menus and drag-and-drop. We use these to provide the following file operations:

- Show in Finder
- Create Folder
- Create Component
- Delete
- Move

This also fixes a crash when saving colors and textStyles, due to the OS creating and deleting a `~colors.json` automatically.

There are still some unusual bugs that can occur, but this is better than before in most ways.