### PR TITLE
Fixes #339: Display SVG files

### DIFF
--- a/studio/LonaStudio/Documents/ImageDocument.swift
+++ b/studio/LonaStudio/Documents/ImageDocument.swift
@@ -42,11 +42,11 @@ class ImageDocument: NSDocument {
 
     override func read(from url: URL, ofType typeName: String) throws {
         let data = try Data(contentsOf: url, options: NSData.ReadingOptions())
-		if url.pathExtension == "svg" {
-			let sz = CGSize(width: 450, height: 450)
-			content = SVG.render(contentsOf: url, size: sz, resizingMode: .scaleAspectFit)
-		} else {
-			content = NSImage(data: data)
-		}
+        if url.pathExtension == "svg" {
+            let size = CGSize(width: 450, height: 450)
+            content = SVG.render(contentsOf: url, size: size, resizingMode: .scaleAspectFit)
+        } else {
+            content = NSImage(data: data)
+        }
     }
 }

--- a/studio/LonaStudio/Documents/ImageDocument.swift
+++ b/studio/LonaStudio/Documents/ImageDocument.swift
@@ -42,6 +42,11 @@ class ImageDocument: NSDocument {
 
     override func read(from url: URL, ofType typeName: String) throws {
         let data = try Data(contentsOf: url, options: NSData.ReadingOptions())
-        content = NSImage(data: data)
+		if url.pathExtension == "svg" {
+			let sz = CGSize(width: 450, height: 450)
+			content = SVG.render(contentsOf: url, size: sz, resizingMode: .scaleAspectFit)
+		} else {
+			content = NSImage(data: data)
+		}
     }
 }

--- a/studio/LonaStudio/Info.plist
+++ b/studio/LonaStudio/Info.plist
@@ -15,12 +15,12 @@
 			</array>
 			<key>CFBundleTypeIconFile</key>
 			<string></string>
-			<key>LSHandlerRank</key>
-			<string>Owner</string>
 			<key>CFBundleTypeName</key>
 			<string>DocumentType</string>
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
 			<key>NSDocumentClass</key>
 			<string>$(PRODUCT_MODULE_NAME).ComponentDocument</string>
 		</dict>
@@ -47,6 +47,7 @@
 				<string>eps</string>
 				<string>bmp</string>
 				<string>gif</string>
+				<string>svg</string>
 			</array>
 			<key>CFBundleTypeName</key>
 			<string>Image</string>


### PR DESCRIPTION
## What
This PR contains a fix for #339: it displays SVG images, when the file was selected in file navigator: <br />
<img width="450" alt="Screen Shot 2019-03-12 at 10 11 23 PM" src="https://user-images.githubusercontent.com/26641473/54319727-e9cbdd80-45c0-11e9-840d-a65be441c15f.png">
