### PR TITLE
Fixes an issue where the plugin params sheet wouldn't show

### DIFF
--- a/studio/LonaStudio/Plugins/PluginAPI.swift
+++ b/studio/LonaStudio/Plugins/PluginAPI.swift
@@ -80,6 +80,11 @@ class PluginAPI {
             }
             return
         case .customParameters:
+            guard let workspaceViewController = WorkspaceWindowController.first?.contentViewController else {
+                onSuccess(nil)
+                return
+            }
+
             var title = "Parameters"
             var parameters: [CSParameter] = []
             var initialValues: [String: CSData] = [:]
@@ -121,6 +126,7 @@ class PluginAPI {
 
             DispatchQueue.main.async {
                 CustomParametersEditorView.presentSheet(
+                    parentViewController: workspaceViewController,
                     titleText: title,
                     parameters: parameters,
                     initialValues: initialValues,

--- a/studio/LonaStudio/Workspace/CustomParametersEditorView.swift
+++ b/studio/LonaStudio/Workspace/CustomParametersEditorView.swift
@@ -32,13 +32,14 @@ class CustomParametersEditorView: NSBox {
 
     public var onSubmit: (([String: CSData]) -> Void)?
 
-    static func presentSheet(titleText: String, parameters: [CSParameter], initialValues: [String: CSData], onCompletion: @escaping ([String: CSData]?) -> Void) {
-        let sheetView = CustomParametersEditorView(parameters: parameters, initialValues: initialValues)
+    static func presentSheet(
+        parentViewController: NSViewController,
+        titleText: String,
+        parameters: [CSParameter],
+        initialValues: [String: CSData],
+        onCompletion: @escaping ([String: CSData]?) -> Void) {
 
-        guard let rootViewController = NSApp.mainWindow?.contentViewController else {
-            onCompletion(nil)
-            return
-        }
+        let sheetView = CustomParametersEditorView(parameters: parameters, initialValues: initialValues)
 
         let container = CustomParametersEditorSheet(titleText: titleText, cancelText: "Cancel", submitText: "Continue")
 
@@ -51,15 +52,15 @@ class CustomParametersEditorView: NSBox {
 
         let viewController = NSViewController(view: container)
 
-        rootViewController.presentViewControllerAsSheet(viewController)
+        parentViewController.presentViewControllerAsSheet(viewController)
 
         container.onSubmit = {
-            rootViewController.dismissViewController(viewController)
+            parentViewController.dismissViewController(viewController)
             onCompletion(sheetView.currentValues)
         }
 
         container.onCancel = {
-            rootViewController.dismissViewController(viewController)
+            parentViewController.dismissViewController(viewController)
             onCompletion(nil)
         }
     }

--- a/studio/LonaStudio/Workspace/WorkspaceWindowController.swift
+++ b/studio/LonaStudio/Workspace/WorkspaceWindowController.swift
@@ -16,6 +16,15 @@ private let storyboardName = NSStoryboard.Name(rawValue: "Main")
 private let codeViewVisibleKey = "LonaStudio code view visible"
 
 class WorkspaceWindowController: NSWindowController {
+    static var first: WorkspaceWindowController? {
+        return NSApp.windows
+            .map { $0.windowController }
+            .compactMap { $0 }
+            .map { $0 as? WorkspaceWindowController }
+            .compactMap { $0 }
+            .first
+    }
+
     @discardableResult static func create(andAttachTo document: NSDocument? = nil) -> WorkspaceWindowController {
         let storyboard = NSStoryboard(name: storyboardName, bundle: nil)
 


### PR DESCRIPTION
## What

Previously I was using the `main` window as the parent of the modal sheet, but this doesn't exist if the window is minimized. Now I use the first workspace window if one exists.