### PR TITLE
Fix the component and types compiler commands

### DIFF
--- a/compiler/core/src/core/config.re
+++ b/compiler/core/src/core/config.re
@@ -104,9 +104,6 @@ module Workspace = {
         Js.String.replace("file://", "", path) : path;
     Node.Path.join2(config.workspacePath, path);
   };
-
-  let getRelativePathToOutputRoot = (config: t, outputPath: string): string =>
-    Node.Path.relative(~from=outputPath, ~to_=config.outputPath, ());
 };
 
 exception ComponentNotFound(string);

--- a/compiler/core/src/javaScript/javaScriptComponent.re
+++ b/compiler/core/src/javaScript/javaScriptComponent.re
@@ -790,7 +790,7 @@ let importComponents =
     (
       config: Config.t,
       options: JavaScriptOptions.options,
-      outputFile,
+      relativePathToWorkspaceRoot,
       getComponentFile,
       assignments,
       componentName,
@@ -901,10 +901,7 @@ let importComponents =
           [
             Ast.ImportDeclaration({
               source:
-                Config.Workspace.getRelativePathToOutputRoot(
-                  config,
-                  Node.Path.dirname(outputFile),
-                )
+                relativePathToWorkspaceRoot
                 ++ "/utils/createActivatableComponent",
               specifiers: [
                 Ast.ImportDefaultSpecifier("createActivatableComponent"),
@@ -919,12 +916,7 @@ let importComponents =
         if (framework == ReactDOM && importsFocusUtil) {
           [
             Ast.ImportDeclaration({
-              source:
-                Config.Workspace.getRelativePathToOutputRoot(
-                  config,
-                  Node.Path.dirname(outputFile),
-                )
-                ++ "/utils/focusUtils",
+              source: relativePathToWorkspaceRoot ++ "/utils/focusUtils",
               specifiers: [
                 Ast.ImportSpecifier({imported: "isFocused", local: None}),
                 Ast.ImportSpecifier({imported: "focusFirst", local: None}),
@@ -1067,7 +1059,7 @@ let generate =
       shadowsFilePath,
       textStylesFilePath,
       config: Config.t,
-      outputFile,
+      relativePathToWorkspaceRoot,
       getComponentFile,
       getAssetPath,
       json,
@@ -1119,7 +1111,7 @@ let generate =
     |> importComponents(
          config,
          options,
-         outputFile,
+         relativePathToWorkspaceRoot,
          getComponentFile,
          assignments,
          componentName,


### PR DESCRIPTION
## What

The `component` and `types` commands stopped working after the compiler changes that introduced the `Config` object. This fixes them.

cc @mathieudutour 