### PR TITLE
extend ApolloClient for GH auth

### DIFF
--- a/studio/LonaStudio/GraphQL/Network.swift
+++ b/studio/LonaStudio/GraphQL/Network.swift
@@ -53,46 +53,19 @@ extension Network: HTTPNetworkTransportPreflightDelegate {
       // We need this to get the check suites
       request.addValue("application/vnd.github.antiope-preview+json", forHTTPHeaderField: "Accept")
 
-      // this will be up to date when using *AfterGitHubAuth
-      // might not be otherwise
+      let group = DispatchGroup()
+      group.enter()
+
+      Account.shared.me().finalResult({_ in
+        group.leave()
+      })
+
+      // wait for the Lona account to be fetched
+      group.wait()
+
       if let githubToken = Account.shared.cachedMe?.githubAccessToken {
         request.addValue("Bearer \(githubToken)", forHTTPHeaderField: "Authorization")
       }
     }
-  }
-}
-
-/// Support waiting for the GitHub token to be fetched
-extension ApolloClient {
-  @discardableResult
-  public func fetchAfterGitHubAuth<Query: GraphQLQuery>(
-    query: Query,
-    cachePolicy: CachePolicy = .returnCacheDataElseFetch,
-    context: UnsafeMutableRawPointer? = nil,x
-    queue: DispatchQueue = DispatchQueue.main,
-    resultHandler: GraphQLResultHandler<Query.Data>? = nil
-  ) -> Cancellable {
-    Account.shared.me().finalResult({_ in
-      self.fetch(query: query, cachePolicy: cachePolicy, context: context, queue: queue, resultHandler: resultHandler)
-    })
-
-    // TODO: return the result of self.fetch when available
-    return EmptyCancellable()
-  }
-
-  @discardableResult
-  public func performAfterGitHubAuth<Mutation: GraphQLMutation>(
-    mutation: Mutation,
-    cachePolicy: CachePolicy = .returnCacheDataElseFetch,
-    context: UnsafeMutableRawPointer? = nil,x
-    queue: DispatchQueue = DispatchQueue.main,
-    resultHandler: GraphQLResultHandler<Mutation.Data>? = nil
-  ) -> Cancellable {
-    Account.shared.me().finalResult({_ in
-      self.perform(mutation: mutation, context: context, queue: queue, resultHandler: resultHandler)
-    })
-
-    // TODO: return the result of self.perform when available
-    return EmptyCancellable()
   }
 }

--- a/studio/LonaStudio/Preferences/LonaAccount.swift
+++ b/studio/LonaStudio/Preferences/LonaAccount.swift
@@ -69,7 +69,7 @@ class Account {
   private var pendingMePromise: Promise<GetMeQuery.Data.GetMe, NSError>?
 
   func me(forceRefresh: Bool = false) -> Promise<GetMeQuery.Data.GetMe, NSError> {
-    if let cachedMe = cachedMe, (!forceRefresh && pendingMePromise != nil) {
+    if let cachedMe = cachedMe, (!forceRefresh && pendingMePromise == nil) {
       return .success(cachedMe)
     }
 

--- a/studio/LonaStudio/Preferences/LonaAccount.swift
+++ b/studio/LonaStudio/Preferences/LonaAccount.swift
@@ -69,7 +69,7 @@ class Account {
   private var pendingMePromise: Promise<GetMeQuery.Data.GetMe, NSError>?
 
   func me(forceRefresh: Bool = false) -> Promise<GetMeQuery.Data.GetMe, NSError> {
-    if let cachedMe = cachedMe, !forceRefresh {
+    if let cachedMe = cachedMe, (!forceRefresh && pendingMePromise != nil) {
       return .success(cachedMe)
     }
 

--- a/studio/LonaStudio/Workspace/PublishingViewController.swift
+++ b/studio/LonaStudio/Workspace/PublishingViewController.swift
@@ -511,7 +511,7 @@ extension PublishingViewController {
         return .result { complete in
             self.showsProgressIndicator = true
 
-            Network.shared.github.fetchAfterGitHubAuth(query: GetOrganizationsQuery()) { [weak self] result in
+            Network.shared.github.fetch(query: GetOrganizationsQuery()) { [weak self] result in
                 guard let self = self else { return }
 
                 self.showsProgressIndicator = false
@@ -553,7 +553,7 @@ extension PublishingViewController {
                 visibility: isPrivate ? .private : .public
             )
 
-            Network.shared.github.performAfterGitHubAuth(mutation: mutation) { [weak self] result in
+            Network.shared.github.perform(mutation: mutation) { [weak self] result in
                 guard let self = self else { return }
 
                 switch result {

--- a/studio/LonaStudio/Workspace/PublishingViewController.swift
+++ b/studio/LonaStudio/Workspace/PublishingViewController.swift
@@ -511,7 +511,7 @@ extension PublishingViewController {
         return .result { complete in
             self.showsProgressIndicator = true
 
-            Network.shared.github.fetch(query: GetOrganizationsQuery()) { [weak self] result in
+            Network.shared.github.fetchAfterGitHubAuth(query: GetOrganizationsQuery()) { [weak self] result in
                 guard let self = self else { return }
 
                 self.showsProgressIndicator = false
@@ -553,7 +553,7 @@ extension PublishingViewController {
                 visibility: isPrivate ? .private : .public
             )
 
-            Network.shared.github.perform(mutation: mutation) { [weak self] result in
+            Network.shared.github.performAfterGitHubAuth(mutation: mutation) { [weak self] result in
                 guard let self = self else { return }
 
                 switch result {


### PR DESCRIPTION
## What

This extends `ApolloClient` to wait for `Account.shared.me()` because doing a call. I haven't found a way to use the existing `func networkTransport(_ networkTransport: HTTPNetworkTransport, willSend request: inout URLRequest)` delegate hook because it needs to be synchronous.
If you have a better idea...

cc: @dabbott
