### PR TITLE
Fix #325: Pressing "Return" key opens the selected project

### DIFF
--- a/studio/LonaStudio/Workspace/RecentProjectsList.swift
+++ b/studio/LonaStudio/Workspace/RecentProjectsList.swift
@@ -172,6 +172,13 @@ extension RecentProjectsTableView: NSTableViewDelegate {
 
         onOpenProject?(projects[tableView.selectedRow])
     }
+
+	override func keyDown(with event: NSEvent) {
+		let carriageReturnKeyCode = 36
+		if event.keyCode == carriageReturnKeyCode {
+			onOpenProject?(projects[tableView.selectedRow])
+		}
+	}
 }
 
 extension RecentProjectsTableView: NSTableViewDataSource {


### PR DESCRIPTION
## What
This PR contains fix for #325: it adds support for opening selected project from welcome screen when "Enter" was pressed.

![mar-06-2019 21-01-59](https://user-images.githubusercontent.com/26641473/53926947-48d6a300-4053-11e9-9ea6-c096094240c9.gif)

In order to implement this feature, I overrode `keyDown` function inside the extension of `RecentProjectsTableView`, where I basically check if the keyCode of the pressed code is equalled to carriage return key code (36).


cc: @dabbott, @ryngonzalez
