### PR TITLE
catch more errors from the compiler

### DIFF
--- a/compiler/webpack-loader/lib/LonaCompilerError.js
+++ b/compiler/webpack-loader/lib/LonaCompilerError.js
@@ -1,0 +1,11 @@
+module.exports = class LonaCompilerError extends Error {
+  constructor(...params) {
+    // Pass remaining arguments (including vendor specific ones) to parent constructor
+    super(...params)
+
+    // Maintains proper stack trace for where our error was thrown (only available on V8)
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, LonaCompilerError)
+    }
+  }
+}

--- a/compiler/webpack-loader/lib/loader.js
+++ b/compiler/webpack-loader/lib/loader.js
@@ -4,6 +4,7 @@ const qs = require('querystring')
 const { exec } = require('child_process')
 const { getOptions } = require('loader-utils')
 const validateOptions = require('schema-utils')
+const LonaCompilerError = require('./LonaCompilerError')
 
 const optionsSchema = require('./options-schema.json')
 
@@ -35,8 +36,8 @@ function lonac(command, filePath, options, callback) {
         : ''
     } "${filePath}"`,
     (err, stdout, stderr) => {
-      if (err) {
-        callback(stderr || err)
+      if (err || (!stdout && stderr)) {
+        callback(stderr ? new LonaCompilerError(stderr) : err)
         return
       }
 


### PR DESCRIPTION
## What

The compiler can exit with `0` (which won't trigger an error) but write to stderr. This makes sure that when there is no `stdout`, we consider it an error

