### PR TITLE
Improve flexbox fix for safari 10

### DIFF
--- a/compiler/core/src/javaScript/javaScriptComponent.re
+++ b/compiler/core/src/javaScript/javaScriptComponent.re
@@ -554,7 +554,7 @@ let createJSXElement =
   };
 };
 
-let ieFixClassname = "'lona--ie-flex-1-1-auto'";
+let flexFixClassname = "lona--flex-1-1-0percent";
 
 let rec layerToJavaScriptAST =
         (
@@ -646,7 +646,7 @@ let rec layerToJavaScriptAST =
                   BinaryExpression({
                     left: focusRingExpression,
                     operator: Plus,
-                    right: StringLiteral(ieFixClassname),
+                    right: StringLiteral(flexFixClassname),
                   });
                 } else {
                   focusRingExpression;
@@ -665,7 +665,7 @@ let rec layerToJavaScriptAST =
           | (true, ReactDOM) => [
               JSXAttribute({
                 name: "className",
-                value: Identifier([ieFixClassname]),
+                value: StringLiteral(flexFixClassname),
               }),
             ]
           | _ => []


### PR DESCRIPTION
## What

- Fixed a bug when generating the flexbox fix code that resulted in "_" instead of "-" in classname
- Changes the classname to better indicate what it's for now that we use it for safari also

## Testing
- [X] Edge 18
- [X] IE11
- [X] Safari 12
- [X] Safari 11
- [X] Safari 10.1
- [X] Safari 9.1

The full set of styles I'm applying:

```css
/* IE 11 and Safari 10.1 (and below) don't support `flex: 1 1 0%`. 
   We override this with `flex: 1 1 auto` which has very similar behavior.

/* IE 11 */
@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
  .lona--flex-1-1-0percent {
    flex: 1 1 auto !important;
  }
}

/* https://stackoverflow.com/questions/16348489/is-there-a-css-hack-for-safari-only-not-chrome */

/* Safari 9+ */
_:default:not(:root:root),
.lona--flex-1-1-0percent {
  flex: 1 1 auto !important;
}

/* Safari 11+ */
@media not all and (min-resolution: 0.001dpcm) {
  @supports (-webkit-appearance: none) and (stroke-color: transparent) {
    .lona--flex-1-1-0percent {
      flex: 1 1 0% !important;
    }
  }
}
```

cc @outdooricon 