### PR TITLE
Fix compiler outputting JS variables with spaces

### DIFF
--- a/compiler/core/src/javaScript/javaScriptComponent.re
+++ b/compiler/core/src/javaScript/javaScriptComponent.re
@@ -635,11 +635,23 @@ let rec layerToJavaScriptAST =
             }),
             JSXAttribute({
               name: "className",
-              value:
-                Identifier([
-                  "this.state.focusRing ? 'lona--focus-ring' : 'lona--no-focus-ring'"
-                  ++ (needsIeFix ? " + " ++ ieFixClassname : ""),
-                ]),
+              value: {
+                let focusRingExpression =
+                  ConditionalExpression({
+                    test: Identifier(["this.state.focusRing"]),
+                    consequent: StringLiteral("lona--focus-ring"),
+                    alternate: StringLiteral("lona--no-focus-ring"),
+                  });
+                if (needsIeFix) {
+                  BinaryExpression({
+                    left: focusRingExpression,
+                    operator: Plus,
+                    right: StringLiteral(ieFixClassname),
+                  });
+                } else {
+                  focusRingExpression;
+                };
+              },
             }),
             JSXAttribute({
               name: "onKeyDown",

--- a/compiler/core/src/javaScript/javaScriptRender.re
+++ b/compiler/core/src/javaScript/javaScriptRender.re
@@ -76,6 +76,24 @@ let rec render = ast: Prettier.Doc.t('a) =>
     | [IfStatement(_) as node] => ifPart <+> s(" else ") <+> render(node)
     | _ => ifPart <+> s(" else ") <+> renderBlockBody(o.alternate, true)
     };
+  | ConditionalExpression(o) =>
+    group(
+      s("(")
+      <+> indent(
+            line
+            <+> render(o.test)
+            <+> indent(
+                  line
+                  <+> s("? ")
+                  <+> render(o.consequent)
+                  <+> line
+                  <+> s(": ")
+                  <+> render(o.alternate),
+                ),
+          )
+      <+> line
+      <+> s(")"),
+    )
   | ImportDefaultSpecifier(o) => s(o)
   | ImportSpecifier(o) =>
     switch (o.local) {

--- a/examples/generated/test/react-dom/interactivity/AccessibilityNested.js
+++ b/examples/generated/test/react-dom/interactivity/AccessibilityNested.js
@@ -101,7 +101,11 @@ export default class AccessibilityNested extends React.Component {
             customTextAccessibilityLabel={"Text"}
             onToggleCheckbox={AccessibilityTest$onToggleCheckbox}
             tabIndex={-1}
-            className={this.state.focusRing ? 'lona--focus-ring' : 'lona--no-focus-ring'}
+            className={(
+              this.state.focusRing
+                ? "lona--focus-ring"
+                : "lona--no-focus-ring"
+            )}
             onKeyDown={this._handleKeyDown}
             ref={(ref) => { this._AccessibilityTest = ref }}
 
@@ -111,7 +115,11 @@ export default class AccessibilityNested extends React.Component {
           <AccessibilityVisibility
             showText={AccessibilityVisibility$showText}
             tabIndex={-1}
-            className={this.state.focusRing ? 'lona--focus-ring' : 'lona--no-focus-ring'}
+            className={(
+              this.state.focusRing
+                ? "lona--focus-ring"
+                : "lona--no-focus-ring"
+            )}
             onKeyDown={this._handleKeyDown}
             ref={(ref) => { this._AccessibilityVisibility = ref }}
 

--- a/examples/generated/test/react-dom/interactivity/AccessibilityTest.js
+++ b/examples/generated/test/react-dom/interactivity/AccessibilityTest.js
@@ -121,7 +121,11 @@ export default class AccessibilityTest extends React.Component {
           onAccessibilityActivate={CheckboxRow$onAccessibilityActivate}
           aria-checked={CheckboxRow$accessibilityChecked}
           tabIndex={-1}
-          className={this.state.focusRing ? 'lona--focus-ring' : 'lona--no-focus-ring'}
+          className={(
+            this.state.focusRing
+              ? "lona--focus-ring"
+              : "lona--no-focus-ring"
+          )}
           onKeyDown={this._handleKeyDown}
           ref={(ref) => { this._CheckboxRow = ref }}
         >
@@ -137,7 +141,11 @@ export default class AccessibilityTest extends React.Component {
             aria-label={"Red box"}
             role={"button"}
             tabIndex={-1}
-            className={this.state.focusRing ? 'lona--focus-ring' : 'lona--no-focus-ring'}
+            className={(
+              this.state.focusRing
+                ? "lona--focus-ring"
+                : "lona--no-focus-ring"
+            )}
             onKeyDown={this._handleKeyDown}
             ref={(ref) => { this._Element = ref }}
           >
@@ -148,7 +156,11 @@ export default class AccessibilityTest extends React.Component {
               src={require("../assets/icon_128x128.png")}
               aria-label={"My image"}
               tabIndex={-1}
-              className={this.state.focusRing ? 'lona--focus-ring' : 'lona--no-focus-ring'}
+              className={(
+                this.state.focusRing
+                  ? "lona--focus-ring"
+                  : "lona--no-focus-ring"
+              )}
               onKeyDown={this._handleKeyDown}
               ref={(ref) => { this._Image = ref }}
 
@@ -156,7 +168,11 @@ export default class AccessibilityTest extends React.Component {
             <AccessibleText
               aria-label={AccessibleText$accessibilityLabel}
               tabIndex={-1}
-              className={this.state.focusRing ? 'lona--focus-ring' : 'lona--no-focus-ring'}
+              className={(
+                this.state.focusRing
+                  ? "lona--focus-ring"
+                  : "lona--no-focus-ring"
+              )}
               onKeyDown={this._handleKeyDown}
               ref={(ref) => { this._AccessibleText = ref }}
             >

--- a/examples/generated/test/react-dom/interactivity/AccessibilityVisibility.js
+++ b/examples/generated/test/react-dom/interactivity/AccessibilityVisibility.js
@@ -92,7 +92,11 @@ export default class AccessibilityVisibility extends React.Component {
         <GreyBox
           aria-label={"Grey box"}
           tabIndex={-1}
-          className={this.state.focusRing ? 'lona--focus-ring' : 'lona--no-focus-ring'}
+          className={(
+            this.state.focusRing
+              ? "lona--focus-ring"
+              : "lona--no-focus-ring"
+          )}
           onKeyDown={this._handleKeyDown}
           ref={(ref) => { this._GreyBox = ref }}
 
@@ -102,7 +106,11 @@ export default class AccessibilityVisibility extends React.Component {
           <Text
             aria-label={"Some text that is sometimes hidden"}
             tabIndex={-1}
-            className={this.state.focusRing ? 'lona--focus-ring' : 'lona--no-focus-ring'}
+            className={(
+              this.state.focusRing
+                ? "lona--focus-ring"
+                : "lona--no-focus-ring"
+            )}
             onKeyDown={this._handleKeyDown}
             ref={(ref) => { this._Text = ref }}
           >

--- a/examples/material-design/components/Card.component
+++ b/examples/material-design/components/Card.component
@@ -128,7 +128,6 @@
         "id" : "Image",
         "params" : {
           "alignSelf" : "stretch",
-          "aspectRatio" : 2,
           "flex" : 1,
           "image" : ""
         },


### PR DESCRIPTION
This fixes an issue where JS variables representing layer ids would have spaces in the compiler output.

cc @mathieudutour