### PR TITLE
Automatically configure SSH key for user

### DIFF
--- a/studio/LonaStudio.xcodeproj/project.pbxproj
+++ b/studio/LonaStudio.xcodeproj/project.pbxproj
@@ -276,6 +276,8 @@
 		6B7DBF6022A87B050062031E /* LogicViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B7DBF5F22A87B050062031E /* LogicViewController.swift */; };
 		6B7DBF6422A885350062031E /* LogicNumberInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B7DBF6322A885350062031E /* LogicNumberInput.swift */; };
 		6B80645A21D8322B006560C7 /* CanvasTableHeaderExtra.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B80645921D8322A006560C7 /* CanvasTableHeaderExtra.swift */; };
+		6B82AD2724204210004C6BC0 /* SSH.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B82AD2624204210004C6BC0 /* SSH.swift */; };
+		6B82AD29242056FF004C6BC0 /* RESTClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B82AD28242056FF004C6BC0 /* RESTClient.swift */; };
 		6B87001622EFBC42007C589C /* Logic+Builders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B87001522EFBC42007C589C /* Logic+Builders.swift */; };
 		6B892C6022CAB81600D0AEDA /* GeneratedOutputPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B892C5F22CAB81500D0AEDA /* GeneratedOutputPreview.swift */; };
 		6B8D1E8823FCE9AF00EA6E40 /* NSError+String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8D1E8723FCE9AF00EA6E40 /* NSError+String.swift */; };
@@ -676,6 +678,8 @@
 		6B7DBF5F22A87B050062031E /* LogicViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogicViewController.swift; sourceTree = "<group>"; };
 		6B7DBF6322A885350062031E /* LogicNumberInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogicNumberInput.swift; sourceTree = "<group>"; };
 		6B80645921D8322A006560C7 /* CanvasTableHeaderExtra.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CanvasTableHeaderExtra.swift; sourceTree = "<group>"; };
+		6B82AD2624204210004C6BC0 /* SSH.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSH.swift; sourceTree = "<group>"; };
+		6B82AD28242056FF004C6BC0 /* RESTClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RESTClient.swift; sourceTree = "<group>"; };
 		6B87001522EFBC42007C589C /* Logic+Builders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Logic+Builders.swift"; sourceTree = "<group>"; };
 		6B892C5F22CAB81500D0AEDA /* GeneratedOutputPreview.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratedOutputPreview.swift; sourceTree = "<group>"; };
 		6B8D1E8723FCE9AF00EA6E40 /* NSError+String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSError+String.swift"; sourceTree = "<group>"; };
@@ -961,6 +965,7 @@
 				3069E0991F3243780005E9A8 /* parseCSSColor.swift */,
 				6BE99D7723CD2F4300E35E35 /* Promise.swift */,
 				6BE99D7923CE50CC00E35E35 /* Promise+AppKit.swift */,
+				6B82AD28242056FF004C6BC0 /* RESTClient.swift */,
 				30ACB4E41F663D0A00EEFED6 /* Sketch.swift */,
 				303BDE6C1F76E61300B4CE5A /* VideoUtils.swift */,
 				303C3FE720A375E8008E1541 /* VirtualFileSystem.swift */,
@@ -1361,6 +1366,7 @@
 			isa = PBXGroup;
 			children = (
 				6B6E473823FE0BC30067B2FF /* Git.swift */,
+				6B82AD2624204210004C6BC0 /* SSH.swift */,
 			);
 			path = VersionControl;
 			sourceTree = "<group>";
@@ -1857,6 +1863,7 @@
 				036A4E8A21E0DFE700948DBD /* LonaFileIcon.swift in Sources */,
 				0304A72123FD26CF009A1E82 /* LonaAPI.swift in Sources */,
 				30F870EB20869644007ADA5B /* Fetch.swift in Sources */,
+				6B82AD29242056FF004C6BC0 /* RESTClient.swift in Sources */,
 				303C3FF520A4E3C1008E1541 /* ComponentPreviewCollection.swift in Sources */,
 				3090D7D31F032305009277E7 /* CSComponentLayer.swift in Sources */,
 				6B73809422C66E59007534A0 /* TemplateBrowser.swift in Sources */,
@@ -1919,6 +1926,7 @@
 				6B4DFCEB20A75B900048BB43 /* ColorPreviewCard.swift in Sources */,
 				30DE88091FBA18A600D62A50 /* NSPopoverExtensions.swift in Sources */,
 				307D44102097DC17004B57F5 /* TabIcon.swift in Sources */,
+				6B82AD2724204210004C6BC0 /* SSH.swift in Sources */,
 				30EFC9561EF1AA0B0087711D /* StringExtensions.swift in Sources */,
 				309777741F2BB75B004C8975 /* CSUserPreferences.swift in Sources */,
 				3094DFE31F68D19C00E5C7F0 /* CALayerExtensions.swift in Sources */,

--- a/studio/LonaStudio/Extensions/Process+Execute.swift
+++ b/studio/LonaStudio/Extensions/Process+Execute.swift
@@ -65,6 +65,9 @@ extension Process {
                         complete(.success(buffer))
                     } else {
                         let commandString = ([process.launchPath ?? ""] + (process.arguments ?? [])).joined(separator: " ")
+
+                        Swift.print("Command failed: \(commandString)\n\(buffer.utf8String() ?? "")\n\(stderrBuffer.utf8String() ?? "")")
+
                         let error = ProcessError(command: commandString, code: Int(process.terminationStatus), output: buffer, errorOutput: stderrBuffer)
                         complete(.failure(error))
                     }

--- a/studio/LonaStudio/Generated/screens/PublishInfo.swift
+++ b/studio/LonaStudio/Generated/screens/PublishInfo.swift
@@ -18,8 +18,21 @@ public class PublishInfo: NSBox {
     update()
   }
 
