### PR TITLE
Fixes #338: Update "Add" menu on component change in fileNavigator

### DIFF
--- a/studio/LonaStudio/Plugins/LonaPlugins.swift
+++ b/studio/LonaStudio/Plugins/LonaPlugins.swift
@@ -15,6 +15,7 @@ enum LonaPluginActivationEvent: String, Decodable {
     case onSaveTextStyles = "onSave:textStyles"
     case onReloadWorkspace = "onReload:workspace"
     case onChangeTheme = "onChange:theme"
+    case onChangeFileSystemComponents = "onChange:fileSystem:components"
 }
 
 struct LonaPluginConfig: Decodable {

--- a/studio/LonaStudio/Workspace/FileNavigator.swift
+++ b/studio/LonaStudio/Workspace/FileNavigator.swift
@@ -82,6 +82,11 @@ class FileNavigator: NSBox {
         set { fileTree.onAction = newValue }
     }
 
+    public var onCreateFile: ((FileTree.Path, FileTree.FileEventOptions) -> Void)? {
+        get { return fileTree.onCreateFile }
+        set { fileTree.onCreateFile = newValue}
+    }
+
     public var onDeleteFile: ((FileTree.Path, FileTree.FileEventOptions) -> Void)? {
         get { return fileTree.onDeleteFile }
         set { fileTree.onDeleteFile = newValue }

--- a/studio/LonaStudio/Workspace/LayerListHeader.swift
+++ b/studio/LonaStudio/Workspace/LayerListHeader.swift
@@ -22,8 +22,8 @@ public class LayerListHeader: NSBox {
 
         update()
 
-        subscriptions.append(LonaPlugins.current.register(eventType: .onChangeFileSystemComponents) {
-            self.setUpViews()
+        subscriptions.append(LonaPlugins.current.register(eventType: .onChangeFileSystemComponents) { [unowned self] in
+            self.updateMenuItems()
         })
     }
 
@@ -71,6 +71,10 @@ public class LayerListHeader: NSBox {
     }
 
     private func update() {}
+
+    private func updateMenuItems() {
+        button.menu(forSegment: 0)?.items = ComponentMenu.menuItems()
+    }
 
     deinit {
         subscriptions.forEach({ sub in sub() })

--- a/studio/LonaStudio/Workspace/LayerListHeader.swift
+++ b/studio/LonaStudio/Workspace/LayerListHeader.swift
@@ -10,6 +10,7 @@ import AppKit
 import Foundation
 
 public class LayerListHeader: NSBox {
+    private var subscriptions: [() -> Void] = []
 
     // MARK: Lifecycle
 
@@ -20,6 +21,10 @@ public class LayerListHeader: NSBox {
         setUpConstraints()
 
         update()
+
+        subscriptions.append(LonaPlugins.current.register(eventType: .onChangeFileSystemComponents) {
+            self.setUpViews()
+        })
     }
 
     public required init?(coder decoder: NSCoder) {
@@ -66,4 +71,8 @@ public class LayerListHeader: NSBox {
     }
 
     private func update() {}
+
+    deinit {
+        subscriptions.forEach({ sub in sub() })
+    }
 }

--- a/studio/LonaStudio/Workspace/WorkspaceViewController.swift
+++ b/studio/LonaStudio/Workspace/WorkspaceViewController.swift
@@ -330,11 +330,6 @@ class WorkspaceViewController: NSSplitViewController {
         splitView.identifier = NSUserInterfaceItemIdentifier(rawValue: splitViewResorationIdentifier)
 
         fileNavigator.onCreateFile = { path, options in
-            NSDocumentController.shared.documents.forEach { document in
-                if document.fileURL == URL(fileURLWithPath: path) {
-                    self.close(document: document, discardingUnsavedChanges: true)
-                }
-            }
             LonaPlugins.current.trigger(eventType: .onChangeFileSystemComponents)
         }
 

--- a/studio/LonaStudio/Workspace/WorkspaceViewController.swift
+++ b/studio/LonaStudio/Workspace/WorkspaceViewController.swift
@@ -329,6 +329,15 @@ class WorkspaceViewController: NSSplitViewController {
         splitView.autosaveName = NSSplitView.AutosaveName(rawValue: splitViewResorationIdentifier)
         splitView.identifier = NSUserInterfaceItemIdentifier(rawValue: splitViewResorationIdentifier)
 
+        fileNavigator.onCreateFile = { path, options in
+            NSDocumentController.shared.documents.forEach { document in
+                if document.fileURL == URL(fileURLWithPath: path) {
+                    self.close(document: document, discardingUnsavedChanges: true)
+                }
+            }
+            LonaPlugins.current.trigger(eventType: .onChangeFileSystemComponents)
+        }
+
         fileNavigator.onDeleteFile = { path, options in
             NSDocumentController.shared.documents.forEach { document in
                 if document.fileURL == URL(fileURLWithPath: path) {
@@ -374,7 +383,6 @@ class WorkspaceViewController: NSSplitViewController {
                 to: url,
                 ofType: "DocumentType",
                 for: NSDocument.SaveOperationType.saveOperation, completionHandler: { error in
-                    LonaPlugins.current.trigger(eventType: .onChangeFileSystemComponents)
                     if let error = error {
                         Swift.print("Failed to save \(url): \(error)")
                     }

--- a/studio/LonaStudio/Workspace/WorkspaceViewController.swift
+++ b/studio/LonaStudio/Workspace/WorkspaceViewController.swift
@@ -335,6 +335,7 @@ class WorkspaceViewController: NSSplitViewController {
                     self.close(document: document, discardingUnsavedChanges: true)
                 }
             }
+            LonaPlugins.current.trigger(eventType: .onChangeFileSystemComponents)
         }
 
         // Don't allow moving these json files within Lona Studio.
@@ -350,6 +351,7 @@ class WorkspaceViewController: NSSplitViewController {
         fileNavigator.performMoveFile = { prev, next in
             do {
                 try FileManager.default.moveItem(atPath: prev, toPath: next)
+                LonaPlugins.current.trigger(eventType: .onChangeFileSystemComponents)
                 return true
             } catch {
                 Swift.print("Failed to move \(prev) to \(next)")
@@ -372,6 +374,7 @@ class WorkspaceViewController: NSSplitViewController {
                 to: url,
                 ofType: "DocumentType",
                 for: NSDocument.SaveOperationType.saveOperation, completionHandler: { error in
+                    LonaPlugins.current.trigger(eventType: .onChangeFileSystemComponents)
                     if let error = error {
                         Swift.print("Failed to save \(url): \(error)")
                     }


### PR DESCRIPTION
This PR contains fix for #338.

It updates the list of components in the "Add menu" on any of the following actions:
* A new component was created
* Component was moved
* Component was deleted

GIFs for each case:

![add-component](https://user-images.githubusercontent.com/26641473/54731172-16ed3280-4b63-11e9-85e6-599a0dd59653.gif)

![move-component](https://user-images.githubusercontent.com/26641473/54731173-1785c900-4b63-11e9-80ce-1cf0f2f05e91.gif)

![delete-component](https://user-images.githubusercontent.com/26641473/54731212-59af0a80-4b63-11e9-92b3-07ca7816e66e.gif)
