### PR TITLE
make the node API return an execa object

### DIFF
--- a/compiler/generate-docs/cli/index.js
+++ b/compiler/generate-docs/cli/index.js
@@ -6,7 +6,7 @@ const didYouMean = require('./did-you-mean')
 // eslint-disable-next-line no-unused-expressions
 cli
   .scriptName('@lona/docs')
-  .command(require('../commands/build'))
+  .command(require('../commands/build').command)
   .usage('Usage: @lona/docs <command> [options]')
   .parserConfiguration({
     'boolean-negation': false,

--- a/compiler/generate-docs/index.js
+++ b/compiler/generate-docs/index.js
@@ -1,3 +1,3 @@
 module.exports = {
-  build: require('./commands/build').handler,
+  build: require('./commands/build'),
 }


### PR DESCRIPTION
## What

Right now the node API return a normal promise (because the execa promise is catched). This make sure that the node API return an execa promise which is a Promise enhanced with `stdout`, stderr`, and a bunch of other properties really useful for generating the docs on Lambda.

cc: @dabbott
