### PR TITLE
fix copy pasta of token preview type

### DIFF
--- a/compiler/core/src/tokens/tokenHtml.re
+++ b/compiler/core/src/tokens/tokenHtml.re
@@ -95,7 +95,7 @@ let convert = (token: TokenTypes.token): string => {
               [
                 {
                   XmlAst.name: "class",
-                  value: "lona-token-preview lona-token-preview-color",
+                  value: "lona-token-preview lona-token-preview-shadow",
                 },
               ]
               @ (
@@ -153,7 +153,7 @@ let convert = (token: TokenTypes.token): string => {
               [
                 {
                   XmlAst.name: "class",
-                  value: "lona-token-preview lona-token-preview-color",
+                  value: "lona-token-preview lona-token-preview-textStyle",
                 },
               ]
               @ (


### PR DESCRIPTION
## What

- fix typos in class names of token previews


cc: @dabbott
