### PR TITLE
Fix directory documents not closing when switching workspaces

### DIFF
--- a/studio/LonaStudio/AppDelegate.swift
+++ b/studio/LonaStudio/AppDelegate.swift
@@ -248,6 +248,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             return nil
         }
 
+        NSDocumentController.shared.addDocument(newDocument)
+
         return newDocument
     }
 

--- a/studio/LonaStudio/Documents/DocumentController.swift
+++ b/studio/LonaStudio/Documents/DocumentController.swift
@@ -11,7 +11,13 @@ import Foundation
 
 class DocumentController: NSDocumentController {
     public var didOpenADocument = false
-    override public func reopenDocument(for urlOrNil: URL?, withContentsOf contentsURL: URL, display displayDocument: Bool, completionHandler: @escaping (NSDocument?, Bool, Error?) -> Void) {
+
+    override public func reopenDocument(
+        for urlOrNil: URL?,
+        withContentsOf contentsURL: URL,
+        display displayDocument: Bool,
+        completionHandler: @escaping (NSDocument?, Bool, Error?) -> Void) {
+
         if FileUtils.fileExists(atPath: contentsURL.path) == .directory {
             guard let newDocument = try? DirectoryDocument(contentsOf: contentsURL, ofType: "Directory Document") else {
                 completionHandler(nil, false, NSError(domain: NSCocoaErrorDomain, code: 256, userInfo: [
@@ -19,6 +25,8 @@ class DocumentController: NSDocumentController {
                     NSLocalizedFailureReasonErrorKey: "LonaStudio cannot open files of this type."]))
                 return
             }
+
+            addDocument(newDocument)
 
             didOpenADocument = true
             completionHandler(newDocument, false, nil)

--- a/studio/LonaStudio/Workspace/WorkspaceViewController.swift
+++ b/studio/LonaStudio/Workspace/WorkspaceViewController.swift
@@ -591,6 +591,8 @@ class WorkspaceViewController: NSSplitViewController {
                     return
                 }
 
+                NSDocumentController.shared.addDocument(newDocument)
+
                 guard let windowController = self.view.window?.windowController else { return }
 
                 newDocument.addWindowController(windowController)
@@ -696,6 +698,8 @@ class WorkspaceViewController: NSSplitViewController {
                 self.inspectedContent = nil
                 return
             }
+
+            NSDocumentController.shared.addDocument(newDocument)
 
             guard let windowController = self.view.window?.windowController else { return }
 


### PR DESCRIPTION
## What

Switching workspaces wasn't closing directory documents, which could result in 2 components open from different workspaces.