### PR TITLE
Fixes #355: Add component duplication support

### DIFF
--- a/studio/LonaStudio.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/studio/LonaStudio.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/studio/LonaStudio/Workspace/FileNavigator.swift
+++ b/studio/LonaStudio/Workspace/FileNavigator.swift
@@ -185,6 +185,36 @@ class FileNavigator: NSBox {
                 menu.addItem(NSMenuItem.separator())
             }
 
+            if NSURL(fileURLWithPath: path).pathExtension == "component"{
+                menu.addItem(NSMenuItem(title: "Duplicate As...", onClick: {
+                    var saveURL: String
+                    let dialog = NSSavePanel()
+
+                    dialog.title                   = "Save .component file"
+                    dialog.showsResizeIndicator    = true
+                    dialog.showsHiddenFiles        = false
+                    dialog.canCreateDirectories    = true
+                    dialog.allowedFileTypes        = ["component"]
+
+                    // User canceled the save. Don't swap out the document.
+                    if dialog.runModal() != NSApplication.ModalResponse.OK {
+                        return
+                    }
+
+                    guard let url = dialog.url else { return }
+                    saveURL = url.path
+                    do {
+                        try FileManager.default.copyItem(atPath: path, toPath: saveURL)
+                        self.onAction?(saveURL)
+                    } catch {
+                        let alert = NSAlert()
+                        alert.messageText = "Couldn't copy componento to \(saveURL)"
+                        alert.addButton(withTitle: "OK")
+                        alert.runModal()
+                    }
+                }))
+            }
+
             menu.addItem(NSMenuItem(title: "Delete", onClick: {
                 let fileName = URL(fileURLWithPath: path).lastPathComponent
 

--- a/studio/LonaStudio/Workspace/FileNavigator.swift
+++ b/studio/LonaStudio/Workspace/FileNavigator.swift
@@ -185,9 +185,8 @@ class FileNavigator: NSBox {
                 menu.addItem(NSMenuItem.separator())
             }
 
-            if NSURL(fileURLWithPath: path).pathExtension == "component"{
+            if URL(fileURLWithPath: path).pathExtension == "component" {
                 menu.addItem(NSMenuItem(title: "Duplicate As...", onClick: {
-                    var saveURL: String
                     let dialog = NSSavePanel()
 
                     dialog.title                   = "Save .component file"
@@ -195,6 +194,7 @@ class FileNavigator: NSBox {
                     dialog.showsHiddenFiles        = false
                     dialog.canCreateDirectories    = true
                     dialog.allowedFileTypes        = ["component"]
+                    dialog.directoryURL = URL(fileURLWithPath: path).deletingLastPathComponent()
 
                     // User canceled the save. Don't swap out the document.
                     if dialog.runModal() != NSApplication.ModalResponse.OK {
@@ -202,16 +202,17 @@ class FileNavigator: NSBox {
                     }
 
                     guard let url = dialog.url else { return }
-                    saveURL = url.path
                     do {
-                        try FileManager.default.copyItem(atPath: path, toPath: saveURL)
-                        self.onAction?(saveURL)
+                        try FileManager.default.copyItem(atPath: path, toPath: url.path)
                     } catch {
                         let alert = NSAlert()
-                        alert.messageText = "Couldn't copy component to \(saveURL)"
+                        alert.messageText = "Couldn't copy component to \(url.path)"
                         alert.addButton(withTitle: "OK")
                         alert.runModal()
+                        return
                     }
+
+                    self.onAction?(url.path)
                 }))
             }
 

--- a/studio/LonaStudio/Workspace/FileNavigator.swift
+++ b/studio/LonaStudio/Workspace/FileNavigator.swift
@@ -208,7 +208,7 @@ class FileNavigator: NSBox {
                         self.onAction?(saveURL)
                     } catch {
                         let alert = NSAlert()
-                        alert.messageText = "Couldn't copy componento to \(saveURL)"
+                        alert.messageText = "Couldn't copy component to \(saveURL)"
                         alert.addButton(withTitle: "OK")
                         alert.runModal()
                     }


### PR DESCRIPTION
This PR contains a fix for #355.

It adds a new item "Duplicate as..." to the context menu. If the user selects this option, the app will prompt the user to type a name for this component and select location for it. Once the user saves the file, it's going to be opened in the Component Editor.

**Implementation**:
1. Check the extension of the selected file.
2. Add menu item "Duplicate As..."
3. onClick it shows save dialog.
4. Try to copy the item to the new path.
5. If successful, open a newly created file. Otherwise, it will show an alert with message "Couldn't copy component to..."