### PR TITLE
Swift enum type generation updates

### DIFF
--- a/compiler/core/src/core/typeSystem.re
+++ b/compiler/core/src/core/typeSystem.re
@@ -32,6 +32,12 @@ type entity =
 type typesFile = {types: list(entity)};
 
 module Access = {
+  let nativeTypeName = (entity: entity): option(string) =>
+    switch (entity) {
+    | GenericType(_) => None
+    | NativeType(nativeType) => Some(nativeType.name)
+    };
+
   let typeCaseName = (typeCase: typeCase): string =>
     switch (typeCase) {
     | NormalCase(name, _)
@@ -136,10 +142,10 @@ module Access = {
 };
 
 module Match = {
-  let nativeTypeName = (name: string, entity: entity): bool =>
+  let nativeType = (entity: entity): bool =>
     switch (entity) {
     | GenericType(_) => false
-    | NativeType(nativeType) => nativeType.name == name
+    | NativeType(_) => true
     };
 
   let genericTypeCaseNames = (names: list(string), entity: entity): bool =>

--- a/compiler/core/src/core/typeSystem.re
+++ b/compiler/core/src/core/typeSystem.re
@@ -139,6 +139,20 @@ module Access = {
       |> List.concat
     | NativeType(_) => []
     };
+
+  let recordCaseLabels = (typeCase: typeCase): list(string) =>
+    switch (typeCase) {
+    | NormalCase(_) => []
+    | RecordCase(_, parameters) =>
+      parameters
+      |> List.map((parameter: recordTypeCaseParameter) => parameter.key)
+    };
+
+  let allRecordCaseLabels = (typeCases: list(typeCase)): list(string) =>
+    typeCases
+    |> List.map(recordCaseLabels)
+    |> List.concat
+    |> Sequence.dedupeMem;
 };
 
 module Match = {

--- a/compiler/core/src/swift/swiftAst.re
+++ b/compiler/core/src/swift/swiftAst.re
@@ -43,6 +43,10 @@ type literal =
   | Color(string)
   | Image(string)
   | Array(list(node))
+and tupleTypeElement = {
+  elementName: option(string),
+  annotation: typeAnnotation,
+}
 and typeAnnotation =
   | TypeName(string)
   | TypeIdentifier(
@@ -61,7 +65,7 @@ and typeAnnotation =
       },
     )
   | OptionalType(typeAnnotation)
-  | TupleType(list(typeAnnotation))
+  | TupleType(list(tupleTypeElement))
   | FunctionType(
       {
         .

--- a/compiler/core/src/swift/swiftComponent.re
+++ b/compiler/core/src/swift/swiftComponent.re
@@ -89,7 +89,10 @@ module Doc = {
       >>= (
         entity => {
           let convertedEntity =
-            SwiftTypeSystem.Build.entity(swiftOptions, entity);
+            SwiftTypeSystem.Build.entity(
+              {nativeTypeNames: [], swiftOptions},
+              entity,
+            );
           switch (convertedEntity.name) {
           | Some(name) =>
             Some([

--- a/compiler/core/src/swift/swiftRender.re
+++ b/compiler/core/src/swift/swiftRender.re
@@ -609,9 +609,15 @@ and renderTypeAnnotation = (node: SwiftAst.typeAnnotation) =>
     )
   | OptionalType(v) => group(concat([renderTypeAnnotation(v), s("?")]))
   | TupleType(o) =>
+    let renderTupleTypeElement = (element: SwiftAst.tupleTypeElement) =>
+      switch (element.elementName) {
+      | Some(name) =>
+        s(name ++ ": ") <+> renderTypeAnnotation(element.annotation)
+      | None => renderTypeAnnotation(element.annotation)
+      };
     s("(")
-    <+> group(o |> List.map(renderTypeAnnotation) |> join(s(", ")))
-    <+> s(")")
+    <+> group(o |> List.map(renderTupleTypeElement) |> join(s(", ")))
+    <+> s(")");
   | FunctionType(o) =>
     let arguments =
       group(


### PR DESCRIPTION
## What

Generated record-style enums now use parameter labels, rather than separate structs that hold the parameters. The JSON format is unchanged.