### PR TITLE
Enable minimap in markdown view

### DIFF
--- a/studio/Cartfile.resolved
+++ b/studio/Cartfile.resolved
@@ -1,7 +1,7 @@
 github "Lona/ColorPicker" "08ff046d9bcee4ad85581748fb02cce7497dec4a"
 github "Lona/ControlledComponents" "262f562cec208a96a6627857400205363429d6e0"
 github "Lona/FileTree" "4b333482b7f47bc5636ae6b60f2b03c367900f01"
-github "Lona/Logic" "d63ca67367832bfd970e50e7a3c1efc28a7141bd"
+github "Lona/Logic" "6e94415832d9df92ec31192b9012a299e59d9221"
 github "davecom/SwiftGraph" "1e1f9997f58291db31d646a909644c4fa3162d06"
 github "dylan/colors" "0.9.10"
 github "njdehoog/Witness" "0.1.3"

--- a/studio/Cartfile.resolved
+++ b/studio/Cartfile.resolved
@@ -1,7 +1,7 @@
 github "Lona/ColorPicker" "08ff046d9bcee4ad85581748fb02cce7497dec4a"
 github "Lona/ControlledComponents" "262f562cec208a96a6627857400205363429d6e0"
 github "Lona/FileTree" "4b333482b7f47bc5636ae6b60f2b03c367900f01"
-github "Lona/Logic" "6e94415832d9df92ec31192b9012a299e59d9221"
+github "Lona/Logic" "bae6e1df08b6867ec3dd1e4e7928c6711e59bef7"
 github "davecom/SwiftGraph" "1e1f9997f58291db31d646a909644c4fa3162d06"
 github "dylan/colors" "0.9.10"
 github "njdehoog/Witness" "0.1.3"

--- a/studio/LonaStudio/AppDelegate.swift
+++ b/studio/LonaStudio/AppDelegate.swift
@@ -32,6 +32,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             forEventClass: AEEventClass(kInternetEventClass),
             andEventID: AEEventID(kAEGetURL)
         )
+
+        MinimapScroller.defaultFillColor = .clear
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {

--- a/studio/LonaStudio/Workspace/MarkdownViewController.swift
+++ b/studio/LonaStudio/Workspace/MarkdownViewController.swift
@@ -103,7 +103,7 @@ class MarkdownViewController: NSViewController {
         containerView.addSubview(contentView)
 
         contentView.fillColor = .clear
-
+        contentView.showsMinimap = true
         contentView.onClickLink = { link in
             guard let url = URL(string: link) else { return true }
             NSWorkspace.shared.open(url)


### PR DESCRIPTION
This displays a markdown minimap to improve visibility/navigation in large files.

The implementation will be slow, because it forces the tableview to render all rows, even those offscreen. however, we can always optimize in the future with more effort, and visibility currently feels very low, so I think it's worth enabling now