-  public convenience init(titleText: String, bodyText: String) {
-    self.init(Parameters(titleText: titleText, bodyText: bodyText))
+  public convenience init(
+    titleText: String,
+    bodyText: String,
+    showsCancelButton: Bool,
+    doneButtonTitle: String,
+    cancelButtonTitle: String)
+  {
+    self
+      .init(
+        Parameters(
+          titleText: titleText,
+          bodyText: bodyText,
+          showsCancelButton: showsCancelButton,
+          doneButtonTitle: doneButtonTitle,
+          cancelButtonTitle: cancelButtonTitle))
   }
 
   public convenience init() {
@@ -62,6 +75,38 @@ public class PublishInfo: NSBox {
     set { parameters.onClickDoneButton = newValue }
   }
 
+  public var showsCancelButton: Bool {
+    get { return parameters.showsCancelButton }
+    set {
+      if parameters.showsCancelButton != newValue {
+        parameters.showsCancelButton = newValue
+      }
+    }
+  }
+
+  public var doneButtonTitle: String {
+    get { return parameters.doneButtonTitle }
+    set {
+      if parameters.doneButtonTitle != newValue {
+        parameters.doneButtonTitle = newValue
+      }
+    }
+  }
+
+  public var cancelButtonTitle: String {
+    get { return parameters.cancelButtonTitle }
+    set {
+      if parameters.cancelButtonTitle != newValue {
+        parameters.cancelButtonTitle = newValue
+      }
+    }
+  }
+
+  public var onClickCancelButton: (() -> Void)? {
+    get { return parameters.onClickCancelButton }
+    set { parameters.onClickCancelButton = newValue }
+  }
+
   public var parameters: Parameters {
     didSet {
       if parameters != oldValue {
@@ -78,11 +123,26 @@ public class PublishInfo: NSBox {
   private var bodyTextView = LNATextField(labelWithString: "")
   private var vSpacer1View = NSBox()
   private var view1View = NSBox()
+  private var cancelContainerView = NSBox()
+  private var cancelButtonView = PrimaryButton()
+  private var view3View = NSBox()
   private var viewView = NSBox()
   private var doneButtonView = PrimaryButton()
 
   private var publishTextViewTextStyle = TextStyles.titleLight
   private var bodyTextViewTextStyle = TextStyles.body
+
+  private var view3ViewLeadingAnchorView1ViewLeadingAnchorConstraint: NSLayoutConstraint?
+  private var cancelContainerViewHeightAnchorParentConstraint: NSLayoutConstraint?
+  private var cancelContainerViewLeadingAnchorView1ViewLeadingAnchorConstraint: NSLayoutConstraint?
+  private var cancelContainerViewTopAnchorView1ViewTopAnchorConstraint: NSLayoutConstraint?
+  private var cancelContainerViewBottomAnchorView1ViewBottomAnchorConstraint: NSLayoutConstraint?
+  private var view3ViewLeadingAnchorCancelContainerViewTrailingAnchorConstraint: NSLayoutConstraint?
+  private var cancelContainerViewWidthAnchorConstraint: NSLayoutConstraint?
+  private var cancelButtonViewTopAnchorCancelContainerViewTopAnchorConstraint: NSLayoutConstraint?
+  private var cancelButtonViewBottomAnchorCancelContainerViewBottomAnchorConstraint: NSLayoutConstraint?
+  private var cancelButtonViewLeadingAnchorCancelContainerViewLeadingAnchorConstraint: NSLayoutConstraint?
+  private var cancelButtonViewTrailingAnchorCancelContainerViewTrailingAnchorConstraint: NSLayoutConstraint?
 
   private func setUpViews() {
     boxType = .custom
@@ -102,6 +162,12 @@ public class PublishInfo: NSBox {
     view1View.borderType = .noBorder
     view1View.contentViewMargins = .zero
     publishTextView.lineBreakMode = .byWordWrapping
+    cancelContainerView.boxType = .custom
+    cancelContainerView.borderType = .noBorder
+    cancelContainerView.contentViewMargins = .zero
+    view3View.boxType = .custom
+    view3View.borderType = .noBorder
+    view3View.contentViewMargins = .zero
     viewView.boxType = .custom
     viewView.borderType = .noBorder
     viewView.contentViewMargins = .zero
@@ -112,7 +178,10 @@ public class PublishInfo: NSBox {
     addSubview(vSpacer1View)
     addSubview(view1View)
     titleContainerView.addSubview(publishTextView)
+    view1View.addSubview(cancelContainerView)
+    view1View.addSubview(view3View)
     view1View.addSubview(viewView)
+    cancelContainerView.addSubview(cancelButtonView)
     viewView.addSubview(doneButtonView)
 
     publishTextViewTextStyle = TextStyles.titleLight
@@ -121,7 +190,6 @@ public class PublishInfo: NSBox {
     bodyTextViewTextStyle = TextStyles.body
     bodyTextView.attributedStringValue = bodyTextViewTextStyle.apply(to: bodyTextView.attributedStringValue)
     vSpacer1View.fillColor = #colorLiteral(red: 0.847058823529, green: 0.847058823529, blue: 0.847058823529, alpha: 1)
-    doneButtonView.titleText = "OK"
   }
 
   private func setUpConstraints() {
@@ -132,7 +200,10 @@ public class PublishInfo: NSBox {
     vSpacer1View.translatesAutoresizingMaskIntoConstraints = false
     view1View.translatesAutoresizingMaskIntoConstraints = false
     publishTextView.translatesAutoresizingMaskIntoConstraints = false
+    cancelContainerView.translatesAutoresizingMaskIntoConstraints = false
+    view3View.translatesAutoresizingMaskIntoConstraints = false
     viewView.translatesAutoresizingMaskIntoConstraints = false
+    cancelButtonView.translatesAutoresizingMaskIntoConstraints = false
     doneButtonView.translatesAutoresizingMaskIntoConstraints = false
 
     let titleContainerViewTopAnchorConstraint = titleContainerView.topAnchor.constraint(equalTo: topAnchor)
@@ -165,9 +236,18 @@ public class PublishInfo: NSBox {
     let vSpacerViewWidthAnchorConstraint = vSpacerView.widthAnchor.constraint(equalToConstant: 0)
     let vSpacer1ViewHeightAnchorConstraint = vSpacer1View.heightAnchor.constraint(equalToConstant: 72)
     let vSpacer1ViewWidthAnchorConstraint = vSpacer1View.widthAnchor.constraint(equalToConstant: 0)
+    let view3ViewHeightAnchorParentConstraint = view3View
+      .heightAnchor
+      .constraint(lessThanOrEqualTo: view1View.heightAnchor)
+    let viewViewHeightAnchorParentConstraint = viewView
+      .heightAnchor
+      .constraint(lessThanOrEqualTo: view1View.heightAnchor)
+    let view3ViewTopAnchorConstraint = view3View.topAnchor.constraint(equalTo: view1View.topAnchor)
+    let view3ViewBottomAnchorConstraint = view3View.bottomAnchor.constraint(equalTo: view1View.bottomAnchor)
+    let viewViewTrailingAnchorConstraint = viewView.trailingAnchor.constraint(equalTo: view1View.trailingAnchor)
+    let viewViewLeadingAnchorConstraint = viewView.leadingAnchor.constraint(equalTo: view3View.trailingAnchor)
     let viewViewTopAnchorConstraint = viewView.topAnchor.constraint(equalTo: view1View.topAnchor)
     let viewViewBottomAnchorConstraint = viewView.bottomAnchor.constraint(equalTo: view1View.bottomAnchor)
-    let viewViewTrailingAnchorConstraint = viewView.trailingAnchor.constraint(equalTo: view1View.trailingAnchor)
     let viewViewWidthAnchorConstraint = viewView.widthAnchor.constraint(equalToConstant: 250)
     let doneButtonViewTopAnchorConstraint = doneButtonView.topAnchor.constraint(equalTo: viewView.topAnchor)
     let doneButtonViewBottomAnchorConstraint = doneButtonView.bottomAnchor.constraint(equalTo: viewView.bottomAnchor)
@@ -175,51 +255,151 @@ public class PublishInfo: NSBox {
     let doneButtonViewTrailingAnchorConstraint = doneButtonView
       .trailingAnchor
       .constraint(equalTo: viewView.trailingAnchor)
+    let view3ViewLeadingAnchorView1ViewLeadingAnchorConstraint = view3View
+      .leadingAnchor
+      .constraint(equalTo: view1View.leadingAnchor)
+    let cancelContainerViewHeightAnchorParentConstraint = cancelContainerView
+      .heightAnchor
+      .constraint(lessThanOrEqualTo: view1View.heightAnchor)
+    let cancelContainerViewLeadingAnchorView1ViewLeadingAnchorConstraint = cancelContainerView
+      .leadingAnchor
+      .constraint(equalTo: view1View.leadingAnchor)
+    let cancelContainerViewTopAnchorView1ViewTopAnchorConstraint = cancelContainerView
+      .topAnchor
+      .constraint(equalTo: view1View.topAnchor)
+    let cancelContainerViewBottomAnchorView1ViewBottomAnchorConstraint = cancelContainerView
+      .bottomAnchor
+      .constraint(equalTo: view1View.bottomAnchor)
+    let view3ViewLeadingAnchorCancelContainerViewTrailingAnchorConstraint = view3View
+      .leadingAnchor
+      .constraint(equalTo: cancelContainerView.trailingAnchor)
+    let cancelContainerViewWidthAnchorConstraint = cancelContainerView.widthAnchor.constraint(equalToConstant: 250)
+    let cancelButtonViewTopAnchorCancelContainerViewTopAnchorConstraint = cancelButtonView
+      .topAnchor
+      .constraint(equalTo: cancelContainerView.topAnchor)
+    let cancelButtonViewBottomAnchorCancelContainerViewBottomAnchorConstraint = cancelButtonView
+      .bottomAnchor
+      .constraint(equalTo: cancelContainerView.bottomAnchor)
+    let cancelButtonViewLeadingAnchorCancelContainerViewLeadingAnchorConstraint = cancelButtonView
+      .leadingAnchor
+      .constraint(equalTo: cancelContainerView.leadingAnchor)
+    let cancelButtonViewTrailingAnchorCancelContainerViewTrailingAnchorConstraint = cancelButtonView
+      .trailingAnchor
+      .constraint(equalTo: cancelContainerView.trailingAnchor)
 
     publishTextViewHeightAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
+    view3ViewHeightAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
+    viewViewHeightAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
+    cancelContainerViewHeightAnchorParentConstraint.priority = NSLayoutConstraint.Priority.defaultLow
 
-    NSLayoutConstraint.activate([
-      titleContainerViewTopAnchorConstraint,
-      titleContainerViewLeadingAnchorConstraint,
-      titleContainerViewTrailingAnchorConstraint,
-      vSpacerViewTopAnchorConstraint,
-      vSpacerViewLeadingAnchorConstraint,
-      bodyTextViewTopAnchorConstraint,
-      bodyTextViewLeadingAnchorConstraint,
-      bodyTextViewTrailingAnchorConstraint,
-      vSpacer1ViewTopAnchorConstraint,
-      vSpacer1ViewLeadingAnchorConstraint,
-      view1ViewBottomAnchorConstraint,
-      view1ViewTopAnchorConstraint,
-      view1ViewLeadingAnchorConstraint,
-      view1ViewTrailingAnchorConstraint,
-      publishTextViewHeightAnchorParentConstraint,
-      publishTextViewLeadingAnchorConstraint,
-      publishTextViewTopAnchorConstraint,
-      publishTextViewBottomAnchorConstraint,
-      vSpacerViewHeightAnchorConstraint,
-      vSpacerViewWidthAnchorConstraint,
-      vSpacer1ViewHeightAnchorConstraint,
-      vSpacer1ViewWidthAnchorConstraint,
-      viewViewTopAnchorConstraint,
-      viewViewBottomAnchorConstraint,
-      viewViewTrailingAnchorConstraint,
-      viewViewWidthAnchorConstraint,
-      doneButtonViewTopAnchorConstraint,
-      doneButtonViewBottomAnchorConstraint,
-      doneButtonViewLeadingAnchorConstraint,
-      doneButtonViewTrailingAnchorConstraint
-    ])
+    self.view3ViewLeadingAnchorView1ViewLeadingAnchorConstraint = view3ViewLeadingAnchorView1ViewLeadingAnchorConstraint
+    self.cancelContainerViewHeightAnchorParentConstraint = cancelContainerViewHeightAnchorParentConstraint
+    self.cancelContainerViewLeadingAnchorView1ViewLeadingAnchorConstraint =
+      cancelContainerViewLeadingAnchorView1ViewLeadingAnchorConstraint
+    self.cancelContainerViewTopAnchorView1ViewTopAnchorConstraint =
+      cancelContainerViewTopAnchorView1ViewTopAnchorConstraint
+    self.cancelContainerViewBottomAnchorView1ViewBottomAnchorConstraint =
+      cancelContainerViewBottomAnchorView1ViewBottomAnchorConstraint
+    self.view3ViewLeadingAnchorCancelContainerViewTrailingAnchorConstraint =
+      view3ViewLeadingAnchorCancelContainerViewTrailingAnchorConstraint
+    self.cancelContainerViewWidthAnchorConstraint = cancelContainerViewWidthAnchorConstraint
+    self.cancelButtonViewTopAnchorCancelContainerViewTopAnchorConstraint =
+      cancelButtonViewTopAnchorCancelContainerViewTopAnchorConstraint
+    self.cancelButtonViewBottomAnchorCancelContainerViewBottomAnchorConstraint =
+      cancelButtonViewBottomAnchorCancelContainerViewBottomAnchorConstraint
+    self.cancelButtonViewLeadingAnchorCancelContainerViewLeadingAnchorConstraint =
+      cancelButtonViewLeadingAnchorCancelContainerViewLeadingAnchorConstraint
+    self.cancelButtonViewTrailingAnchorCancelContainerViewTrailingAnchorConstraint =
+      cancelButtonViewTrailingAnchorCancelContainerViewTrailingAnchorConstraint
+
+    NSLayoutConstraint.activate(
+      [
+        titleContainerViewTopAnchorConstraint,
+        titleContainerViewLeadingAnchorConstraint,
+        titleContainerViewTrailingAnchorConstraint,
+        vSpacerViewTopAnchorConstraint,
+        vSpacerViewLeadingAnchorConstraint,
+        bodyTextViewTopAnchorConstraint,
+        bodyTextViewLeadingAnchorConstraint,
+        bodyTextViewTrailingAnchorConstraint,
+        vSpacer1ViewTopAnchorConstraint,
+        vSpacer1ViewLeadingAnchorConstraint,
+        view1ViewBottomAnchorConstraint,
+        view1ViewTopAnchorConstraint,
+        view1ViewLeadingAnchorConstraint,
+        view1ViewTrailingAnchorConstraint,
+        publishTextViewHeightAnchorParentConstraint,
+        publishTextViewLeadingAnchorConstraint,
+        publishTextViewTopAnchorConstraint,
+        publishTextViewBottomAnchorConstraint,
+        vSpacerViewHeightAnchorConstraint,
+        vSpacerViewWidthAnchorConstraint,
+        vSpacer1ViewHeightAnchorConstraint,
+        vSpacer1ViewWidthAnchorConstraint,
+        view3ViewHeightAnchorParentConstraint,
+        viewViewHeightAnchorParentConstraint,
+        view3ViewTopAnchorConstraint,
+        view3ViewBottomAnchorConstraint,
+        viewViewTrailingAnchorConstraint,
+        viewViewLeadingAnchorConstraint,
+        viewViewTopAnchorConstraint,
+        viewViewBottomAnchorConstraint,
+        viewViewWidthAnchorConstraint,
+        doneButtonViewTopAnchorConstraint,
+        doneButtonViewBottomAnchorConstraint,
+        doneButtonViewLeadingAnchorConstraint,
+        doneButtonViewTrailingAnchorConstraint
+      ] +
+        conditionalConstraints(cancelContainerViewIsHidden: cancelContainerView.isHidden))
+  }
+
+  private func conditionalConstraints(cancelContainerViewIsHidden: Bool) -> [NSLayoutConstraint] {
+    var constraints: [NSLayoutConstraint?]
+
+    switch (cancelContainerViewIsHidden) {
+      case (true):
+        constraints = [view3ViewLeadingAnchorView1ViewLeadingAnchorConstraint]
+      case (false):
+        constraints = [
+          cancelContainerViewHeightAnchorParentConstraint,
+          cancelContainerViewLeadingAnchorView1ViewLeadingAnchorConstraint,
+          cancelContainerViewTopAnchorView1ViewTopAnchorConstraint,
+          cancelContainerViewBottomAnchorView1ViewBottomAnchorConstraint,
+          view3ViewLeadingAnchorCancelContainerViewTrailingAnchorConstraint,
+          cancelContainerViewWidthAnchorConstraint,
+          cancelButtonViewTopAnchorCancelContainerViewTopAnchorConstraint,
+          cancelButtonViewBottomAnchorCancelContainerViewBottomAnchorConstraint,
+          cancelButtonViewLeadingAnchorCancelContainerViewLeadingAnchorConstraint,
+          cancelButtonViewTrailingAnchorCancelContainerViewTrailingAnchorConstraint
+        ]
+    }
+
+    return constraints.compactMap({ $0 })
   }
 
   private func update() {
+    let cancelContainerViewIsHidden = cancelContainerView.isHidden
+
     publishTextView.attributedStringValue = publishTextViewTextStyle.apply(to: titleText)
     bodyTextView.attributedStringValue = bodyTextViewTextStyle.apply(to: bodyText)
     doneButtonView.onClick = handleOnClickDoneButton
+    cancelButtonView.onClick = handleOnClickDoneButton
+    doneButtonView.titleText = doneButtonTitle
+    cancelButtonView.titleText = cancelButtonTitle
+    cancelContainerView.isHidden = !showsCancelButton
+
+    if cancelContainerView.isHidden != cancelContainerViewIsHidden {
+      NSLayoutConstraint.deactivate(conditionalConstraints(cancelContainerViewIsHidden: cancelContainerViewIsHidden))
+      NSLayoutConstraint.activate(conditionalConstraints(cancelContainerViewIsHidden: cancelContainerView.isHidden))
+    }
   }
 
   private func handleOnClickDoneButton() {
     onClickDoneButton?()
+  }
+
+  private func handleOnClickCancelButton() {
+    onClickCancelButton?()
   }
 }
 
@@ -229,20 +409,39 @@ extension PublishInfo {
   public struct Parameters: Equatable {
     public var titleText: String
     public var bodyText: String
+    public var showsCancelButton: Bool
+    public var doneButtonTitle: String
+    public var cancelButtonTitle: String
     public var onClickDoneButton: (() -> Void)?
+    public var onClickCancelButton: (() -> Void)?
 
-    public init(titleText: String, bodyText: String, onClickDoneButton: (() -> Void)? = nil) {
+    public init(
+      titleText: String,
+      bodyText: String,
+      showsCancelButton: Bool,
+      doneButtonTitle: String,
+      cancelButtonTitle: String,
+      onClickDoneButton: (() -> Void)? = nil,
+      onClickCancelButton: (() -> Void)? = nil)
+    {
       self.titleText = titleText
       self.bodyText = bodyText
+      self.showsCancelButton = showsCancelButton
+      self.doneButtonTitle = doneButtonTitle
+      self.cancelButtonTitle = cancelButtonTitle
       self.onClickDoneButton = onClickDoneButton
+      self.onClickCancelButton = onClickCancelButton
     }
 
     public init() {
-      self.init(titleText: "", bodyText: "")
+      self.init(titleText: "", bodyText: "", showsCancelButton: false, doneButtonTitle: "", cancelButtonTitle: "")
     }
 
     public static func ==(lhs: Parameters, rhs: Parameters) -> Bool {
-      return lhs.titleText == rhs.titleText && lhs.bodyText == rhs.bodyText
+      return lhs.titleText == rhs.titleText &&
+        lhs.bodyText == rhs.bodyText &&
+          lhs.showsCancelButton == rhs.showsCancelButton &&
+            lhs.doneButtonTitle == rhs.doneButtonTitle && lhs.cancelButtonTitle == rhs.cancelButtonTitle
     }
   }
 }
@@ -266,12 +465,29 @@ extension PublishInfo {
       self.parameters = parameters
     }
 
-    public init(titleText: String, bodyText: String, onClickDoneButton: (() -> Void)? = nil) {
-      self.init(Parameters(titleText: titleText, bodyText: bodyText, onClickDoneButton: onClickDoneButton))
+    public init(
+      titleText: String,
+      bodyText: String,
+      showsCancelButton: Bool,
+      doneButtonTitle: String,
+      cancelButtonTitle: String,
+      onClickDoneButton: (() -> Void)? = nil,
+      onClickCancelButton: (() -> Void)? = nil)
+    {
+      self
+        .init(
+          Parameters(
+            titleText: titleText,
+            bodyText: bodyText,
+            showsCancelButton: showsCancelButton,
+            doneButtonTitle: doneButtonTitle,
+            cancelButtonTitle: cancelButtonTitle,
+            onClickDoneButton: onClickDoneButton,
+            onClickCancelButton: onClickCancelButton))
     }
 
     public init() {
-      self.init(titleText: "", bodyText: "")
+      self.init(titleText: "", bodyText: "", showsCancelButton: false, doneButtonTitle: "", cancelButtonTitle: "")
     }
   }
 }

--- a/studio/LonaStudio/GraphQL/Network.swift
+++ b/studio/LonaStudio/GraphQL/Network.swift
@@ -12,60 +12,60 @@ import Apollo
 let API_BASE_URL = Bundle.main.infoDictionary?["API_BASE_URL"] as! String
 
 class Network {
-  static let shared = Network()
+    static let shared = Network()
 
-  private(set) lazy var lona: ApolloClient = {
-    let httpNetworkTransport = HTTPNetworkTransport(
-      url: URL(string:"\(API_BASE_URL)/graphql")!,
-      delegate: self
-    )
+    private(set) lazy var lona: ApolloClient = {
+        let httpNetworkTransport = HTTPNetworkTransport(
+            url: URL(string:"\(API_BASE_URL)/graphql")!,
+            delegate: self
+        )
 
-    httpNetworkTransport.clientName = "Lona API Transport"
+        httpNetworkTransport.clientName = "Lona API Transport"
 
-    return ApolloClient(networkTransport: httpNetworkTransport)
-  }()
+        return ApolloClient(networkTransport: httpNetworkTransport)
+    }()
 
-  private(set) lazy var github: ApolloClient = {
-    let httpNetworkTransport = HTTPNetworkTransport(
-      url: URL(string:"https://api.github.com/graphql")!,
-      delegate: self
-    )
+    private(set) lazy var github: ApolloClient = {
+        let httpNetworkTransport = HTTPNetworkTransport(
+            url: URL(string:"https://api.github.com/graphql")!,
+            delegate: self
+        )
 
-    httpNetworkTransport.clientName = "GitHub API Transport"
+        httpNetworkTransport.clientName = "GitHub API Transport"
 
-    return ApolloClient(networkTransport: httpNetworkTransport)
-  }()
+        return ApolloClient(networkTransport: httpNetworkTransport)
+    }()
 }
 
 extension Network: HTTPNetworkTransportPreflightDelegate {
-  func networkTransport(_ networkTransport: HTTPNetworkTransport, shouldSend request: URLRequest) -> Bool {
-    return true
-  }
-
-  func networkTransport(_ networkTransport: HTTPNetworkTransport, willSend request: inout URLRequest) {
-    if networkTransport.clientName == "Lona API Transport" {
-      if let token = Account.shared.token {
-        request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-      }
+    func networkTransport(_ networkTransport: HTTPNetworkTransport, shouldSend request: URLRequest) -> Bool {
+        return true
     }
 
-    if networkTransport.clientName == "GitHub API Transport" {
-      // We need this to get the check suites
-      request.addValue("application/vnd.github.antiope-preview+json", forHTTPHeaderField: "Accept")
+    func networkTransport(_ networkTransport: HTTPNetworkTransport, willSend request: inout URLRequest) {
+        if networkTransport.clientName == "Lona API Transport" {
+            if let token = Account.shared.token {
+                request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+            }
+        }
 
-      let group = DispatchGroup()
-      group.enter()
+        if networkTransport.clientName == "GitHub API Transport" {
+            // We need this to get the check suites
+            request.addValue("application/vnd.github.antiope-preview+json", forHTTPHeaderField: "Accept")
 
-      Account.shared.me().finalResult({_ in
-        group.leave()
-      })
+            let group = DispatchGroup()
+            group.enter()
 
-      // wait for the Lona account to be fetched
-      group.wait()
+            Account.shared.me().finalResult({ _ in
+                group.leave()
+            })
 
-      if let githubToken = Account.shared.cachedMe?.githubAccessToken {
-        request.addValue("Bearer \(githubToken)", forHTTPHeaderField: "Authorization")
-      }
+            // wait for the Lona account to be fetched
+            group.wait()
+
+            if let githubToken = Account.shared.cachedMe?.githubAccessToken {
+                request.addValue("Bearer \(githubToken)", forHTTPHeaderField: "Authorization")
+            }
+        }
     }
-  }
 }

--- a/studio/LonaStudio/Preferences/AccountPreferencesViewController.swift
+++ b/studio/LonaStudio/Preferences/AccountPreferencesViewController.swift
@@ -12,9 +12,14 @@ import MASPreferences
 
 let GITHUB_CLIENT_ID = Bundle.main.infoDictionary?["GITHUB_CLIENT_ID"] as! String
 let GOOGLE_CLIENT_ID = Bundle.main.infoDictionary?["GOOGLE_CLIENT_ID"] as! String
-func GITHUB_SIGNIN_URL(scopes: [String] = ["user:email"]) -> URL {
+
+let GITHUB_BASIC_SCOPES = ["user:email", "read:org"]
+let GITHUB_BASIC_AND_REPO_SCOPES = GITHUB_BASIC_SCOPES + ["repo"]
+
+func GITHUB_SIGNIN_URL(scopes: [String] = GITHUB_BASIC_SCOPES) -> URL {
   return URL(string: "https://github.com/login/oauth/authorize?scope=\(scopes.joined(separator: "%20"))&client_id=\(GITHUB_CLIENT_ID)&redirect_uri=\(encodeURIComponent("\(API_BASE_URL)/oauth/github/\(encodeURIComponent("lonastudio://oauth-callback"))"))")!
 }
+
 func GOOGLE_SIGNIN_URL(scopes: [String] = ["openid", "email", "profile"]) -> URL {
   return URL(string: "https://accounts.google.com/o/oauth2/v2/auth?client_id=\(GOOGLE_CLIENT_ID)&response_type=code&scope=\(scopes.joined(separator: "%20"))&redirect_uri=\(encodeURIComponent("\(API_BASE_URL)/oauth/github/\(encodeURIComponent("lonastudio://oauth-callback"))"))")!
 }

--- a/studio/LonaStudio/Preferences/LonaAccount.swift
+++ b/studio/LonaStudio/Preferences/LonaAccount.swift
@@ -10,100 +10,105 @@ import Foundation
 import Security
 
 private let getTokenQuery: [String: Any] = [
-  kSecClass as String: kSecClassGenericPassword,
-  kSecAttrAccount as String: "LonaStudio",
-  kSecMatchLimit as String: kSecMatchLimitOne,
-  kSecReturnAttributes as String: true,
-  kSecReturnData as String: true
+    kSecClass as String: kSecClassGenericPassword,
+    kSecAttrAccount as String: "LonaStudio",
+    kSecMatchLimit as String: kSecMatchLimitOne,
+    kSecReturnAttributes as String: true,
+    kSecReturnData as String: true
 ]
 private var setTokenQuery: [String: Any] = [
-  kSecClass as String: kSecClassGenericPassword,
-  kSecAttrAccount as String: "LonaStudio"
+    kSecClass as String: kSecClassGenericPassword,
+    kSecAttrAccount as String: "LonaStudio"
 ]
 private let deleteQuery: [String: Any] = [
-  kSecClass as String: kSecClassGenericPassword,
-  kSecAttrAccount as String: "LonaStudio"
+    kSecClass as String: kSecClassGenericPassword,
+    kSecAttrAccount as String: "LonaStudio"
 ]
 
 class Account {
-  static let shared = Account()
+    static let shared = Account()
 
-  private(set) lazy var token: String? = getStoredToken()
+    private(set) lazy var token: String? = getStoredToken()
 
-  private func getStoredToken() -> String? {
-    var item: CFTypeRef?
-    let status = SecItemCopyMatching(getTokenQuery as CFDictionary, &item)
-    guard
-      status == errSecSuccess,
-      let existingItem = item as? [String : Any],
-      let passwordData = existingItem[kSecValueData as String] as? Data,
-      let password = String(data: passwordData, encoding: String.Encoding.utf8)
-    else {
-      return nil
-    }
-    return password
-  }
-
-  func refreshToken() {
-    token = getStoredToken()
-  }
-
-  func logout() {
-    SecItemDelete(deleteQuery as CFDictionary)
-    token = nil
-    cachedMe = nil
-  }
-
-  func signin(token: String) {
-    setTokenQuery[kSecValueData as String] = token.data(using: String.Encoding.utf8)!
-    _ = SecItemAdd(setTokenQuery as CFDictionary, nil)
-    self.token = token
-    _ = me(forceRefresh: true)
-  }
-
-  var signedIn: Bool {
-    return token != nil
-  }
-
-  var cachedMe: GetMeQuery.Data.GetMe?
-  private var pendingMePromise: Promise<GetMeQuery.Data.GetMe, NSError>?
-
-  func me(forceRefresh: Bool = false) -> Promise<GetMeQuery.Data.GetMe, NSError> {
-    if let cachedMe = cachedMe, (!forceRefresh && pendingMePromise == nil) {
-      return .success(cachedMe)
-    }
-
-    if let pendingMePromise = pendingMePromise {
-      return pendingMePromise
-    }
-
-    let promise: Promise<GetMeQuery.Data.GetMe, NSError> = .result({ complete in
-      Network.shared.lona.fetch(query: GetMeQuery(), cachePolicy: forceRefresh ? .fetchIgnoringCacheData : .returnCacheDataElseFetch) { [weak self] result in
-        guard let self = self else { return }
-
-        switch result {
-        case .success(let graphQLResult):
-          if let errors = graphQLResult.errors {
-            complete(.failure(NSError(errors.description)))
-            return
-          }
-
-          guard let data = graphQLResult.data?.getMe else {
-            complete(.failure(NSError("Missing result")))
-            return
-          }
-
-          self.cachedMe = data
-          self.pendingMePromise = nil
-
-          complete(.success(data))
-        case .failure(let error):
-          complete(.failure(NSError(error.localizedDescription)))
+    private func getStoredToken() -> String? {
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(getTokenQuery as CFDictionary, &item)
+        guard
+            status == errSecSuccess,
+            let existingItem = item as? [String : Any],
+            let passwordData = existingItem[kSecValueData as String] as? Data,
+            let password = String(data: passwordData, encoding: String.Encoding.utf8)
+            else {
+                return nil
         }
-      }
-    })
+        return password
+    }
 
-    pendingMePromise = promise
-    return promise
-  }
+    func refreshToken() {
+        token = getStoredToken()
+    }
+
+    func logout() {
+        SecItemDelete(deleteQuery as CFDictionary)
+        token = nil
+        cachedMe = nil
+    }
+
+    func signin(token: String) {
+        setTokenQuery[kSecValueData as String] = token.data(using: String.Encoding.utf8)!
+        _ = SecItemAdd(setTokenQuery as CFDictionary, nil)
+        self.token = token
+        _ = me(forceRefresh: true)
+    }
+
+    var signedIn: Bool {
+        return token != nil
+    }
+
+    var cachedMe: GetMeQuery.Data.GetMe?
+    private var pendingMePromise: Promise<GetMeQuery.Data.GetMe, NSError>?
+
+    func me(forceRefresh: Bool = false) -> Promise<GetMeQuery.Data.GetMe, NSError> {
+        if let cachedMe = cachedMe, (!forceRefresh && pendingMePromise == nil) {
+            return .success(cachedMe)
+        }
+
+        if let pendingMePromise = pendingMePromise {
+            return pendingMePromise
+        }
+
+        let promise: Promise<GetMeQuery.Data.GetMe, NSError> = .result({ complete in
+            Network.shared.lona.fetch(
+                query: GetMeQuery(),
+                cachePolicy: forceRefresh ? .fetchIgnoringCacheData : .returnCacheDataElseFetch,
+                queue: .global(qos: .userInitiated)
+            ) { [weak self] result in
+                guard let self = self else { return }
+
+                self.pendingMePromise = nil
+
+                switch result {
+                case .success(let graphQLResult):
+                    if let errors = graphQLResult.errors {
+                        complete(.failure(NSError(errors.description)))
+                        return
+                    }
+
+                    guard let data = graphQLResult.data?.getMe else {
+                        complete(.failure(NSError("Missing result")))
+                        return
+                    }
+
+                    self.cachedMe = data
+
+                    complete(.success(data))
+                case .failure(let error):
+                    complete(.failure(NSError(error.localizedDescription)))
+                }
+            }
+        })
+
+        pendingMePromise = promise
+        return promise
+    }
 }

--- a/studio/LonaStudio/Utils/Promise.swift
+++ b/studio/LonaStudio/Utils/Promise.swift
@@ -154,6 +154,22 @@ extension Promise where Success == Void {
     }
 }
 
+// MARK: Result Utilities
+
+extension Promise {
+    public func map<S2>(_ mapFunction: @escaping (Success) -> S2) -> Promise<S2, Failure> {
+        return self.onSuccess { (value: Success) -> Promise<S2, Failure> in
+            return Promise<S2, Failure>.success(mapFunction(value))
+        }
+    }
+
+    public func mapError<F2>(_ mapErrorFunction: @escaping (Failure) -> F2) -> Promise<Success, F2> {
+        return self.onFailure { (error: Failure) -> Promise<Success, F2> in
+            return Promise<Success, F2>.failure(mapErrorFunction(error))
+        }
+    }
+}
+
 // MARK: Parallel
 
 extension Promise {

--- a/studio/LonaStudio/Utils/RESTClient.swift
+++ b/studio/LonaStudio/Utils/RESTClient.swift
@@ -59,6 +59,16 @@ extension RESTClient {
         client.configureRequest = { request in
             var request = request
 
+            let group = DispatchGroup()
+            group.enter()
+
+            Account.shared.me().finalResult({_ in
+                group.leave()
+            })
+
+            // wait for the Lona account to be fetched
+            group.wait()
+
             if let githubToken = Account.shared.cachedMe?.githubAccessToken {
                 request.addValue("application/vnd.github.v3+json", forHTTPHeaderField: "Accept")
                 request.addValue("Bearer \(githubToken)", forHTTPHeaderField: "Authorization")

--- a/studio/LonaStudio/Utils/RESTClient.swift
+++ b/studio/LonaStudio/Utils/RESTClient.swift
@@ -1,0 +1,95 @@
+//
+//  RESTClient.swift
+//  LonaStudio
+//
+//  Created by Devin Abbott on 3/16/20.
+//  Copyright © 2020 Devin Abbott. All rights reserved.
+//
+
+import Foundation
+
+class RESTClient {
+    init(baseURL: URL) {
+        self.baseURL = baseURL
+    }
+
+    var baseURL: URL
+
+    var configureRequest: ((URLRequest) -> Result<URLRequest, NSError>)?
+
+    private func makeURL(path: String) -> URL {
+        let pathComponents = path.split(separator: "/").filter({ !$0.isEmpty })
+        let url = pathComponents.reduce(baseURL, { result, component in result.appendingPathComponent(String(component)) })
+        return url
+    }
+
+    private func send(request: URLRequest) -> Promise<Data, NSError> {
+        return request.send().onSuccess({ response, data in
+            let response = response as! HTTPURLResponse
+            if response.statusCode >= 200 && response.statusCode < 300 {
+                return .success(data)
+            } else {
+                return .failure(NSError("Request failed with status code \(response.statusCode). \(data.utf8String() ?? "")"))
+            }
+        })
+    }
+
+    func post(path: String, body: Data) -> Promise<Data, NSError> {
+        var request = URLRequest(url: makeURL(path: path))
+        request.httpMethod = "POST"
+        request.httpBody = body
+
+        if let configureRequest = configureRequest {
+            switch configureRequest(request) {
+            case .success(let request):
+                return send(request: request)
+            case .failure(let error):
+                return .failure(error)
+            }
+        } else {
+            return send(request: request)
+        }
+    }
+}
+
+extension RESTClient {
+    static var githubV3: RESTClient = {
+        let client = RESTClient(baseURL: URL(string: "https://api.github.com")!)
+
+        client.configureRequest = { request in
+            var request = request
+
+            if let githubToken = Account.shared.cachedMe?.githubAccessToken {
+                request.addValue("application/vnd.github.v3+json", forHTTPHeaderField: "Accept")
+                request.addValue("Bearer \(githubToken)", forHTTPHeaderField: "Authorization")
+
+                return .success(request)
+            } else {
+                return .failure(NSError("User not logged in to GitHub through Lona."))
+            }
+        }
+
+        return client
+    }()
+}
+
+extension URLRequest {
+    func send() -> Promise<(URLResponse, Data), NSError> {
+        return .result({ complete in
+            Swift.print("Request", self.url?.absoluteString ?? "")
+
+            let task = URLSession.shared.dataTask(with: self, completionHandler: { data, response, error in
+                Swift.print("Response", self.url?.absoluteString ?? "", data, error)
+
+                if let error = error {
+                    complete(.failure(error as NSError))
+                    return
+                }
+
+                complete(.success((response!, data ?? Data())))
+            })
+
+            task.resume()
+        })
+    }
+}

--- a/studio/LonaStudio/Utils/RESTClient.swift
+++ b/studio/LonaStudio/Utils/RESTClient.swift
@@ -86,11 +86,7 @@ extension RESTClient {
 extension URLRequest {
     func send() -> Promise<(URLResponse, Data), NSError> {
         return .result({ complete in
-            Swift.print("Request", self.url?.absoluteString ?? "")
-
             let task = URLSession.shared.dataTask(with: self, completionHandler: { data, response, error in
-                Swift.print("Response", self.url?.absoluteString ?? "", data, error)
-
                 if let error = error {
                     complete(.failure(error as NSError))
                     return

--- a/studio/LonaStudio/VersionControl/Git.swift
+++ b/studio/LonaStudio/VersionControl/Git.swift
@@ -8,18 +8,38 @@
 
 import AppKit
 
+public enum GitError: Error {
+    case generic(ProcessError)
+    case permissionDenied
+    case invalidRemoteURL(String)
+
+    public var localizedDescription: String {
+        switch self {
+        case .generic(let error):
+            return error.localizedDescription
+        case .permissionDenied:
+            return """
+Permission denied by GitHub.
+
+In order to publish with Lona, you'll need to be able to `push` to GitHub via the command line `git` command.
+"""
+        case .invalidRemoteURL(let url):
+            return "Invalid remote URL: \(url)"
+        }
+    }
+}
+
 public enum Git {
 
     // MARK: Private
 
     private static var launchPath: String = "/usr/bin/git"
 
-    private static func run(arguments: [String], currentDirectoryPath: String) -> Result<String, NSError> {
-
+    private static func run(arguments: [String], currentDirectoryPath: String) -> Result<String, ProcessError> {
         Swift.print("INFO: Running `\(Git.launchPath) \(arguments.joined(separator: " "))`")
 
         let result = Process.runSync(
-            configuration: Process.Configuration(
+            Process.Configuration(
                 launchPath: Git.launchPath,
                 arguments: arguments,
                 currentDirectoryPath: currentDirectoryPath
@@ -34,18 +54,20 @@ public enum Git {
         }
     }
 
-    private static func runAsync(arguments: [String], currentDirectoryPath: String) -> Promise<String, NSError> {
+    private static func runAsync(arguments: [String], currentDirectoryPath: String) -> Promise<String, ProcessError> {
 
         Swift.print("INFO: Running `\(Git.launchPath) \(arguments.joined(separator: " "))`")
 
         return Process.run(
-            configuration: Process.Configuration(
+            Process.Configuration(
                 launchPath: Git.launchPath,
                 arguments: arguments,
                 currentDirectoryPath: currentDirectoryPath
             )
         ).onSuccess({ data in
             return .success(data.utf8String() ?? "")
+        }).onFailure({ error in
+            return .failure(error)
         })
     }
 
@@ -66,11 +88,11 @@ public enum Git {
             self.currentDirectoryPath = currentDirectoryPath
         }
 
-        public func run(arguments: [String]) -> Result<String, NSError> {
+        public func run(arguments: [String]) -> Result<String, ProcessError> {
             return Git.run(arguments: arguments, currentDirectoryPath: currentDirectoryPath)
         }
 
-        public func runAsync(arguments: [String]) -> Promise<String, NSError> {
+        public func runAsync(arguments: [String]) -> Promise<String, ProcessError> {
             return Git.runAsync(arguments: arguments, currentDirectoryPath: currentDirectoryPath)
         }
     }
@@ -79,57 +101,67 @@ public enum Git {
 // MARK: Sync
 
 extension Git.Client {
-    public func initRepo() -> Result<String, NSError> {
+    public func initRepo() -> Result<String, ProcessError> {
         return run(arguments: ["init"])
     }
 
-    public func addAllFiles() -> Result<String, NSError> {
+    public func addAllFiles() -> Result<String, ProcessError> {
         return run(arguments: ["add", "."])
     }
 
-    public func commit(message: String) -> Result<String, NSError> {
+    public func commit(message: String) -> Result<String, ProcessError> {
         return run(arguments: ["commit", "-m", message])
     }
 
-    public func addRemote(name: String, url: URL) -> Result<String, NSError> {
+    public func addRemote(name: String, url: URL) -> Result<String, ProcessError> {
         return run(arguments: ["remote", "add", name, url.absoluteString])
     }
 
-    public func push(repository: String, refspec: String) -> Result<String, NSError> {
-        return run(arguments: ["push", repository, refspec])
+    public func push(repository: String, refspec: String) -> Result<String, GitError> {
+        return run(arguments: ["push", repository, refspec]).mapError({ error in
+            if error.code == 128,
+                let errorString = error.errorOutput.utf8String(),
+                (errorString.contains("git@github.com: Permission denied (publickey)") || errorString.contains("Host key verification failed")) {
+                return .permissionDenied
+            } else {
+                return .generic(error)
+            }
+        })
     }
 
-    public func getRootDirectoryPath() -> Result<String, NSError> {
+    public func getRootDirectoryPath() -> Result<String, ProcessError> {
         return run(arguments: ["rev-parse", "--show-toplevel"]).map({ output in
             output.trimmingCharacters(in: .whitespacesAndNewlines)
         })
     }
 
-    public func getRemoteURL() -> Result<URL, NSError> {
+    public func getRemoteURL() -> Result<URL, GitError> {
         return run(arguments: ["remote", "get-url", Git.defaultOriginName]).map({ output in
             output.trimmingCharacters(in: .whitespacesAndNewlines)
-        }).flatMap({ urlString in
-            if let url = URL(string: urlString) {
-                return .success(url)
-            } else {
-                return .failure(NSError("Invalid URL: \(urlString)"))
-            }
         })
+            .mapError({ error in .generic(error) })
+            .flatMap({ urlString in
+                if let url = URL(string: urlString) {
+                    return .success(url)
+                } else {
+                    return .failure(.invalidRemoteURL(urlString))
+                }
+            })
     }
 
-    public func getHeadSHA() -> Result<String, NSError> {
+    public func getHeadSHA() -> Result<String, ProcessError> {
         return run(arguments: ["rev-parse", "HEAD"]).map({ output in
             output.trimmingCharacters(in: .whitespacesAndNewlines)
         })
     }
 
-    public func hasUncommittedChanges() -> Result<Bool, NSError> {
+    public func hasUncommittedChanges() -> Result<Bool, ProcessError> {
         return run(arguments: ["status", "--porcelain"]).map({ output in
             !output.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         })
     }
 
-    public func clone(repository: URL, localDirectoryPath: String) -> Result<String, NSError> {
+    public func clone(repository: URL, localDirectoryPath: String) -> Result<String, ProcessError> {
         return run(arguments: ["clone", repository.absoluteString, localDirectoryPath])
     }
 }
@@ -137,23 +169,29 @@ extension Git.Client {
 // MARK: Async
 
 extension Git.Client {
-    public func getRemoteSHAAsync() -> Promise<String, NSError> {
+    public func getRemoteSHAAsync() -> Promise<String, ProcessError> {
         return runAsync(arguments: ["ls-remote", Git.defaultOriginName, Git.defaultBranchName, "--porcelain"]).onSuccess({ result in
             return .success(String(result.prefix(40)))
         })
     }
 
-    public func isLocalBranchUpToDateWithRemote() -> Promise<Bool, NSError> {
+    public func isLocalBranchUpToDateWithRemote() -> Promise<Bool, GitError> {
         let headSHA = Git.client.getHeadSHA()
 
         return Git.client.getRemoteSHAAsync().onResult({ result in
             switch (headSHA, result) {
             case (.success(let headSHA), .success(let remoteSHA)):
-                return .success(headSHA == remoteSHA)
+                let isEmptyRepo = remoteSHA.isEmpty
+                return .success(headSHA == remoteSHA || isEmptyRepo)
             case (.failure(let error), _):
-                return .failure(NSError("Git failure: couldn't find git SHA for HEAD.\n\(error)"))
+                Swift.print("Git failure: couldn't find git SHA for HEAD.")
+                return .failure(.generic(error))
             case (_, .failure(let error)):
-                return .failure(NSError("Failed to connect to remote git repository. Are you connected to the internet?\n\(error)"))
+                if SSH.canConnectToGithub() {
+                    return .failure(.generic(error))
+                } else {
+                    return .failure(.permissionDenied)
+                }
             }
         })
     }

--- a/studio/LonaStudio/VersionControl/Git.swift
+++ b/studio/LonaStudio/VersionControl/Git.swift
@@ -119,9 +119,11 @@ extension Git.Client {
 
     public func push(repository: String, refspec: String) -> Result<String, GitError> {
         return run(arguments: ["push", repository, refspec]).mapError({ error in
-            if error.code == 128,
-                let errorString = error.errorOutput.utf8String(),
-                (errorString.contains("git@github.com: Permission denied (publickey)") || errorString.contains("Host key verification failed")) {
+            if error.code != 0, let errorString = error.errorOutput.utf8String(),
+                (
+                    errorString.contains("fatal: Authentication failed") ||
+                    errorString.contains("fatal: Could not read from remote repository.")
+                ) {
                 return .permissionDenied
             } else {
                 return .generic(error)

--- a/studio/LonaStudio/VersionControl/SSH.swift
+++ b/studio/LonaStudio/VersionControl/SSH.swift
@@ -1,0 +1,169 @@
+//
+//  SSH.swift
+//  LonaStudio
+//
+//  Created by Devin Abbott on 3/16/20.
+//  Copyright © 2020 Devin Abbott. All rights reserved.
+//
+
+import Foundation
+
+public enum SSHError: Error {
+    case keyscan(ProcessError)
+    case fingerprint(ProcessError)
+    case process(ProcessError)
+    case invalidFingerprint
+    case writingToKnownHosts
+    case createKey(ProcessError)
+    case failedToReadDirectory
+    case failedToReadFile
+    case localKeyMissing
+}
+
+public enum SSH {
+    public static func keyscan(host: String) -> Result<Data, ProcessError> {
+        return Process.runSync(
+            .init(
+                launchPath: "/usr/bin/ssh-keyscan",
+                arguments: ["-t", "rsa", host]
+            )
+        )
+    }
+
+    public static func fingerprint(key: Data) -> Result<Data, ProcessError> {
+        return Process.runSync(
+            .init(
+                launchPath: "/usr/bin/ssh-keygen",
+                arguments: ["-lf", "-"]
+            ),
+            inputData: key
+        )
+    }
+
+    public static func addToKnownHosts(key: Data) -> Result<Void, SSHError> {
+        let knownHostsFileURL = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".ssh")
+            .appendingPathComponent("known_hosts")
+
+        if FileManager.default.fileExists(atPath: knownHostsFileURL.path) {
+            // If the host is already in the file, we can stop
+            if let fileString = try? Data(contentsOf: knownHostsFileURL).utf8String(),
+                let keyString = key.utf8String(),
+                fileString.contains(keyString.trimmingCharacters(in: .whitespacesAndNewlines)) {
+                return .success(())
+            }
+
+            // Append the host to the file
+            if let fileHandle = FileHandle(forWritingAtPath: knownHostsFileURL.path) {
+                defer { fileHandle.closeFile() }
+                fileHandle.seekToEndOfFile()
+                fileHandle.write(key)
+                return .success(())
+            } else {
+                return .failure(.writingToKnownHosts)
+            }
+        } else {
+            // Create a new known_hosts file
+            if FileManager.default.createFile(
+                atPath: knownHostsFileURL.path,
+                contents: key,
+                attributes: [.posixPermissions: 0o644]) {
+                return .success(())
+            } else {
+                return .failure(.writingToKnownHosts)
+            }
+        }
+    }
+
+    public static func validateGithubKeyAndAddToHosts() -> Result<Void, SSHError> {
+        return keyscan(host: "github.com")
+            .mapError({ SSHError.keyscan($0) })
+            .flatMap({ key in
+                switch fingerprint(key: key).mapError({ SSHError.fingerprint($0) }) {
+                case .success(let value):
+                    if value.utf8String() == githubRSAFingerprint {
+                        return addToKnownHosts(key: key)
+                    }
+                    return .failure(.invalidFingerprint)
+                case .failure(let error):
+                    return .failure(error)
+                }
+            })
+    }
+
+    public static func createLocalKey() -> Result<String, SSHError> {
+        let keyPath = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".ssh").appendingPathComponent("id_rsa").path
+
+        let result = Process.runSync(
+            Process.Configuration(
+                launchPath: "/usr/bin/ssh-keygen",
+                arguments: ["-t", "rsa", "-N", "", "-f", keyPath],
+                currentDirectoryPath: FileManager.default.homeDirectoryForCurrentUser.path
+            )
+        )
+
+        switch result {
+        case .success:
+            Swift.print("Created local SSH key")
+            switch localKey() {
+            case .success(nil):
+                return .failure(.localKeyMissing)
+            case .success(.some(let key)):
+                return .success(key)
+            case .failure(let error):
+                return .failure(error)
+            }
+        case .failure(let error):
+            Swift.print("Failed to create local SSH key")
+            return .failure(.createKey(error))
+        }
+    }
+
+    public static func localKey() -> Result<String?, SSHError> {
+        let files: [String]
+
+        let sshDirectory = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".ssh")
+
+        do {
+            try files = FileManager.default.contentsOfDirectory(atPath: sshDirectory.path)
+        } catch {
+            return .failure(.failedToReadDirectory)
+        }
+
+        guard let publicKeyFile = files.filter({ $0.hasSuffix(".pub") }).first else {
+            return .success(nil)
+        }
+
+        guard let publicKey = FileManager.default.contents(atPath: sshDirectory.appendingPathComponent(publicKeyFile).path)?.utf8String() else {
+            return .failure(.failedToReadFile)
+        }
+
+        return .success(publicKey.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    public static func canConnectToGithub() -> Bool {
+        // We make an _unsafe_ request to GitHub, but this is OK, since we don't actually do anything beyond
+        // check that we can access it. We don't want to add to the hosts file here, because we should only
+        // do that from a user-initiated SSH flow.
+        let result = Process.runSync(
+            Process.Configuration(
+                launchPath: "/usr/bin/ssh",
+                arguments: ["-T", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", "git@github.com"],
+                currentDirectoryPath: FileManager.default.homeDirectoryForCurrentUser.path
+            )
+        )
+
+        switch result {
+        // This is success. GitHub said "Hi" on stderr.
+        case .failure(let error) where error.code == 1:
+            return true
+        case .failure:
+            return false
+        // As far as I can tell, this command always returns an exit code > 0, so `success` never happens
+        case .success:
+            return false
+        }
+    }
+
+    public static var githubRSAFingerprint = "2048 SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8 github.com (RSA)\n"
+}

--- a/studio/LonaStudio/Workspace/FlowView.swift
+++ b/studio/LonaStudio/Workspace/FlowView.swift
@@ -186,6 +186,13 @@ class FlowView: NSBox {
             window.setContentSize(.zero)
         }
     }
+
+    // Prevent the user from taking any action when awaiting an async event
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        if showsProgressIndicator { return nil }
+
+        return super.hitTest(point)
+    }
 }
 
 // MARK: - Promise Helper

--- a/studio/LonaStudio/Workspace/FlowView.swift
+++ b/studio/LonaStudio/Workspace/FlowView.swift
@@ -198,16 +198,6 @@ class FlowView: NSBox {
 // MARK: - Promise Helper
 
 extension FlowView {
-    public func withProgress<S, F>(_ f: () -> Promise<S, F>) -> Promise<S, F> {
-        self.showsProgressIndicator = true
-
-        return f().onResult({ result in
-            self.showsProgressIndicator = false
-
-            return .result(result)
-        })
-    }
-
     public func withProgress<S, F>(_ promise: Promise<S, F>) {
         self.showsProgressIndicator = true
 

--- a/studio/LonaStudio/Workspace/OpenWorkspaceViewController.swift
+++ b/studio/LonaStudio/Workspace/OpenWorkspaceViewController.swift
@@ -119,7 +119,11 @@ class OpenWorkspaceViewController: NSViewController {
                 }
             }
             screen.onClickRemoteButton = {
-                self.flowView.withProgress(PublishingViewController.fetchRepositoriesAndOrganizations).finalResult({ result in
+                let promise = PublishingViewController.fetchRepositoriesAndOrganizations()
+
+                self.flowView.withProgress(promise)
+
+                promise.finalResult({ result in
                     switch result {
                     case .failure(let error):
                         Alert.runInformationalAlert(messageText: "Failed to connect to GitHub", informativeText: "Are you connected to the internet? \(error)")

--- a/studio/LonaStudio/Workspace/OpenWorkspaceViewController.swift
+++ b/studio/LonaStudio/Workspace/OpenWorkspaceViewController.swift
@@ -109,7 +109,7 @@ class OpenWorkspaceViewController: NSViewController {
             let screen = OpenWorkspace()
             screen.isLoggedIn = isLoggedIn
             screen.onClickGithubButton = {
-                if !NSWorkspace.shared.open(GITHUB_SIGNIN_URL(scopes: ["user:email", "read:org", "repo"])) {
+                if !NSWorkspace.shared.open(GITHUB_SIGNIN_URL(scopes: GITHUB_BASIC_AND_REPO_SCOPES)) {
                     print("couldn't open the  browser")
                 }
             }
@@ -199,7 +199,13 @@ class OpenWorkspaceViewController: NSViewController {
             }
             return screen
         case .error(title: let title, body: let body):
-            let screen = PublishInfo(titleText: title, bodyText: body)
+            let screen = PublishInfo(
+                titleText: title,
+                bodyText: body,
+                showsCancelButton: false,
+                doneButtonTitle: "OK",
+                cancelButtonTitle: ""
+            )
             screen.onClickDoneButton = self.onRequestClose
             return screen
         case .done:

--- a/studio/workspace/screens/PublishInfo.component
+++ b/studio/workspace/screens/PublishInfo.component
@@ -9,6 +9,15 @@
   ],
   "examples" : [
     {
+      "id" : "Cancellable",
+      "name" : "Cancellable",
+      "params" : {
+        "cancelButtonTitle" : "Cancel",
+        "doneButtonTitle" : "OK",
+        "showsCancelButton" : true
+      }
+    },
+    {
       "id" : "Default",
       "name" : "Default",
       "params" : {
@@ -52,6 +61,54 @@
         "onClickDoneButton"
       ],
       "type" : "AssignExpr"
+    },
+    {
+      "assignee" : [
+        "layers",
+        "CancelButton",
+        "onClick"
+      ],
+      "content" : [
+        "parameters",
+        "onClickDoneButton"
+      ],
+      "type" : "AssignExpr"
+    },
+    {
+      "assignee" : [
+        "layers",
+        "DoneButton",
+        "titleText"
+      ],
+      "content" : [
+        "parameters",
+        "doneButtonTitle"
+      ],
+      "type" : "AssignExpr"
+    },
+    {
+      "assignee" : [
+        "layers",
+        "CancelButton",
+        "titleText"
+      ],
+      "content" : [
+        "parameters",
+        "cancelButtonTitle"
+      ],
+      "type" : "AssignExpr"
+    },
+    {
+      "assignee" : [
+        "layers",
+        "CancelContainer",
+        "visible"
+      ],
+      "content" : [
+        "parameters",
+        "showsCancelButton"
+      ],
+      "type" : "AssignExpr"
     }
   ],
   "params" : [
@@ -65,6 +122,24 @@
     },
     {
       "name" : "onClickDoneButton",
+      "type" : {
+        "name" : "Function"
+      }
+    },
+    {
+      "name" : "showsCancelButton",
+      "type" : "Boolean"
+    },
+    {
+      "name" : "doneButtonTitle",
+      "type" : "String"
+    },
+    {
+      "name" : "cancelButtonTitle",
+      "type" : "String"
+    },
+    {
+      "name" : "onClickCancelButton",
       "type" : {
         "name" : "Function"
       }
@@ -121,6 +196,30 @@
           {
             "children" : [
               {
+                "id" : "CancelButton",
+                "params" : {
+                  "titleText" : "Cancel"
+                },
+                "type" : "PrimaryButton"
+              }
+            ],
+            "id" : "CancelContainer",
+            "params" : {
+              "visible" : false,
+              "width" : 250
+            },
+            "type" : "Lona:View"
+          },
+          {
+            "id" : "View 3",
+            "params" : {
+              "flex" : 1
+            },
+            "type" : "Lona:View"
+          },
+          {
+            "children" : [
+              {
                 "id" : "DoneButton",
                 "params" : {
                   "titleText" : "OK"
@@ -137,8 +236,9 @@
         ],
         "id" : "View 1",
         "params" : {
-          "alignItems" : "flex-end",
-          "alignSelf" : "stretch"
+          "alignSelf" : "stretch",
+          "flexDirection" : "row",
+          "justifyContent" : "flex-end"
         },
         "type" : "Lona:View"
       }


### PR DESCRIPTION
This needs some testing still, but the idea is:

Can we make a fully automated flow, so that once somebody has a GitHub account, we can set up push access? (everything is opt-in)

This means, if a push fails due to invalid credentials:
- we prompt them to ask if we should set up SSH access
- if they don't have an .ssh key, we create one
- we upload their public key to their github account (which requires `write:public_key`)
- we verify the identity of github.com using a compiled-in SSH fingerprint

I couldn't find a GraphQL mutation for adding a public_key, so I use the API v3 here... but maybe I just missed it?

I thought it was going to be hacky but it's actually not too bad IMO. There's still a bug after github repo creation where it doesn't move to the next part of the flow automatically