### PR TITLE
Generate all Swift custom type enums as indirect

### DIFF
--- a/compiler/core/src/swift/swiftTypeSystem.re
+++ b/compiler/core/src/swift/swiftTypeSystem.re
@@ -1122,7 +1122,7 @@ module Build = {
               node:
                 EnumDeclaration({
                   "name": swiftOptions.typePrefix ++ name,
-                  "isIndirect": false,
+                  "isIndirect": true,
                   "inherits": [
                     ProtocolCompositionType([
                       TypeName("Codable"),
@@ -1148,7 +1148,7 @@ module Build = {
               node:
                 EnumDeclaration({
                   "name": swiftOptions.typePrefix ++ name,
-                  "isIndirect": false,
+                  "isIndirect": true,
                   "inherits": [
                     ProtocolCompositionType([
                       TypeName("Codable"),
@@ -1172,7 +1172,7 @@ module Build = {
               node:
                 EnumDeclaration({
                   "name": swiftOptions.typePrefix ++ name,
-                  "isIndirect": false,
+                  "isIndirect": true,
                   "inherits": [
                     TypeName("String"),
                     ProtocolCompositionType([
@@ -1190,7 +1190,7 @@ module Build = {
               node:
                 EnumDeclaration({
                   "name": swiftOptions.typePrefix ++ name,
-                  "isIndirect": false,
+                  "isIndirect": true,
                   "inherits": [
                     ProtocolCompositionType([
                       TypeName("Codable"),

--- a/examples/generated/test/appkit/style/InlineVariantTest.swift
+++ b/examples/generated/test/appkit/style/InlineVariantTest.swift
@@ -152,7 +152,7 @@ extension InlineVariantTest {
 // MARK: - ItemType
 
 extension InlineVariantTest {
-  public enum ItemType: Codable & Equatable {
+  public indirect enum ItemType: Codable & Equatable {
     case standard
     case error
 

--- a/examples/generated/test/swift/style/InlineVariantTest.swift
+++ b/examples/generated/test/swift/style/InlineVariantTest.swift
@@ -150,7 +150,7 @@ extension InlineVariantTest {
 // MARK: - ItemType
 
 extension InlineVariantTest {
-  public enum ItemType: Codable & Equatable {
+  public indirect enum ItemType: Codable & Equatable {
     case standard
     case error
 


### PR DESCRIPTION
## What

It's currently impossible to determine if enums generated for custom types need to be indirect or not. This is a quick fix -- making them all indirect.

A more comprehensive fix would be to calculate cycles, and allow annotating NativeTypes as indirect (since otherwise it's impossible to calculate cycles).