### PR TITLE
patch gatsby instead of fork

### DIFF
--- a/compiler/generate-docs/commands/build.js
+++ b/compiler/generate-docs/commands/build.js
@@ -45,11 +45,13 @@ function handler(argv) {
     argv.cacheDir = path.join(process.cwd(), '.cache')
   }
 
-  const gatsbyPath = require.resolve('@mathieudutour/gatsby/dist/bin/gatsby.js')
+  const gatsbyPath = require.resolve(
+    '../tasks/run-gatsby.js' /* 'gatsby/dist/bin/gatsby.js' */
+  )
 
   const gatsbyOptions = [
-    `--build-dir=${argv.buildDir}`,
-    `--cache-dir=${argv.cacheDir}`,
+    `--build-dir="${argv.buildDir}"`,
+    `--cache-dir="${argv.cacheDir}"`,
   ]
 
   if (argv.noColor) {

--- a/compiler/generate-docs/package.json
+++ b/compiler/generate-docs/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@lona/docs",
-  "version": "0.0.32",
+  "version": "0.0.40",
   "description": "",
   "main": "index.js",
   "bin": {
     "lona-docs": "cli/index.js"
   },
   "scripts": {
+    "postinstall": "echo \"Patching Gatsby to allow to specify output paths...\" && patch-package",
     "test": "echo \"Error: no test specified\" && exit 1",
     "clear": "rm -rf ./public || true && rm -rf ./.cache || true",
     "dev": "./cli/index.js build --workspace=../../examples/material-design --watch"
@@ -20,22 +21,25 @@
   },
   "dependencies": {
     "@lona/workspace-to-sketch-library": "^0.1.12",
-    "@mathieudutour/gatsby": "^2.1.51",
     "@mdx-js/mdx": "^1.0.0",
     "@mdx-js/react": "^1.0.0",
     "babel-plugin-styled-components": "^1.10.0",
     "chokidar": "^2.1.1",
     "execa": "^1.0.0",
     "fs-extra": "^7.0.1",
-    "gatsby": "^2.1.30",
+    "gatsby": "2.3.4",
+    "gatsby-cli": "2.5.4",
     "gatsby-mdx": "^0.6.1",
     "gatsby-plugin-react-helmet": "^3.0.6",
     "gatsby-plugin-styled-components": "^3.0.5",
     "graphql": "^14.1.1",
+    "linkfs": "^2.1.0",
     "lona-loader": "^0.1.3",
     "lonac": "^0.5.3",
     "meant": "^1.0.1",
     "mime": "^2.4.0",
+    "mock-require": "^3.0.3",
+    "patch-sibling-package": "^6.1.5",
     "prop-types": "^15.7.2",
     "react": "^16.8.2",
     "react-dom": "^16.8.2",

--- a/compiler/generate-docs/patches/babel-preset-gatsby+0.1.10.patch
+++ b/compiler/generate-docs/patches/babel-preset-gatsby+0.1.10.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/babel-preset-gatsby/index.js b/node_modules/babel-preset-gatsby/index.js
+index 7da0918..aeb9ec8 100644
+--- a/node_modules/babel-preset-gatsby/index.js
++++ b/node_modules/babel-preset-gatsby/index.js
+@@ -9,7 +9,7 @@ const loadCachedConfig = () => {
+ 
+   if (process.env.NODE_ENV !== `test`) {
+     try {
+-      pluginBabelConfig = require(path.join(process.cwd(), `./.cache/babelState.json`));
++      pluginBabelConfig = require(path.join(process.env.GATSBY_CACHE_DIR || path.join(process.cwd(), `./.cache`), `babelState.json`));
+     } catch (err) {
+       if (err.message.includes(`Cannot find module`)) {
+         // This probably is being used outside of the Gatsby CLI.

--- a/compiler/generate-docs/patches/gatsby+2.3.4.patch
+++ b/compiler/generate-docs/patches/gatsby+2.3.4.patch
@@ -1,0 +1,184 @@
+diff --git a/node_modules/gatsby/cache-dir/static-entry.js b/node_modules/gatsby/cache-dir/static-entry.js
+index aa3b9cf..98c271e 100644
+--- a/node_modules/gatsby/cache-dir/static-entry.js
++++ b/node_modules/gatsby/cache-dir/static-entry.js
+@@ -14,13 +14,9 @@ const { version: gatsbyVersion } = require(`gatsby/package.json`)
+ const pagesObjectMap = new Map()
+ pages.forEach(p => pagesObjectMap.set(p.path, p))
+ 
+-const stats = JSON.parse(
+-  fs.readFileSync(`${process.cwd()}/public/webpack.stats.json`, `utf-8`)
+-)
++const stats = require(`gatsby-public-dir/webpack.stats.json`)
+ 
+-const chunkMapping = JSON.parse(
+-  fs.readFileSync(`${process.cwd()}/public/chunk-map.json`, `utf-8`)
+-)
++const chunkMapping = require(`gatsby-public-dir/chunk-map.json`)
+ 
+ // const testRequireError = require("./test-require-error")
+ // For some extremely mysterious reason, webpack adds the above module *after*
+@@ -126,13 +122,11 @@ export default (pagePath, callback) => {
+ 
+   let dataAndContext = {}
+   if (page.jsonName in dataPaths) {
+-    const pathToJsonData = join(
+-      process.cwd(),
+-      `/public/static/d`,
+-      `${dataPaths[page.jsonName]}.json`
+-    )
++    const pathToJsonData = `gatsby-public-dir/static/d/${
++      dataPaths[page.jsonName]
++    }.json`
+     try {
+-      dataAndContext = JSON.parse(fs.readFileSync(pathToJsonData))
++      dataAndContext = JSON.parse(fs.readFileSync(require.resolve(`gatsby-public-dir/static/d/${dataPaths[page.jsonName]}.json`)))
+     } catch (e) {
+       console.log(`error`, pathToJsonData, e)
+       process.exit()
+@@ -324,7 +318,7 @@ export default (pagePath, callback) => {
+             data-href={`${__PATH_PREFIX__}/${style.name}`}
+             dangerouslySetInnerHTML={{
+               __html: fs.readFileSync(
+-                join(process.cwd(), `public`, style.name),
++                join(__PUBLIC_PATH__, style.name),
+                 `utf-8`
+               ),
+             }}
+diff --git a/node_modules/gatsby/dist/commands/build-html.js b/node_modules/gatsby/dist/commands/build-html.js
+index 6ae293a..ed98191 100644
+--- a/node_modules/gatsby/dist/commands/build-html.js
++++ b/node_modules/gatsby/dist/commands/build-html.js
+@@ -43,7 +43,7 @@ function () {
+           return reject(e);
+         }
+ 
+-        const outputFile = `${directory}/public/render-page.js`;
++        const outputFile = `${process.env.GATSBY_BUILD_DIR || `${directory}/public`}/render-page.js`;
+ 
+         if (stats.hasErrors()) {
+           let webpackErrors = stats.toJson().errors.filter(Boolean);
+diff --git a/node_modules/gatsby/dist/commands/develop-html.js b/node_modules/gatsby/dist/commands/develop-html.js
+index 7acd08d..ff3996f 100644
+--- a/node_modules/gatsby/dist/commands/develop-html.js
++++ b/node_modules/gatsby/dist/commands/develop-html.js
+@@ -31,7 +31,7 @@ function () {
+           return reject(e);
+         }
+ 
+-        const outputFile = `${directory}/public/render-page.js`;
++        const outputFile = `${process.env.GATSBY_BUILD_DIR || `${directory}/public`}/render-page.js`
+ 
+         if (stats.hasErrors()) {
+           let webpackErrors = stats.toJson().errors;
+diff --git a/node_modules/gatsby/dist/internal-plugins/dev-404-page/gatsby-node.js b/node_modules/gatsby/dist/internal-plugins/dev-404-page/gatsby-node.js
+index 7e795fd..ee0dd75 100644
+--- a/node_modules/gatsby/dist/internal-plugins/dev-404-page/gatsby-node.js
++++ b/node_modules/gatsby/dist/internal-plugins/dev-404-page/gatsby-node.js
+@@ -23,7 +23,7 @@ function () {
+ 
+       const createPage = actions.createPage;
+       const source = path.join(__dirname, `./raw_dev-404-page.js`);
+-      const destination = path.join(program.directory, `.cache`, `dev-404-page.js`);
++      const destination = path.join(process.env.GATSBY_CACHE_DIR || path.join(program.directory, `.cache`), `dev-404-page.js`);
+ 
+       const copy = () => fs.copy(source, destination);
+ 
+diff --git a/node_modules/gatsby/dist/internal-plugins/query-runner/pages-writer.js b/node_modules/gatsby/dist/internal-plugins/query-runner/pages-writer.js
+index 95d724d..6da0d89 100644
+--- a/node_modules/gatsby/dist/internal-plugins/query-runner/pages-writer.js
++++ b/node_modules/gatsby/dist/internal-plugins/query-runner/pages-writer.js
+@@ -93,7 +93,7 @@ const preferDefault = m => m && m.default || m
+     asyncRequires += `exports.data = () => import(/* webpackChunkName: "pages-manifest" */ "${(0, _path.joinPath)(program.directory, `.cache`, `data.json`)}")\n\n`;
+ 
+     const writeAndMove = (file, data) => {
+-      const destination = (0, _path.joinPath)(program.directory, `.cache`, file);
++      const destination = (0, _path.joinPath)(process.env.GATSBY_CACHE_DIR || (0, _path.joinPath)(program.directory, `.cache`), file);
+       const tmp = `${destination}.${Date.now()}`;
+       return fs.writeFile(tmp, data).then(() => fs.move(tmp, destination, {
+         overwrite: true
+diff --git a/node_modules/gatsby/dist/utils/babel-loader-helpers.js b/node_modules/gatsby/dist/utils/babel-loader-helpers.js
+index 4d3ac6c..0a9a435 100644
+--- a/node_modules/gatsby/dist/utils/babel-loader-helpers.js
++++ b/node_modules/gatsby/dist/utils/babel-loader-helpers.js
+@@ -15,7 +15,7 @@ const loadCachedConfig = () => {
+   };
+ 
+   if (process.env.NODE_ENV !== `test`) {
+-    pluginBabelConfig = require(path.join(process.cwd(), `./.cache/babelState.json`));
++    pluginBabelConfig = require(path.join(process.env.GATSBY_CACHE_DIR || path.join(process.cwd(), `./.cache`), `babelState.json`));
+   }
+ 
+   return pluginBabelConfig;
+diff --git a/node_modules/gatsby/dist/utils/html-renderer-queue.js b/node_modules/gatsby/dist/utils/html-renderer-queue.js
+index a9dfb2a..3a42dc9 100644
+--- a/node_modules/gatsby/dist/utils/html-renderer-queue.js
++++ b/node_modules/gatsby/dist/utils/html-renderer-queue.js
+@@ -24,7 +24,10 @@ module.exports = (htmlComponentRendererPath, pages, activity) => new Promise((re
+   const envVars = Object.entries({
+     NODE_ENV: process.env.NODE_ENV,
+     gatsby_executing_command: process.env.gatsby_executing_command,
+-    gatsby_log_level: process.env.gatsby_log_level
++    gatsby_log_level: process.env.gatsby_log_level,
++    NODE_PATH: process.env.NODE_PATH,
++    GATSBY_BUILD_DIR: process.env.GATSBY_BUILD_DIR,
++    GATSBY_CACHE_DIR: process.env.GATSBY_CACHE_DIR
+   });
+   const start = process.hrtime();
+   const segments = chunk(pages, 50);
+diff --git a/node_modules/gatsby/dist/utils/webpack.config.js b/node_modules/gatsby/dist/utils/webpack.config.js
+index d94fbe1..3cab803 100644
+--- a/node_modules/gatsby/dist/utils/webpack.config.js
++++ b/node_modules/gatsby/dist/utils/webpack.config.js
+@@ -193,7 +193,8 @@ function () {
+       let configPlugins = [plugins.moment(), // Add a few global variables. Set NODE_ENV to production (enables
+       // optimizations for React) and what the link prefix is (__PATH_PREFIX__).
+       plugins.define(Object.assign({}, processEnv(stage, `development`), {
+-        __PATH_PREFIX__: JSON.stringify(program.prefixPaths ? store.getState().config.pathPrefix : ``)
++        __PATH_PREFIX__: JSON.stringify(program.prefixPaths ? store.getState().config.pathPrefix : ``),
++        __PUBLIC_PATH__: JSON.stringify(process.env.GATSBY_BUILD_DIR || directoryPath(`public`)),
+       }))];
+ 
+       switch (stage) {
+@@ -319,12 +320,13 @@ function () {
+           "@babel/runtime": path.dirname(require.resolve(`@babel/runtime/package.json`)),
+           "core-js": path.dirname(require.resolve(`core-js/package.json`)),
+           "react-hot-loader": path.dirname(require.resolve(`react-hot-loader/package.json`)),
+-          "react-lifecycles-compat": directoryPath(`.cache/react-lifecycles-compat.js`),
+-          "create-react-context": directoryPath(`.cache/create-react-context.js`)
++          "react-lifecycles-compat": (process.env.GATSBY_CACHE_DIR || directoryPath(`.cache`)) + `/react-lifecycles-compat.js`,
++          "create-react-context": (process.env.GATSBY_CACHE_DIR || directoryPath(`.cache`)) + `/create-react-context.js`,
++          "gatsby-public-dir": process.env.GATSBY_BUILD_DIR || directoryPath(`public`)
+         },
+         plugins: [// Those two folders are special and contain gatsby-generated files
+         // whose dependencies should be resolved through the `gatsby` package
+-        PnpWebpackPlugin.bind(directoryPath(`.cache`), module), PnpWebpackPlugin.bind(directoryPath(`public`), module), // Transparently resolve packages via PnP when needed; noop otherwise
++        PnpWebpackPlugin.bind(process.env.GATSBY_CACHE_DIR || directoryPath(`.cache`), module), PnpWebpackPlugin.bind(process.env.GATSBY_BUILD_DIR || directoryPath(`public`), module), // Transparently resolve packages via PnP when needed; noop otherwise
+         PnpWebpackPlugin]
+       };
+     }
+diff --git a/node_modules/gatsby/dist/utils/worker.js b/node_modules/gatsby/dist/utils/worker.js
+index 542d07b..2d7cf58 100644
+--- a/node_modules/gatsby/dist/utils/worker.js
++++ b/node_modules/gatsby/dist/utils/worker.js
+@@ -17,7 +17,7 @@ const generatePathToOutput = outputPath => {
+     outputFileName = path.join(outputFileName, `index.html`);
+   }
+ 
+-  return path.join(process.cwd(), `public`, outputFileName);
++  return path.join(process.env.GATSBY_BUILD_DIR || path.join(process.cwd(), 'public'), outputFileName);
+ };
+ 
+ function renderHTML({
+@@ -28,6 +28,11 @@ function renderHTML({
+   // This is being executed in child process, so we need to set some vars
+   // for modules that aren't bundled by webpack.
+   envVars.forEach(([key, value]) => process.env[key] = value);
++
++  // if process.env.NODE_PATH is set, you need to update the directories
++  // node is looking for to match the parent.
++  require(`module`).Module._initPaths()
++
+   return Promise.map(paths, path => new Promise((resolve, reject) => {
+     const htmlComponentRenderer = require(htmlComponentRendererPath);
+ 

--- a/compiler/generate-docs/tasks/run-gatsby.js
+++ b/compiler/generate-docs/tasks/run-gatsby.js
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+
+// This file is here to hack into Gatsby. Gatsby is not made to be run outside
+// the current directly and output paths aren't configurable.
+// so we need some hack to make it work while waiting for it to be a gatsby feature
+// (discussions in progress)
+// ideally this should just be removed
+
+const { link } = require('linkfs')
+const mock = require('mock-require')
+const fs = require('fs')
+const path = require('path')
+
+// parse the arguments
+const { argv } = process
+argv._ = argv.slice(2)
+argv.noColor = argv.some(arg => arg === '--no-color')
+argv.verbose = argv.some(arg => arg === '--verbose')
+argv.prefixPaths = argv.some(arg => arg === '--prefix-paths')
+argv.port = 8000
+argv.host = 'localhost'
+/* eslint-disable prefer-destructuring */
+argv.command = argv[2]
+argv.buildDir = (
+  argv.find(arg => arg.indexOf('--build-dir') === 0) || '--build-dir=""'
+)
+  .split('--build-dir="')[1]
+  .split('"')[0]
+argv.cacheDir = (
+  argv.find(arg => arg.indexOf('--cache-dir') === 0) || '--cache-dir=""'
+)
+  .split('--cache-dir="')[1]
+  .split('"')[0]
+/* eslint-enable */
+
+// redirect the gatsby output paths to what we want
+const linkedFs = link(
+  fs,
+  [
+    [`${process.cwd()}/.cache`, argv.cacheDir],
+    [`${process.cwd()}/public`, argv.buildDir],
+  ].filter(x => x[1])
+)
+
+// those are missing in linkfs
+linkedFs.ReadStream = fs.ReadStream
+linkedFs.WriteStream = fs.WriteStream
+
+// replace fs with linkfs globally
+mock('fs', linkedFs)
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+const report = require('gatsby-cli/lib/reporter')
+
+report.setVerbose(!!argv.verbose)
+if (argv.some(arg => arg === '--no-color')) {
+  // disables colors in popular terminal output coloring packages
+  //  - chalk: see https://www.npmjs.com/package/chalk#chalksupportscolor
+  //  - ansi-colors: see https://github.com/doowb/ansi-colors/blob/8024126c7115a0efb25a9a0e87bc5e29fd66831f/index.js#L5-L7
+  process.env.FORCE_COLOR = `0`
+}
+
+report.setNoColor(!!argv.noColor)
+
+process.env.gatsby_log_level = argv.verbose ? `verbose` : `normal`
+report.verbose(`set gatsby_log_level: "${process.env.gatsby_log_level}"`)
+
+process.env.gatsby_executing_command = argv.command
+
+if (argv.command === 'develop') {
+  process.env.NODE_ENV = process.env.NODE_ENV || 'development'
+} else {
+  process.env.NODE_ENV = 'production'
+}
+
+process.env.GATSBY_BUILD_DIR =
+  argv.buildDir || path.join(process.cwd(), 'public')
+process.env.GATSBY_CACHE_DIR =
+  argv.cacheDir || path.join(process.cwd(), '.cache')
+
+const gatsby = require(`gatsby/dist/commands/${argv.command}`)
+const sitePackageJson = require('../package.json')
+
+gatsby({
+  ...argv,
+  directory: process.cwd(),
+  browserslist: sitePackageJson.browserslist || [`>0.25%`, `not dead`],
+  sitePackageJson,
+  report,
+  useYarn: true,
+})
+  .then(() => {
+    if (argv.command !== 'develop') {
+      process.exit(0)
+    }
+  })
+  .catch(err => {
+    console.error(err)
+    process.exit(1)
+  })

--- a/compiler/generate-docs/yarn.lock
+++ b/compiler/generate-docs/yarn.lock
@@ -802,7 +802,7 @@
     core-js "^2.6.5"
     regenerator-runtime "^0.13.2"
 
-"@babel/preset-env@^7.0.0", "@babel/preset-env@^7.3.1", "@babel/preset-env@^7.4.1":
+"@babel/preset-env@^7.3.1", "@babel/preset-env@^7.4.1":
   version "7.4.2"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.4.2.tgz#2f5ba1de2daefa9dcca653848f96c7ce2e406676"
   integrity sha512-OEz6VOZaI9LW08CWVS3d9g/0jZA6YCn1gsKIy/fut7yZCJti5Lm1/Hi+uo/U+ODm7g4I6gULrCP+/+laT8xAsA==
@@ -1040,178 +1040,6 @@
     react-sketchapp "^3.0.0-beta.8"
     react-test-renderer "^16.8.1"
     sketch-file "^0.2.0"
-
-"@mathieudutour/babel-plugin-remove-graphql-queries@^2.6.3":
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/@mathieudutour/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-2.6.3.tgz#39020953319b0858fae0a71d4d90ece6192fbad4"
-  integrity sha512-V6cd6wwR8eUIvy0j22inJuQ4P2SIyqsbJhfxjemwpCei7iPy+soNPj/aM6BRj/eUum2XM4FEtHOi7i0d6zBAng==
-
-"@mathieudutour/babel-preset-gatsby@^0.1.9":
-  version "0.1.9"
-  resolved "https://registry.yarnpkg.com/@mathieudutour/babel-preset-gatsby/-/babel-preset-gatsby-0.1.9.tgz#be9782930b640bae9b548205892587c5a4113cf3"
-  integrity sha512-EnZwAI6dA7lFcXg4/M1ukHKMjYiTfe4f+fjMt26dX+AP3UXEsB23/mNVCjcOCLoEQDAAek0IUDdjuz1vZUmuIw==
-  dependencies:
-    "@babel/plugin-proposal-class-properties" "^7.0.0"
-    "@babel/plugin-syntax-dynamic-import" "^7.0.0"
-    "@babel/plugin-transform-runtime" "^7.0.0"
-    "@babel/preset-env" "^7.0.0"
-    "@babel/preset-react" "^7.0.0"
-    babel-plugin-macros "^2.4.2"
-
-"@mathieudutour/gatsby-cli@^2.4.20":
-  version "2.4.20"
-  resolved "https://registry.yarnpkg.com/@mathieudutour/gatsby-cli/-/gatsby-cli-2.4.20.tgz#3e1cea05a113caf726b78507bd8d54732ce99bda"
-  integrity sha512-U7Gj49Z8Cs6Y5rDboOy56L2qk1GZGS0qOb2LLCvpZy/cedjx4pLCRxBT3At3zrEXBBWBiERNNzwiaUjWA5vCcA==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    "@babel/runtime" "^7.0.0"
-    bluebird "^3.5.0"
-    common-tags "^1.4.0"
-    convert-hrtime "^2.0.0"
-    core-js "^2.5.0"
-    envinfo "^5.8.1"
-    execa "^0.8.0"
-    fs-exists-cached "^1.0.0"
-    fs-extra "^4.0.1"
-    hosted-git-info "^2.6.0"
-    is-ci "^2.0.0"
-    lodash "^4.17.10"
-    meant "^1.0.1"
-    opentracing "^0.14.3"
-    pretty-error "^2.1.1"
-    resolve-cwd "^2.0.0"
-    source-map "^0.5.7"
-    stack-trace "^0.0.10"
-    update-notifier "^2.3.0"
-    yargs "^12.0.5"
-    yurnalist "^1.0.2"
-
-"@mathieudutour/gatsby@^2.1.51":
-  version "2.1.51"
-  resolved "https://registry.yarnpkg.com/@mathieudutour/gatsby/-/gatsby-2.1.51.tgz#8ce096941bbff9f978db94f42fa62998267524d5"
-  integrity sha512-HdPfKjC5qqvYhosQMBCoFuRKJ+DgNfYs5SdTBuEGtSPliyyCm74/XN2E7A7hZQYaJ5hay1W6/sUDMK8uyMNaZQ==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    "@babel/core" "^7.0.0"
-    "@babel/parser" "^7.0.0"
-    "@babel/polyfill" "^7.0.0"
-    "@babel/runtime" "^7.0.0"
-    "@babel/traverse" "^7.0.0"
-    "@gatsbyjs/relay-compiler" "2.0.0-printer-fix.2"
-    "@mathieudutour/babel-plugin-remove-graphql-queries" "^2.6.3"
-    "@mathieudutour/babel-preset-gatsby" "^0.1.9"
-    "@mathieudutour/gatsby-cli" "^2.4.20"
-    "@reach/router" "^1.1.1"
-    address "1.0.3"
-    autoprefixer "^9.4.3"
-    babel-core "7.0.0-bridge.0"
-    babel-eslint "^9.0.0"
-    babel-loader "^8.0.0"
-    babel-plugin-add-module-exports "^0.2.1"
-    babel-plugin-dynamic-import-node "^1.2.0"
-    better-opn "0.1.4"
-    better-queue "^3.8.6"
-    bluebird "^3.5.0"
-    browserslist "3.2.8"
-    cache-manager "^2.9.0"
-    cache-manager-fs-hash "^0.0.6"
-    chalk "^2.3.2"
-    chokidar "^2.0.2"
-    common-tags "^1.4.0"
-    compression "^1.7.3"
-    convert-hrtime "^2.0.0"
-    copyfiles "^1.2.0"
-    core-js "^2.5.0"
-    css-loader "^1.0.0"
-    debug "^3.1.0"
-    del "^3.0.0"
-    detect-port "^1.2.1"
-    devcert-san "^0.3.3"
-    domready "^1.0.8"
-    dotenv "^4.0.0"
-    eslint "^5.6.0"
-    eslint-config-react-app "^3.0.0"
-    eslint-loader "^2.1.0"
-    eslint-plugin-flowtype "^2.46.1"
-    eslint-plugin-graphql "^2.0.0"
-    eslint-plugin-import "^2.9.0"
-    eslint-plugin-jsx-a11y "^6.0.3"
-    eslint-plugin-react "^7.8.2"
-    event-source-polyfill "^1.0.5"
-    express "^4.16.3"
-    express-graphql "^0.6.12"
-    fast-levenshtein "~2.0.4"
-    file-loader "^1.1.11"
-    flat "^4.0.0"
-    friendly-errors-webpack-plugin "^1.6.1"
-    fs-exists-cached "1.0.0"
-    fs-extra "^5.0.0"
-    gatsby-link "^2.0.16"
-    gatsby-plugin-page-creator "^2.0.10"
-    gatsby-react-router-scroll "^2.0.5"
-    glob "^7.1.1"
-    graphql "^14.1.1"
-    graphql-playground-middleware-express "^1.7.10"
-    graphql-relay "^0.6.0"
-    graphql-skip-limit "^2.0.6"
-    graphql-tools "^3.0.4"
-    graphql-type-json "^0.2.1"
-    hash-mod "^0.0.5"
-    invariant "^2.2.4"
-    is-relative "^1.0.0"
-    is-relative-url "^2.0.0"
-    jest-worker "^23.2.0"
-    joi "12.x.x"
-    json-loader "^0.5.7"
-    json-stringify-safe "^5.0.1"
-    kebab-hash "^0.1.2"
-    lodash "^4.17.10"
-    lokijs "^1.5.6"
-    md5 "^2.2.1"
-    md5-file "^3.1.1"
-    mime "^2.2.0"
-    mini-css-extract-plugin "^0.4.0"
-    mitt "^1.1.2"
-    mkdirp "^0.5.1"
-    moment "^2.21.0"
-    name-all-modules-plugin "^1.0.1"
-    normalize-path "^2.1.1"
-    null-loader "^0.1.1"
-    opentracing "^0.14.3"
-    optimize-css-assets-webpack-plugin "^5.0.1"
-    parseurl "^1.3.2"
-    physical-cpu-count "^2.0.0"
-    postcss-flexbugs-fixes "^3.0.0"
-    postcss-loader "^2.1.3"
-    prop-types "^15.6.1"
-    raw-loader "^0.5.1"
-    react-dev-utils "^4.2.1"
-    react-error-overlay "^3.0.0"
-    react-hot-loader "^4.6.2"
-    redux "^4.0.0"
-    request "^2.85.0"
-    semver "^5.6.0"
-    shallow-compare "^1.2.2"
-    sift "^5.1.0"
-    signal-exit "^3.0.2"
-    slash "^1.0.0"
-    socket.io "^2.0.3"
-    stack-trace "^0.0.10"
-    string-similarity "^1.2.0"
-    style-loader "^0.21.0"
-    terser-webpack-plugin "^1.2.2"
-    "true-case-path" "^1.0.3"
-    type-of "^2.0.1"
-    url-loader "^1.0.1"
-    uuid "^3.1.0"
-    v8-compile-cache "^1.1.0"
-    webpack "~4.28.4"
-    webpack-dev-middleware "^3.0.1"
-    webpack-dev-server "^3.1.14"
-    webpack-hot-middleware "^2.21.0"
-    webpack-merge "^4.1.0"
-    webpack-stats-plugin "^0.1.5"
-    yaml-loader "^0.5.0"
 
 "@mdx-js/mdx@^1.0.0":
   version "1.0.2"
@@ -1538,6 +1366,11 @@
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.1.tgz#5c85d662f76fa1d34575766c5dcd6615abcd30d8"
   integrity sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g==
+
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
 
 abbrev@1:
   version "1.1.1"
@@ -4701,6 +4534,14 @@ find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
+find-yarn-workspace-root@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/find-yarn-workspace-root/-/find-yarn-workspace-root-1.2.1.tgz#40eb8e6e7c2502ddfaa2577c176f221422f860db"
+  integrity sha512-dVtfb0WuQG+8Ag2uWkbG79hOUzEsRrhBzgfn86g2sJPkzmcpGdghbNTfUKGTxymFrY/tLIodDzLoW9nOJ4FY8Q==
+  dependencies:
+    fs-extra "^4.0.3"
+    micromatch "^3.1.4"
+
 flat-cache@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0"
@@ -4773,15 +4614,6 @@ fresh@0.5.2:
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
 
-friendly-errors-webpack-plugin@^1.6.1:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/friendly-errors-webpack-plugin/-/friendly-errors-webpack-plugin-1.7.0.tgz#efc86cbb816224565861a1be7a9d84d0aafea136"
-  integrity sha512-K27M3VK30wVoOarP651zDmb93R9zF28usW4ocaK3mfQeIEI5BPht/EzZs5E8QLLwbLRJQMwscAjDxYPb1FuNiw==
-  dependencies:
-    chalk "^1.1.3"
-    error-stack-parser "^2.0.0"
-    string-width "^2.0.0"
-
 from2@^2.1.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/from2/-/from2-2.3.0.tgz#8bfb5502bde4a4d36cfdeea007fcca21d7e382af"
@@ -4795,7 +4627,7 @@ fs-exists-cached@1.0.0, fs-exists-cached@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs-exists-cached/-/fs-exists-cached-1.0.0.tgz#cf25554ca050dc49ae6656b41de42258989dcbce"
   integrity sha1-zyVVTKBQ3EmuZla0HeQiWJidy84=
 
-fs-extra@^4.0.1:
+fs-extra@^4.0.1, fs-extra@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
   integrity sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==
@@ -4891,7 +4723,7 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
-gatsby-cli@^2.5.4:
+gatsby-cli@2.5.4, gatsby-cli@^2.5.4:
   version "2.5.4"
   resolved "https://registry.yarnpkg.com/gatsby-cli/-/gatsby-cli-2.5.4.tgz#d11a00f61227a6db7965e71ac93e142d73b25587"
   integrity sha512-tjkE0+H6ZV0hVwH/A4ld3/M2C12Apd5HMgjfI9r5hjSeN0yMEsohnky/mm4uFF8Pt3zfqPrL8XXpg2D9kY16Hg==
@@ -4961,7 +4793,7 @@ gatsby-mdx@^0.6.1:
     unist-util-remove "^1.0.1"
     unist-util-visit "^1.4.0"
 
-gatsby-plugin-page-creator@^2.0.10, gatsby-plugin-page-creator@^2.0.12:
+gatsby-plugin-page-creator@^2.0.12:
   version "2.0.12"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.0.12.tgz#00a5103715881e141c81b68b670ad8fb06291b7d"
   integrity sha512-Pb4jpcI4Fqr6pqDdwm1+8DsyesZwBcvoQyDDvLBF+hbWD33iURjBqTrL8quTNtIO4svLkfieIdQ8D4IhlpFCmw==
@@ -4990,7 +4822,7 @@ gatsby-plugin-styled-components@^3.0.5:
   dependencies:
     "@babel/runtime" "^7.0.0"
 
-gatsby-react-router-scroll@^2.0.5, gatsby-react-router-scroll@^2.0.7:
+gatsby-react-router-scroll@^2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/gatsby-react-router-scroll/-/gatsby-react-router-scroll-2.0.7.tgz#b9425e366d4be546036080d85664d60ae76e6c29"
   integrity sha512-Yq8UBgurjt5XqezkBr67ZmMmsxFPdGG/7OERlju34PL05mAwOB1P2wdcZfjpVZM/k2xfVPcTRYk2zoUbtB/adg==
@@ -5018,7 +4850,7 @@ gatsby-telemetry@^1.0.4:
     stack-utils "1.0.2"
     uuid "3.3.2"
 
-gatsby@^2.1.30:
+gatsby@2.3.4:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/gatsby/-/gatsby-2.3.4.tgz#4f8b2a7649b645779333535860c34e576eb8321a"
   integrity sha512-H23UIbrYtjpSnzzE8VxW3U25fP9eM5CY/RQs4obv1sYaHI6sFUN3S97v+hvdMRg64zfkAnTGRZ2gsjHQUOTHlA==
@@ -5162,7 +4994,7 @@ gauge@~2.7.3:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
-get-caller-file@^1.0.1:
+get-caller-file@^1.0.1, get-caller-file@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
   integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
@@ -5364,13 +5196,6 @@ graphql-request@^1.5.0:
   dependencies:
     cross-fetch "2.2.2"
 
-graphql-skip-limit@^2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/graphql-skip-limit/-/graphql-skip-limit-2.0.6.tgz#67cdfbf33254db338aade6e7b44ea3e779b4b1c4"
-  integrity sha512-Jg/K/Tvxno5Rkq+KRwEZ0ME+PZBRrgDIvYIUvYMj8/hitc38hXen1XLuHEbqfrlkmrzPzQv6TB6W5utfZwJs+Q==
-  dependencies:
-    "@babel/runtime" "^7.0.0"
-
 graphql-tools@^3.0.4:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-3.1.1.tgz#d593358f01e7c8b1671a17b70ddb034dea9dbc50"
@@ -5382,7 +5207,7 @@ graphql-tools@^3.0.4:
     iterall "^1.1.3"
     uuid "^3.1.0"
 
-graphql-type-json@^0.2.1, graphql-type-json@^0.2.2:
+graphql-type-json@^0.2.2:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/graphql-type-json/-/graphql-type-json-0.2.4.tgz#545af27903e40c061edd30840a272ea0a49992f9"
   integrity sha512-/tq02ayMQjrG4oDFDRLLrPk0KvJXue0nVXoItBe7uAdbNXjQUu+HYCBdAmPLQoseVzUKKMzrhq2P/sfI76ON6w==
@@ -6582,6 +6407,13 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
   integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
 
+klaw-sync@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-6.0.0.tgz#1fd2cfd56ebb6250181114f0a581167099c2b28c"
+  integrity sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==
+  dependencies:
+    graceful-fs "^4.1.11"
+
 last-call-webpack-plugin@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/last-call-webpack-plugin/-/last-call-webpack-plugin-3.0.0.tgz#9742df0e10e3cf46e5c0381c2de90d3a7a2d7555"
@@ -6630,6 +6462,11 @@ lie@~3.3.0:
   integrity sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==
   dependencies:
     immediate "~3.0.5"
+
+linkfs@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/linkfs/-/linkfs-2.1.0.tgz#5cc774ad8ed6b0aae5a858bd67e3334cc300a917"
+  integrity sha512-kmsGcmpvjStZ0ATjuHycBujtNnXiZR28BTivEu0gAMDTT7GEyodcK6zSRtu6xsrdorrPZEIN380x7BD7xEYkew==
 
 load-json-file@^2.0.0:
   version "2.0.0"
@@ -7287,6 +7124,14 @@ mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdi
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
+
+mock-require@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/mock-require/-/mock-require-3.0.3.tgz#ccd544d9eae81dd576b3f219f69ec867318a1946"
+  integrity sha512-lLzfLHcyc10MKQnNUCv7dMcoY/2Qxd6wJfbqCcVk3LDb8An4hF6ohk5AztrvgKhJCqj36uyzi/p5se+tvyD+Wg==
+  dependencies:
+    get-caller-file "^1.0.2"
+    normalize-path "^2.1.1"
 
 moment@^2.21.0:
   version "2.24.0"
@@ -8109,6 +7954,25 @@ pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
+
+patch-sibling-package@^6.1.5:
+  version "6.1.5"
+  resolved "https://registry.yarnpkg.com/patch-sibling-package/-/patch-sibling-package-6.1.5.tgz#a536bfa9c777831837e761085253cb995f289712"
+  integrity sha512-5gCAglMBr0tmkfATS5iRd3UDmTFQr5PJi1UZU1/kG68g3Jm8zQP+lLBtAdGTgNqvMp+0bINPhhTBGNM1vN7fCw==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    chalk "^2.4.2"
+    cross-spawn "^6.0.5"
+    find-yarn-workspace-root "^1.2.1"
+    fs-extra "^7.0.1"
+    is-ci "^2.0.0"
+    klaw-sync "^6.0.0"
+    minimist "^1.2.0"
+    rimraf "^2.6.3"
+    semver "^5.6.0"
+    slash "^2.0.0"
+    tmp "^0.0.33"
+    update-notifier "^2.5.0"
 
 path-browserify@0.0.0:
   version "0.0.0"
@@ -9496,7 +9360,7 @@ rgba-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
   integrity sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=
 
-rimraf@2, rimraf@2.6.3, rimraf@^2.2.8, rimraf@^2.5.0, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
+rimraf@2, rimraf@2.6.3, rimraf@^2.2.8, rimraf@^2.5.0, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
@@ -10941,7 +10805,7 @@ upath@^1.1.0, upath@^1.1.1:
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.2.tgz#3db658600edaeeccbe6db5e684d67ee8c2acd068"
   integrity sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==
 
-update-notifier@^2.3.0:
+update-notifier@^2.3.0, update-notifier@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-2.5.0.tgz#d0744593e13f161e406acb1d9408b72cad08aff6"
   integrity sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==


### PR DESCRIPTION
## What

So I changed my mind. Instead of forking gatsby and trying to maintain a separate fork, I'm just going to patch it using https://github.com/ds300/patch-package and setup a redirect on the `fs` package level. That's ugly but it removes the need to have 2 different version of gatsby and parallel and I was never going to be able to maintain the fork.
Hopefully the patches are small enough that they are manageable.
